### PR TITLE
Build the standalone system-design session foundation

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,0 +1,21 @@
+name: Swift
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: macos-15
+    timeout-minutes: 15
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+      - name: Report Swift toolchain
+        run: swift --version
+      - name: Test package
+        run: swift test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+.build/
+.swiftpm/
+DerivedData/
+*.xcuserstate
+.DS_Store
+
+# Private runtime state
+.env
+.env.*
+Models/
+Recordings/
+Sessions/
+Diagnostics/
+*.m4a
+*.wav
+*.mp3

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,74 @@
+# Interview Arc Live Agent Instructions
+
+Read `README.md`, `CONTEXT.md`, relevant ADRs under `docs/adr/`, and
+`docs/agents/issue-lifecycle.md` before changing this repository.
+
+Interview Arc Live is a separate experimental native macOS technical mock-
+interview application. It must not depend on Interview Arc Voice running or
+share Voice's queues, credentials, storage, preferences, hotkeys, or recorder
+ownership. The sibling `interview-arc` repository owns hosted Interview Arc
+state and APIs; `interview-arc-voice` owns the system-wide dictation client.
+
+Do not create or change a thread Goal unless the user explicitly asks.
+
+## Product invariants
+
+- One `InterviewRoomSession` is bound to one Interview Arc activity.
+- A Candidate Turn is one logical answer, even when it contains multiple audio
+  segments or working pauses.
+- Silence may finalize a segment; it never commits a Candidate Turn by itself.
+- `Hand off` is always available. Cue Only, Patient Auto, and Manual remain
+  explicit turn-taking modes.
+- The first semantic endpoint Adapter is Groq `openai/gpt-oss-20b`. Do not add
+  SmartTurn or OpenAI Realtime without a new approved issue and ADR.
+- Preserve every nonempty best Groq transcript candidate verbatim with an
+  explicit quality state. Never fabricate missing speech.
+- Each Interviewer Turn owns one canonical `displayMarkdown`/`spokenText` pair.
+- The Session Manifest is canonical. Combined audio is a derived export.
+- Keep credentials in a Live-specific Keychain service and runtime data under
+  a Live-specific Application Support root. Never commit credentials, audio,
+  transcripts, model caches, private IDs, personal paths, or personal contact
+  information.
+
+## Architecture
+
+Use the vocabulary and process from `improve-codebase-architecture`:
+
+- Prefer a deep Module: high leverage behind a small Interface.
+- The Interface is the test surface; test observable behavior through it.
+- Apply the deletion test before extracting a Module.
+- Introduce a Seam only when at least two Adapters are real.
+- Optimize for locality: ordering, recovery, and invariants belong in the
+  Module that owns them, not in every caller.
+- Do not split files into shallow pass-through Modules or expose state mutators
+  merely to make tests easy.
+
+Record new domain terms in `CONTEXT.md`. Record durable architectural choices
+as ADRs instead of duplicating narrative across guides.
+
+## Source control and verification
+
+- Every product change starts with an issue and uses a feature branch/PR.
+- Link PRs with `Refs #<issue>`; merge does not close an issue automatically.
+- Preserve unrelated dirty files and never commit generated credentials,
+  recordings, transcripts, model artifacts, or local session state.
+- Run `swift test` for core/client changes. Run a parse or build check when the
+  executable changes. CI is the canonical clean macOS package environment.
+- Recording, transcription, persistence, privacy, synchronization, signing,
+  and recovery changes use the Reliability lane.
+- Do not merge, install, or release without explicit user authorization.
+
+## Agent skills
+
+### Issue tracker
+
+Issues and PRDs live in GitHub Issues. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Use the five canonical triage labels. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+This is a single-context repository with `CONTEXT.md` and `docs/adr/`. See
+`docs/agents/domain.md`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,90 @@
+# Interview Arc Live Domain Context
+
+## Purpose
+
+Interview Arc Live is a standalone native macOS room for spoken technical mock
+interviews. It projects durable Interview Arc activity state into a focused
+conversation and specialty work surface. Interview Arc Voice remains the
+system-wide dictation companion.
+
+## Glossary
+
+### Interview Room
+
+The Live experience bound to one Activity. It owns the current Interview Room
+Session and may be presented full-size or compactly.
+
+### Activity
+
+The owner-scoped Interview Arc practice item. Its stable `activityId` selects
+the specialty contract. Persona or provider changes never change the Activity.
+
+### Interview Room Session
+
+The ordered, recoverable state for one Activity while Live owns interaction.
+It includes phase, Turns, mode, revision, and artifact references. A model
+thread is a replaceable runtime binding, not the Session identity.
+
+### Candidate Floor
+
+The interval in which the candidate may speak, think, code, or draw. Silence
+may finalize an audio Segment but never ends the Candidate Floor by itself.
+
+### Hand off
+
+The durable transition that commits one Candidate Turn and permits an
+Interviewer Turn. It may be explicit or proposed by the selected Turn Mode.
+
+### Candidate Turn
+
+One logical candidate answer. It may contain multiple Segments separated by
+thinking or work. Segments are never sent to the interviewer independently.
+
+### Interviewer Turn
+
+One canonical response containing rich `displayMarkdown` and concise
+`spokenText` under one stable identity.
+
+### Segment
+
+One finalized candidate audio interval with stable identity, timing,
+transcription attempts, and quality. Multiple Segments may belong to one
+Candidate Turn.
+
+### Turn Mode
+
+The policy controlling Hand off: `Cue Only`, experimental `Patient Auto`, or
+`Manual`.
+
+### Endpoint Proposal
+
+A non-authoritative semantic result—`likely_continue`, `likely_end`, or
+`ambiguous`—derived from the accumulated answer and current Activity context.
+It may start a cancellable grace period but does not itself mutate durable
+conversation state.
+
+### Session Manifest
+
+The canonical, monotonically revisioned recovery record for an Interview Room
+Session. Audio exports are derived from it and never replace it.
+
+### Work Surface
+
+The specialty-specific artifact area: system-design Board, coding workspace,
+or behavioral Story Kit.
+
+### Presentation
+
+A view of one Interview Room Session. Full and compact Presentations never own
+separate recording, model, transcript, or persistence state.
+
+## Invariants
+
+- One Activity has at most one Live interaction writer.
+- One Hand off creates at most one Candidate Turn and one matching Interviewer
+  Turn, even after retries.
+- Accepted transitions advance the Session Manifest revision monotonically.
+- Every nonempty audio-derived transcript candidate remains visible with an
+  explicit quality state.
+- No client invents speech, hidden model memory, an Accepted verdict, or a
+  durable write receipt.

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+let package = Package(
+    name: "InterviewArcLive",
+    platforms: [.macOS(.v14)],
+    products: [
+        .library(name: "InterviewArcLiveCore", targets: ["InterviewArcLiveCore"]),
+        .executable(name: "InterviewArcLive", targets: ["InterviewArcLive"]),
+    ],
+    targets: [
+        .target(name: "InterviewArcLiveCore"),
+        .executableTarget(
+            name: "InterviewArcLive",
+            dependencies: ["InterviewArcLiveCore"]
+        ),
+        .testTarget(
+            name: "InterviewArcLiveCoreTests",
+            dependencies: ["InterviewArcLiveCore"]
+        ),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -2,3 +2,22 @@
 Experimental native macOS technical mock-interview client for Interview Arc
 
 Current product design: [specialty room concepts](docs/design/specialty-rooms.md).
+
+## Current implementation
+
+The first vertical slice establishes a standalone Swift package and a locally
+durable system-design session tracer bullet. Product decisions live in
+[issue #1](https://github.com/Vinosaamaa/interview-arc-live/issues/1); the
+foundation is tracked by
+[issue #3](https://github.com/Vinosaamaa/interview-arc-live/issues/3).
+
+Requirements: macOS 14 or newer and Swift 6.1 or newer.
+
+```bash
+swift test
+swift run InterviewArcLive
+```
+
+The preview uses fixture interviewer output and local Application Support
+storage. It does not claim microphone, Groq, Codex, TTS, or Interview Arc
+hosted-state integration until those slices are implemented and verified.

--- a/Sources/InterviewArcLive/InterviewArcLiveApp.swift
+++ b/Sources/InterviewArcLive/InterviewArcLiveApp.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+@main
+struct InterviewArcLiveApp: App {
+    @StateObject private var model = SystemDesignRoomModel()
+
+    var body: some Scene {
+        WindowGroup("Interview Arc Live") {
+            SystemDesignRoomView(model: model)
+                .frame(minWidth: 980, minHeight: 640)
+        }
+        .windowStyle(.hiddenTitleBar)
+    }
+}

--- a/Sources/InterviewArcLive/SystemDesignRoomModel.swift
+++ b/Sources/InterviewArcLive/SystemDesignRoomModel.swift
@@ -1,0 +1,131 @@
+import Foundation
+import InterviewArcLiveCore
+
+@MainActor
+final class SystemDesignRoomModel: ObservableObject {
+    @Published private(set) var snapshot: InterviewRoomSnapshot?
+    @Published private(set) var isWorking = false
+    @Published private(set) var statusMessage = "Restoring local session…"
+
+    let question = "Design a global notification system."
+
+    private let sessionID = SessionID("local-system-design-tracer")
+    private var session: InterviewRoomSession?
+
+    var canAct: Bool {
+        guard !isWorking, let phase = snapshot?.phase else { return false }
+        return phase == .candidateFloor
+            || phase == .interviewerProcessing
+            || phase == .interviewerTurn
+    }
+
+    var actionTitle: String {
+        switch snapshot?.phase {
+        case .interviewerProcessing: "Retry interviewer"
+        case .interviewerTurn: "Give me the floor"
+        default: "Hand off"
+        }
+    }
+
+    var actionIcon: String {
+        snapshot?.phase == .interviewerProcessing
+            ? "arrow.clockwise.circle.fill"
+            : "arrowshape.right.circle.fill"
+    }
+
+    func open() async {
+        guard session == nil, !isWorking else { return }
+        isWorking = true
+        defer { isWorking = false }
+
+        do {
+            let store = try FileSessionManifestStore()
+            let runtime = DeterministicInterviewerRuntime(
+                response: CanonicalInterviewerResponse(
+                    displayMarkdown: "Good. How will clients observe delivery without coupling every channel to the request path?",
+                    spokenText: "Good. How will clients observe delivery without coupling every channel to the request path?"
+                )
+            )
+
+            let openedSession: InterviewRoomSession
+            if try await store.load(sessionID: sessionID) == nil {
+                openedSession = try await InterviewRoomSession.start(
+                    sessionID: sessionID,
+                    activityID: "local-system-design-tracer",
+                    manifestStore: store,
+                    interviewerRuntime: runtime
+                )
+            } else {
+                openedSession = try await InterviewRoomSession.restore(
+                    sessionID: sessionID,
+                    manifestStore: store,
+                    interviewerRuntime: runtime
+                )
+            }
+
+            session = openedSession
+            var restored = await openedSession.snapshot()
+            if restored.phase == .ready {
+                restored = try await openedSession.execute(
+                    .giveCandidateFloor(commandID: CommandID("local-give-floor-0"))
+                )
+            }
+            snapshot = restored
+            statusMessage = status(for: restored)
+        } catch {
+            statusMessage = "Local session unavailable"
+        }
+    }
+
+    func performPrimaryAction() async {
+        guard let session, let snapshot, canAct else { return }
+        isWorking = true
+        defer { isWorking = false }
+
+        do {
+            let updated: InterviewRoomSnapshot
+            switch snapshot.phase {
+            case .candidateFloor:
+                updated = try await session.execute(
+                    .handOff(
+                        commandID: CommandID("local-handoff-\(snapshot.revision)"),
+                        transcript: CandidateTranscript(
+                            body: "Transactional alerts need a durable path with explicit delivery state.",
+                            quality: .verified
+                        )
+                    )
+                )
+            case .interviewerProcessing:
+                updated = try await session.execute(
+                    .retryInterviewerResponse(
+                        commandID: CommandID(
+                            "local-retry-interviewer-\(snapshot.revision)"
+                        )
+                    )
+                )
+            case .interviewerTurn:
+                updated = try await session.execute(
+                    .giveCandidateFloor(
+                        commandID: CommandID("local-give-floor-\(snapshot.revision)")
+                    )
+                )
+            default:
+                return
+            }
+
+            self.snapshot = updated
+            statusMessage = status(for: updated)
+        } catch {
+            let recovered = await session.snapshot()
+            self.snapshot = recovered
+            statusMessage = status(for: recovered)
+        }
+    }
+
+    private func status(for snapshot: InterviewRoomSnapshot) -> String {
+        if snapshot.phase == .interviewerProcessing {
+            return "Answer saved · interviewer retry available"
+        }
+        return "Saved locally · revision \(snapshot.revision)"
+    }
+}

--- a/Sources/InterviewArcLive/SystemDesignRoomView.swift
+++ b/Sources/InterviewArcLive/SystemDesignRoomView.swift
@@ -1,0 +1,296 @@
+import InterviewArcLiveCore
+import SwiftUI
+
+struct SystemDesignRoomView: View {
+    @ObservedObject var model: SystemDesignRoomModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            question
+
+            HSplitView {
+                transcript
+                    .frame(minWidth: 330, idealWidth: 390, maxWidth: 470)
+                board
+                    .frame(minWidth: 560)
+            }
+
+            floorRail
+        }
+        .background(LivePalette.room)
+        .foregroundStyle(LivePalette.ink)
+        .task { await model.open() }
+    }
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            LiveMark()
+                .frame(width: 34, height: 34)
+            Text("Interview Arc Live")
+                .font(.system(.headline, design: .rounded, weight: .semibold))
+            Spacer()
+            Label("System design", systemImage: "point.3.connected.trianglepath.dotted")
+            Rectangle()
+                .fill(LivePalette.line.opacity(0.45))
+                .frame(width: 1, height: 18)
+            Text(model.statusMessage)
+                .foregroundStyle(LivePalette.line)
+            Rectangle()
+                .fill(LivePalette.line.opacity(0.45))
+                .frame(width: 1, height: 18)
+            Label("Private", systemImage: "lock")
+        }
+        .font(.system(.body, design: .rounded))
+        .foregroundStyle(LivePalette.paper)
+        .padding(.horizontal, 22)
+        .frame(height: 60)
+        .background(LivePalette.shell)
+    }
+
+    private var question: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("QUESTION")
+                .font(.system(.caption, design: .monospaced, weight: .semibold))
+                .tracking(1.4)
+                .foregroundStyle(LivePalette.muted)
+            Text(model.question)
+                .font(.system(size: 28, weight: .semibold, design: .rounded))
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 28)
+        .padding(.vertical, 20)
+        .background(LivePalette.paper)
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(LivePalette.line).frame(height: 1)
+        }
+    }
+
+    private var transcript: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 0) {
+                if let snapshot = model.snapshot, !snapshot.turns.isEmpty {
+                    ForEach(snapshot.turns.indices, id: \.self) { index in
+                        turnlineEntry(
+                            snapshot.turns[index],
+                            isLast: index == snapshot.turns.count - 1
+                        )
+                    }
+                } else {
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("CANDIDATE FLOOR")
+                            .font(.system(.caption, design: .monospaced, weight: .bold))
+                            .foregroundStyle(LivePalette.candidate)
+                        Text("Think aloud, work on the board, then hand off one complete answer.")
+                            .font(.system(.body, design: .rounded))
+                            .foregroundStyle(LivePalette.muted)
+                    }
+                    .padding(28)
+                }
+            }
+        }
+        .background(LivePalette.paper)
+    }
+
+    private func turnlineEntry(_ turn: InterviewTurn, isLast: Bool) -> some View {
+        let role: String
+        let body: String
+        let color: Color
+
+        switch turn {
+        case .candidate(let candidate):
+            role = "YOU"
+            body = candidate.transcript.body
+            color = LivePalette.candidate
+        case .interviewer(let interviewer):
+            role = "MARA"
+            body = interviewer.displayMarkdown
+            color = LivePalette.interviewer
+        }
+
+        return HStack(alignment: .top, spacing: 18) {
+            VStack(spacing: 0) {
+                Circle()
+                    .fill(color)
+                    .frame(width: 11, height: 11)
+                Rectangle()
+                    .fill(isLast ? Color.clear : LivePalette.line)
+                    .frame(width: 1)
+                    .frame(minHeight: 82)
+            }
+            .padding(.top, 4)
+            .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 10) {
+                Text(role)
+                    .font(.system(.caption, design: .monospaced, weight: .bold))
+                    .foregroundStyle(color)
+                Text(.init(body))
+                    .font(.system(.title3, design: .rounded))
+                    .textSelection(.enabled)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.bottom, 24)
+        }
+        .padding(.horizontal, 28)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(role): \(body)")
+    }
+
+    private var board: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("BOARD")
+                    .font(.system(.caption, design: .monospaced, weight: .bold))
+                    .tracking(1.1)
+                Spacer()
+                Text("Draft revision \(model.snapshot?.revision ?? 0)")
+                    .foregroundStyle(LivePalette.muted)
+                Button("Attach revision") {}
+                    .disabled(true)
+            }
+            .padding(.horizontal, 20)
+            .frame(height: 52)
+            .background(LivePalette.paper)
+
+            Rectangle().fill(LivePalette.line).frame(height: 1)
+
+            ZStack {
+                DotGrid()
+                HStack(spacing: 34) {
+                    BoardNode(icon: "network", title: "API gateway")
+                    BoardArrow()
+                    BoardNode(icon: "tray.full", title: "Durable queue")
+                    BoardArrow()
+                    BoardNode(icon: "shippingbox", title: "Delivery workers")
+                }
+                .padding(30)
+            }
+        }
+        .background(LivePalette.room)
+    }
+
+    private var floorRail: some View {
+        HStack(spacing: 18) {
+            Circle()
+                .fill(LivePalette.liveSignal)
+                .frame(width: 8, height: 8)
+                .accessibilityHidden(true)
+            Text(floorLabel.uppercased())
+                .font(.system(.caption, design: .monospaced, weight: .bold))
+            Capsule()
+                .fill(LivePalette.liveSignal.opacity(0.72))
+                .frame(height: 3)
+            Button {
+                Task { await model.performPrimaryAction() }
+            } label: {
+                Label(model.actionTitle, systemImage: model.actionIcon)
+                    .font(.system(.body, design: .rounded, weight: .semibold))
+                    .padding(.horizontal, 8)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(LivePalette.handoff)
+            .disabled(!model.canAct)
+            .keyboardShortcut(.return, modifiers: [.command])
+        }
+        .foregroundStyle(LivePalette.paper)
+        .padding(.horizontal, 24)
+        .frame(height: 72)
+        .background(LivePalette.shell)
+    }
+
+    private var floorLabel: String {
+        switch model.snapshot?.phase {
+        case .candidateFloor: "Your floor"
+        case .interviewerProcessing: "Answer saved · interviewer retry required"
+        case .interviewerTurn: "Interviewer turn"
+        case .completed: "Session complete"
+        default: "Preparing room"
+        }
+    }
+}
+
+private enum LivePalette {
+    static let room = Color(red: 232 / 255, green: 239 / 255, blue: 236 / 255)
+    static let paper = Color(red: 251 / 255, green: 252 / 255, blue: 250 / 255)
+    static let ink = Color(red: 16 / 255, green: 42 / 255, blue: 42 / 255)
+    static let muted = Color(red: 102 / 255, green: 122 / 255, blue: 118 / 255)
+    static let line = Color(red: 198 / 255, green: 214 / 255, blue: 209 / 255)
+    static let shell = Color(red: 11 / 255, green: 40 / 255, blue: 40 / 255)
+    static let candidate = Color(red: 13 / 255, green: 148 / 255, blue: 136 / 255)
+    static let interviewer = Color(red: 88 / 255, green: 105 / 255, blue: 201 / 255)
+    static let handoff = Color(red: 223 / 255, green: 102 / 255, blue: 63 / 255)
+    static let liveSignal = Color(red: 185 / 255, green: 219 / 255, blue: 87 / 255)
+}
+
+private struct LiveMark: View {
+    var body: some View {
+        ZStack {
+            Circle()
+                .trim(from: 0.05, to: 0.43)
+                .stroke(LivePalette.liveSignal, style: StrokeStyle(lineWidth: 3, lineCap: .round))
+                .rotationEffect(.degrees(-22))
+            Circle()
+                .trim(from: 0.55, to: 0.92)
+                .stroke(LivePalette.handoff, style: StrokeStyle(lineWidth: 3, lineCap: .round))
+                .rotationEffect(.degrees(-22))
+        }
+        .padding(4)
+        .accessibilityLabel("Interview Arc Live")
+    }
+}
+
+private struct BoardNode: View {
+    let icon: String
+    let title: String
+
+    var body: some View {
+        VStack(spacing: 10) {
+            Image(systemName: icon)
+                .font(.title2)
+                .foregroundStyle(LivePalette.candidate)
+            Text(title)
+                .font(.system(.subheadline, design: .rounded, weight: .semibold))
+                .multilineTextAlignment(.center)
+        }
+        .frame(width: 120, height: 108)
+        .background(LivePalette.paper, in: RoundedRectangle(cornerRadius: 14))
+        .overlay {
+            RoundedRectangle(cornerRadius: 14)
+                .stroke(LivePalette.line, lineWidth: 1.5)
+        }
+    }
+}
+
+private struct BoardArrow: View {
+    var body: some View {
+        Image(systemName: "arrow.right")
+            .foregroundStyle(LivePalette.muted)
+            .accessibilityHidden(true)
+    }
+}
+
+private struct DotGrid: View {
+    var body: some View {
+        Canvas { context, size in
+            for x in stride(from: 10.0, through: size.width, by: 20) {
+                for y in stride(from: 10.0, through: size.height, by: 20) {
+                    context.fill(
+                        Path(ellipseIn: CGRect(x: x, y: y, width: 1.5, height: 1.5)),
+                        with: .color(LivePalette.line.opacity(0.6))
+                    )
+                }
+            }
+        }
+        .accessibilityHidden(true)
+    }
+}
+
+private struct SystemDesignRoomViewPreview: PreviewProvider {
+    static var previews: some View {
+        SystemDesignRoomView(model: SystemDesignRoomModel())
+            .frame(width: 1180, height: 760)
+            .previewDisplayName("System design tracer")
+    }
+}

--- a/Sources/InterviewArcLiveCore/FileSessionManifestStore.swift
+++ b/Sources/InterviewArcLiveCore/FileSessionManifestStore.swift
@@ -1,0 +1,191 @@
+import Darwin
+import Foundation
+
+/// Atomic local-file Adapter for the Session Manifest persistence Seam.
+///
+/// Each replacement is prepared beside its destination, then renamed over the
+/// prior manifest. If encoding, writing, or replacement fails, the last
+/// complete destination remains readable.
+public actor FileSessionManifestStore: SessionManifestStore {
+    private let directoryURL: URL
+    private let replace: @Sendable (_ destination: URL, _ prepared: URL) throws -> Void
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    public init(directoryURL: URL) {
+        self.init(directoryURL: directoryURL) { destination, prepared in
+            _ = try FileManager.default.replaceItemAt(
+                destination,
+                withItemAt: prepared,
+                backupItemName: nil,
+                options: []
+            )
+        }
+    }
+
+    public init() throws {
+        self.init(
+            directoryURL: try LivePaths.sessionManifestsDirectory()
+        )
+    }
+
+    init(
+        directoryURL: URL,
+        replace: @escaping @Sendable (
+            _ destination: URL,
+            _ prepared: URL
+        ) throws -> Void
+    ) {
+        self.directoryURL = directoryURL
+        self.replace = replace
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        self.encoder = encoder
+        self.decoder = JSONDecoder()
+    }
+
+    public func load(sessionID: SessionID) throws -> SessionManifest? {
+        try prepareDirectory()
+        return try withLock(sessionID: sessionID, mode: LOCK_SH) {
+            try loadUnlocked(sessionID: sessionID)
+        }
+    }
+
+    private func loadUnlocked(sessionID: SessionID) throws -> SessionManifest? {
+        let manifestURL = try manifestURL(for: sessionID)
+        guard FileManager.default.fileExists(atPath: manifestURL.path) else {
+            return nil
+        }
+
+        let manifest = try decoder.decode(
+            SessionManifest.self,
+            from: Data(contentsOf: manifestURL)
+        )
+
+        guard manifest.sessionID == sessionID else {
+            throw SessionManifestStoreError.sessionIdentityMismatch
+        }
+
+        return manifest
+    }
+
+    public func save(
+        _ manifest: SessionManifest,
+        expectedRevision: Int?
+    ) throws {
+        try prepareDirectory()
+
+        try withLock(sessionID: manifest.sessionID, mode: LOCK_EX) {
+            try saveUnlocked(manifest, expectedRevision: expectedRevision)
+        }
+    }
+
+    private func saveUnlocked(
+        _ manifest: SessionManifest,
+        expectedRevision: Int?
+    ) throws {
+        let destination = try manifestURL(for: manifest.sessionID)
+        let current = try loadUnlocked(sessionID: manifest.sessionID)
+        let actualRevision = current?.revision
+
+        guard actualRevision == expectedRevision else {
+            throw SessionManifestStoreError.revisionConflict(
+                expected: expectedRevision,
+                actual: actualRevision
+            )
+        }
+
+        if let actualRevision, manifest.revision <= actualRevision {
+            throw SessionManifestStoreError.nonMonotonicRevision(
+                previous: actualRevision,
+                proposed: manifest.revision
+            )
+        }
+
+        let prepared = directoryURL.appendingPathComponent(
+            ".manifest-\(UUID().uuidString).prepared",
+            isDirectory: false
+        )
+
+        defer {
+            try? FileManager.default.removeItem(at: prepared)
+        }
+
+        try encoder.encode(manifest).write(to: prepared, options: [.atomic])
+
+        if current == nil {
+            try FileManager.default.moveItem(at: prepared, to: destination)
+        } else {
+            try replace(destination, prepared)
+        }
+    }
+
+    private func prepareDirectory() throws {
+        try FileManager.default.createDirectory(
+            at: directoryURL,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+    }
+
+    /// `flock` coordinates distinct Adapter instances and processes. The lock
+    /// stays held for the complete expected-revision read and atomic replace.
+    private func withLock<Result>(
+        sessionID: SessionID,
+        mode: Int32,
+        operation: () throws -> Result
+    ) throws -> Result {
+        let lockURL = try lockURL(for: sessionID)
+        let descriptor = Darwin.open(
+            lockURL.path,
+            O_CREAT | O_RDWR | O_CLOEXEC | O_NOFOLLOW,
+            mode_t(0o600)
+        )
+        guard descriptor >= 0 else {
+            throw lockError(operation: "open")
+        }
+        defer { Darwin.close(descriptor) }
+
+        guard Darwin.fchmod(descriptor, mode_t(0o600)) == 0 else {
+            throw lockError(operation: "chmod")
+        }
+
+        while flock(descriptor, mode) != 0 {
+            if errno != EINTR {
+                throw lockError(operation: "lock")
+            }
+        }
+        defer {
+            while flock(descriptor, LOCK_UN) != 0, errno == EINTR {}
+        }
+
+        return try operation()
+    }
+
+    private func lockError(operation: String) -> SessionManifestStoreError {
+        .fileLockFailed(operation: operation, code: errno)
+    }
+
+    private func manifestURL(for sessionID: SessionID) throws -> URL {
+        directoryURL.appendingPathComponent(
+            "\(try fileName(for: sessionID)).json",
+            isDirectory: false
+        )
+    }
+
+    private func lockURL(for sessionID: SessionID) throws -> URL {
+        directoryURL.appendingPathComponent(
+            "\(try fileName(for: sessionID)).lock",
+            isDirectory: false
+        )
+    }
+
+    private func fileName(for sessionID: SessionID) throws -> String {
+        try encoder.encode(sessionID)
+            .base64EncodedString()
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}

--- a/Sources/InterviewArcLiveCore/GroqEndpointClassifier.swift
+++ b/Sources/InterviewArcLiveCore/GroqEndpointClassifier.swift
@@ -1,0 +1,436 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+public protocol GroqEndpointTransport: Sendable {
+  func send(_ request: URLRequest) async throws -> (Data, HTTPURLResponse)
+}
+
+/// The production HTTP Adapter. Its ephemeral session does not persist model
+/// payloads, cookies, or response data to disk.
+public struct URLSessionGroqEndpointTransport: GroqEndpointTransport {
+  private let session: URLSession
+
+  public init(session: URLSession = URLSession(configuration: .ephemeral)) {
+    self.session = session
+  }
+
+  public func send(_ request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+    let (data, response) = try await session.data(for: request)
+    guard let response = response as? HTTPURLResponse else {
+      throw GroqEndpointClassifierError.invalidHTTPResponse
+    }
+    return (data, response)
+  }
+}
+
+public enum GroqEndpointContextField: String, Sendable, Equatable {
+  case interviewerQuestion = "interviewer_question"
+  case requestedParts = "requested_parts"
+  case accumulatedAnswer = "accumulated_answer"
+  case latestSegment = "latest_segment"
+  case silenceDuration = "silence_duration_ms"
+  case specialty
+  case stage
+  case workspaceActivity = "workspace_activity"
+  case totalContext = "total_context"
+}
+
+/// Errors intentionally contain no request content, provider response body, or
+/// credential material.
+public enum GroqEndpointClassifierError: Error, Sendable, Equatable {
+  case missingCredential
+  case invalidContext(GroqEndpointContextField)
+  case contextLimitExceeded(GroqEndpointContextField)
+  case transportFailure
+  case invalidHTTPResponse
+  case rejected(statusCode: Int)
+  case malformedResponse
+  case invalidClassification
+}
+
+/// Groq `openai/gpt-oss-20b` Adapter for the semantic endpoint Seam.
+///
+/// The Adapter accepts only bounded, complete context. It never truncates the
+/// interviewer question, requested parts, accumulated answer, or latest
+/// Segment, so every accepted request preserves those values exactly.
+public struct GroqEndpointClassifier: SemanticEndpointClassifying {
+  private static let endpoint = URL(string: "https://api.groq.com/openai/v1/chat/completions")!
+  private static let model = "openai/gpt-oss-20b"
+  private static let maximumTotalContextBytes = 96 * 1_024
+  private static let maximumQuestionBytes = 16 * 1_024
+  private static let maximumRequestedParts = 24
+  private static let maximumRequestedPartBytes = 4 * 1_024
+  private static let maximumAccumulatedAnswerBytes = 64 * 1_024
+  private static let maximumLatestSegmentBytes = 16 * 1_024
+  private static let maximumLabelBytes = 256
+  private static let maximumWorkspaceEvents = 24
+  private static let maximumWorkspaceSummaryBytes = 2 * 1_024
+  private static let maximumSilenceMilliseconds = 10 * 60 * 1_000
+  private static let maximumResponseBytes = 64 * 1_024
+
+  private let apiKey: String
+  private let transport: any GroqEndpointTransport
+
+  public init(
+    apiKey: String,
+    transport: any GroqEndpointTransport = URLSessionGroqEndpointTransport()
+  ) {
+    self.apiKey = apiKey
+    self.transport = transport
+  }
+
+  public func classify(_ context: SemanticEndpointContext) async throws -> SemanticEndpointProposal
+  {
+    guard !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+      throw GroqEndpointClassifierError.missingCredential
+    }
+
+    let request: URLRequest
+    do {
+      request = try makeRequest(context)
+    } catch let error as GroqEndpointClassifierError {
+      throw error
+    } catch {
+      throw GroqEndpointClassifierError.invalidContext(.totalContext)
+    }
+
+    let data: Data
+    let response: HTTPURLResponse
+    do {
+      (data, response) = try await transport.send(request)
+    } catch let error as GroqEndpointClassifierError {
+      throw error
+    } catch {
+      throw GroqEndpointClassifierError.transportFailure
+    }
+
+    guard (200..<300).contains(response.statusCode) else {
+      throw GroqEndpointClassifierError.rejected(statusCode: response.statusCode)
+    }
+    guard data.count <= Self.maximumResponseBytes else {
+      throw GroqEndpointClassifierError.malformedResponse
+    }
+
+    return try decodeProposal(from: data)
+  }
+
+  private func makeRequest(_ context: SemanticEndpointContext) throws -> URLRequest {
+    try validate(context)
+
+    let endpointContext = EndpointContextPayload(
+      interviewerQuestion: context.interviewerQuestion,
+      requestedParts: context.requestedParts,
+      accumulatedAnswer: context.accumulatedAnswer,
+      latestSegment: context.latestSegment,
+      silenceDurationMilliseconds: context.silenceDurationMilliseconds,
+      specialty: context.specialty,
+      stage: context.stage,
+      explicitCue: context.explicitCue,
+      workspaceActivity: context.workspaceActivity.map {
+        WorkspaceActivityPayload(
+          kind: $0.kind,
+          millisecondsAgo: $0.millisecondsAgo,
+          summary: $0.summary
+        )
+      }
+    )
+
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+    let contextData = try encoder.encode(endpointContext)
+    guard contextData.count <= Self.maximumTotalContextBytes else {
+      throw GroqEndpointClassifierError.contextLimitExceeded(.totalContext)
+    }
+    guard let contextJSON = String(data: contextData, encoding: .utf8) else {
+      throw GroqEndpointClassifierError.invalidContext(.totalContext)
+    }
+
+    let body = ChatCompletionRequest(
+      model: Self.model,
+      temperature: 0,
+      maxCompletionTokens: 256,
+      reasoningEffort: "low",
+      messages: [
+        .init(role: "system", content: Self.systemInstruction),
+        .init(role: "user", content: contextJSON),
+      ],
+      responseFormat: .semanticEndpoint
+    )
+
+    var request = URLRequest(url: Self.endpoint)
+    request.httpMethod = "POST"
+    request.timeoutInterval = 15
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+    request.httpBody = try encoder.encode(body)
+    return request
+  }
+
+  private func validate(_ context: SemanticEndpointContext) throws {
+    try requireNonempty(context.interviewerQuestion, field: .interviewerQuestion)
+    try requireNonempty(context.accumulatedAnswer, field: .accumulatedAnswer)
+    try requireNonempty(context.latestSegment, field: .latestSegment)
+    try requireNonempty(context.specialty, field: .specialty)
+    try requireNonempty(context.stage, field: .stage)
+
+    try requireByteCount(
+      context.interviewerQuestion,
+      atMost: Self.maximumQuestionBytes,
+      field: .interviewerQuestion
+    )
+    guard context.requestedParts.count <= Self.maximumRequestedParts else {
+      throw GroqEndpointClassifierError.contextLimitExceeded(.requestedParts)
+    }
+    for part in context.requestedParts {
+      try requireNonempty(part, field: .requestedParts)
+      try requireByteCount(part, atMost: Self.maximumRequestedPartBytes, field: .requestedParts)
+    }
+    try requireByteCount(
+      context.accumulatedAnswer,
+      atMost: Self.maximumAccumulatedAnswerBytes,
+      field: .accumulatedAnswer
+    )
+    try requireByteCount(
+      context.latestSegment,
+      atMost: Self.maximumLatestSegmentBytes,
+      field: .latestSegment
+    )
+    try requireByteCount(context.specialty, atMost: Self.maximumLabelBytes, field: .specialty)
+    try requireByteCount(context.stage, atMost: Self.maximumLabelBytes, field: .stage)
+
+    guard
+      context.silenceDurationMilliseconds >= 0,
+      context.silenceDurationMilliseconds <= Self.maximumSilenceMilliseconds
+    else {
+      throw GroqEndpointClassifierError.invalidContext(.silenceDuration)
+    }
+
+    guard context.workspaceActivity.count <= Self.maximumWorkspaceEvents else {
+      throw GroqEndpointClassifierError.contextLimitExceeded(.workspaceActivity)
+    }
+    for activity in context.workspaceActivity {
+      try requireNonempty(activity.kind, field: .workspaceActivity)
+      try requireByteCount(activity.kind, atMost: Self.maximumLabelBytes, field: .workspaceActivity)
+      guard activity.millisecondsAgo >= 0 else {
+        throw GroqEndpointClassifierError.invalidContext(.workspaceActivity)
+      }
+      try requireByteCount(
+        activity.summary,
+        atMost: Self.maximumWorkspaceSummaryBytes,
+        field: .workspaceActivity
+      )
+    }
+  }
+
+  private func requireNonempty(_ value: String, field: GroqEndpointContextField) throws {
+    guard !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+      throw GroqEndpointClassifierError.invalidContext(field)
+    }
+  }
+
+  private func requireByteCount(
+    _ value: String,
+    atMost limit: Int,
+    field: GroqEndpointContextField
+  ) throws {
+    guard value.utf8.count <= limit else {
+      throw GroqEndpointClassifierError.contextLimitExceeded(field)
+    }
+  }
+
+  private func decodeProposal(from data: Data) throws -> SemanticEndpointProposal {
+    let response: ChatCompletionResponse
+    do {
+      response = try JSONDecoder().decode(ChatCompletionResponse.self, from: data)
+    } catch {
+      throw GroqEndpointClassifierError.malformedResponse
+    }
+
+    guard
+      response.choices.count == 1,
+      let content = response.choices.first?.message.content,
+      let contentData = content.data(using: .utf8)
+    else {
+      throw GroqEndpointClassifierError.malformedResponse
+    }
+
+    let object: Any
+    do {
+      object = try JSONSerialization.jsonObject(with: contentData)
+    } catch {
+      throw GroqEndpointClassifierError.invalidClassification
+    }
+    guard let dictionary = object as? [String: Any] else {
+      throw GroqEndpointClassifierError.invalidClassification
+    }
+    guard Set(dictionary.keys) == ["decision", "reason_code"] else {
+      throw GroqEndpointClassifierError.invalidClassification
+    }
+    guard
+      let decisionValue = dictionary["decision"] as? String,
+      let decision = SemanticEndpointDecision(rawValue: decisionValue),
+      let reasonValue = dictionary["reason_code"] as? String,
+      let reason = SemanticEndpointReasonCode(rawValue: reasonValue),
+      Self.isConsistent(decision: decision, reason: reason)
+    else {
+      throw GroqEndpointClassifierError.invalidClassification
+    }
+
+    return SemanticEndpointProposal(decision: decision, reasonCode: reason)
+  }
+
+  private static let systemInstruction = """
+    You classify whether a candidate has finished one logical technical-interview answer. Use only the supplied JSON context. Silence alone never ends the Candidate Turn. Return likely_continue when a thought or requested part remains unfinished, or recent coding, drawing, or note activity indicates continued work. Return likely_end only when the answer resolves the exact question or an explicit Hand off cue is present. Return ambiguous when the evidence is insufficient. Never invent omitted speech. Return only the required JSON object; do not include confidence, prose, or additional keys.
+    """
+
+  private static func isConsistent(
+    decision: SemanticEndpointDecision,
+    reason: SemanticEndpointReasonCode
+  ) -> Bool {
+    switch reason {
+    case .explicitHandoffCue, .answerResolvesQuestion:
+      decision == .likelyEnd
+    case .unfinishedThought, .requestedPartUnanswered, .recentWorkspaceActivity:
+      decision == .likelyContinue
+    case .insufficientEvidence:
+      decision == .ambiguous
+    }
+  }
+}
+
+private struct EndpointContextPayload: Encodable, Sendable {
+  let interviewerQuestion: String
+  let requestedParts: [String]
+  let accumulatedAnswer: String
+  let latestSegment: String
+  let silenceDurationMilliseconds: Int
+  let specialty: String
+  let stage: String
+  let explicitCue: Bool
+  let workspaceActivity: [WorkspaceActivityPayload]
+
+  enum CodingKeys: String, CodingKey {
+    case interviewerQuestion = "interviewer_question"
+    case requestedParts = "requested_parts"
+    case accumulatedAnswer = "accumulated_answer"
+    case latestSegment = "latest_segment"
+    case silenceDurationMilliseconds = "silence_duration_ms"
+    case specialty
+    case stage
+    case explicitCue = "explicit_cue"
+    case workspaceActivity = "workspace_activity"
+  }
+}
+
+private struct WorkspaceActivityPayload: Encodable, Sendable {
+  let kind: String
+  let millisecondsAgo: Int
+  let summary: String
+
+  enum CodingKeys: String, CodingKey {
+    case kind
+    case millisecondsAgo = "milliseconds_ago"
+    case summary
+  }
+}
+
+private struct ChatCompletionRequest: Encodable, Sendable {
+  let model: String
+  let temperature: Int
+  let maxCompletionTokens: Int
+  let reasoningEffort: String
+  let messages: [Message]
+  let responseFormat: ResponseFormat
+
+  enum CodingKeys: String, CodingKey {
+    case model
+    case temperature
+    case maxCompletionTokens = "max_completion_tokens"
+    case reasoningEffort = "reasoning_effort"
+    case messages
+    case responseFormat = "response_format"
+  }
+
+  struct Message: Encodable, Sendable {
+    let role: String
+    let content: String
+  }
+
+  struct ResponseFormat: Encodable, Sendable {
+    let type: String
+    let jsonSchema: JSONSchemaEnvelope
+
+    enum CodingKeys: String, CodingKey {
+      case type
+      case jsonSchema = "json_schema"
+    }
+
+    static let semanticEndpoint = ResponseFormat(
+      type: "json_schema",
+      jsonSchema: JSONSchemaEnvelope(
+        name: "semantic_endpoint_proposal",
+        strict: true,
+        schema: JSONSchema(
+          type: "object",
+          properties: [
+            "decision": .init(
+              type: "string",
+              enumValues: SemanticEndpointDecision.allCases.map(\.rawValue)
+            ),
+            "reason_code": .init(
+              type: "string",
+              enumValues: SemanticEndpointReasonCode.allCases.map(\.rawValue)
+            ),
+          ],
+          required: ["decision", "reason_code"],
+          additionalProperties: false
+        )
+      )
+    )
+  }
+
+  struct JSONSchemaEnvelope: Encodable, Sendable {
+    let name: String
+    let strict: Bool
+    let schema: JSONSchema
+  }
+
+  struct JSONSchema: Encodable, Sendable {
+    let type: String
+    let properties: [String: JSONProperty]
+    let required: [String]
+    let additionalProperties: Bool
+
+    enum CodingKeys: String, CodingKey {
+      case type
+      case properties
+      case required
+      case additionalProperties = "additionalProperties"
+    }
+  }
+
+  struct JSONProperty: Encodable, Sendable {
+    let type: String
+    let enumValues: [String]
+
+    enum CodingKeys: String, CodingKey {
+      case type
+      case enumValues = "enum"
+    }
+  }
+}
+
+private struct ChatCompletionResponse: Decodable {
+  let choices: [Choice]
+
+  struct Choice: Decodable {
+    let message: Message
+  }
+
+  struct Message: Decodable {
+    let content: String?
+  }
+}

--- a/Sources/InterviewArcLiveCore/InterviewRoomSession.swift
+++ b/Sources/InterviewArcLiveCore/InterviewRoomSession.swift
@@ -1,0 +1,426 @@
+import Foundation
+import CryptoKit
+
+public enum InterviewRoomCommand: Codable, Sendable, Equatable {
+    case giveCandidateFloor(commandID: CommandID)
+    case setTurnMode(commandID: CommandID, mode: TurnMode)
+    case handOff(commandID: CommandID, transcript: CandidateTranscript)
+    case retryInterviewerResponse(commandID: CommandID)
+    case finish(commandID: CommandID)
+
+    var commandID: CommandID {
+        switch self {
+        case .giveCandidateFloor(let commandID),
+             .setTurnMode(let commandID, _),
+             .handOff(let commandID, _),
+             .retryInterviewerResponse(let commandID),
+             .finish(let commandID):
+            commandID
+        }
+    }
+}
+
+public enum InterviewRoomSessionError: Error, Sendable, Equatable {
+    case emptyIdentifier(name: String)
+    case sessionAlreadyExists(SessionID)
+    case sessionNotFound(SessionID)
+    case invalidManifest(reason: String)
+    case invalidTransition(command: String, phase: InterviewRoomPhase)
+    case emptyCandidateTranscript
+    case invalidInterviewerResponse
+    case commandIDReused(CommandID)
+    case commandInProgress
+    case commandEncodingFailed
+}
+
+/// Deep Module owning Interview Room ordering, transitions, idempotency, and
+/// persist-before-publish behavior. Callers submit commands and receive only
+/// immutable snapshots; they cannot mutate the Session Manifest directly.
+public actor InterviewRoomSession {
+    private var manifest: SessionManifest
+    private let manifestStore: any SessionManifestStore
+    private let interviewerRuntime: any InterviewerRuntime
+    private var isExecutingCommand = false
+
+    private init(
+        manifest: SessionManifest,
+        manifestStore: any SessionManifestStore,
+        interviewerRuntime: any InterviewerRuntime
+    ) {
+        self.manifest = manifest
+        self.manifestStore = manifestStore
+        self.interviewerRuntime = interviewerRuntime
+    }
+
+    /// Creates and durably records a new session at revision zero.
+    public static func start(
+        sessionID: SessionID,
+        activityID: String,
+        turnMode: TurnMode = .manual,
+        manifestStore: any SessionManifestStore,
+        interviewerRuntime: any InterviewerRuntime
+    ) async throws -> InterviewRoomSession {
+        try validateIdentifier(sessionID.rawValue, name: "sessionID")
+        try validateIdentifier(activityID, name: "activityID")
+
+        if try await manifestStore.load(sessionID: sessionID) != nil {
+            throw InterviewRoomSessionError.sessionAlreadyExists(sessionID)
+        }
+
+        let manifest = SessionManifest(
+            sessionID: sessionID,
+            activityID: activityID,
+            phase: .ready,
+            turnMode: turnMode,
+            turns: [],
+            revision: 0,
+            appliedCommands: []
+        )
+        try await manifestStore.save(manifest, expectedRevision: nil)
+
+        return InterviewRoomSession(
+            manifest: manifest,
+            manifestStore: manifestStore,
+            interviewerRuntime: interviewerRuntime
+        )
+    }
+
+    /// Restores the latest complete manifest without advancing its revision.
+    public static func restore(
+        sessionID: SessionID,
+        manifestStore: any SessionManifestStore,
+        interviewerRuntime: any InterviewerRuntime
+    ) async throws -> InterviewRoomSession {
+        try validateIdentifier(sessionID.rawValue, name: "sessionID")
+
+        guard let manifest = try await manifestStore.load(sessionID: sessionID) else {
+            throw InterviewRoomSessionError.sessionNotFound(sessionID)
+        }
+        try validate(manifest)
+
+        return InterviewRoomSession(
+            manifest: manifest,
+            manifestStore: manifestStore,
+            interviewerRuntime: interviewerRuntime
+        )
+    }
+
+    public func snapshot() -> InterviewRoomSnapshot {
+        InterviewRoomSnapshot(manifest: manifest)
+    }
+
+    /// Applies one command serially. An accepted transition is persisted before
+    /// it becomes observable through `snapshot()` or this return value.
+    public func execute(_ command: InterviewRoomCommand) async throws -> InterviewRoomSnapshot {
+        guard !isExecutingCommand else {
+            throw InterviewRoomSessionError.commandInProgress
+        }
+        isExecutingCommand = true
+        defer { isExecutingCommand = false }
+
+        try Self.validateIdentifier(command.commandID.rawValue, name: "commandID")
+        let fingerprint = try Self.fingerprint(for: command)
+
+        if let applied = manifest.appliedCommands.first(where: {
+            $0.commandID == command.commandID
+        }) {
+            guard applied.payloadFingerprint == fingerprint else {
+                throw InterviewRoomSessionError.commandIDReused(command.commandID)
+            }
+            return InterviewRoomSnapshot(manifest: manifest)
+        }
+
+        switch command {
+        case .handOff(let commandID, let transcript):
+            return try await handOff(
+                commandID: commandID,
+                transcript: transcript,
+                fingerprint: fingerprint
+            )
+        case .retryInterviewerResponse(let commandID):
+            return try await retryInterviewerResponse(
+                commandID: commandID,
+                fingerprint: fingerprint
+            )
+        default:
+            let next = try applyingImmediate(command, fingerprint: fingerprint)
+            try await persist(next)
+            return InterviewRoomSnapshot(manifest: next)
+        }
+    }
+
+    private func applyingImmediate(
+        _ command: InterviewRoomCommand,
+        fingerprint: String
+    ) throws -> SessionManifest {
+        var phase = manifest.phase
+        var mode = manifest.turnMode
+        let turns = manifest.turns
+
+        switch command {
+        case .giveCandidateFloor:
+            guard phase == .ready || phase == .interviewerTurn else {
+                throw invalidTransition("giveCandidateFloor")
+            }
+            phase = .candidateFloor
+
+        case .setTurnMode(_, let selectedMode):
+            guard phase != .completed else {
+                throw invalidTransition("setTurnMode")
+            }
+            mode = selectedMode
+
+        case .handOff, .retryInterviewerResponse:
+            preconditionFailure("Provider commands use their durable two-stage paths")
+
+        case .finish:
+            guard phase == .ready || phase == .interviewerTurn else {
+                throw invalidTransition("finish")
+            }
+            phase = .completed
+        }
+
+        let nextRevision = manifest.revision + 1
+        let applied = AppliedCommandRecord(
+            commandID: command.commandID,
+            payloadFingerprint: fingerprint,
+            resultingRevision: nextRevision
+        )
+        return SessionManifest(
+            sessionID: manifest.sessionID,
+            activityID: manifest.activityID,
+            phase: phase,
+            turnMode: mode,
+            turns: turns,
+            revision: nextRevision,
+            appliedCommands: manifest.appliedCommands + [applied]
+        )
+    }
+
+    /// Hand off is deliberately two durable transitions. The Candidate Turn is
+    /// saved before provider work starts, so a provider failure cannot erase an
+    /// accepted answer. Retrying the same Hand off only returns that pending
+    /// state; response recovery is an explicit command.
+    private func handOff(
+        commandID: CommandID,
+        transcript: CandidateTranscript,
+        fingerprint: String
+    ) async throws -> InterviewRoomSnapshot {
+        guard manifest.phase == .candidateFloor else {
+            throw invalidTransition("handOff")
+        }
+        guard !transcript.body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw InterviewRoomSessionError.emptyCandidateTranscript
+        }
+
+        let candidate = CandidateTurn(
+            id: Self.turnID(
+                sessionID: manifest.sessionID,
+                commandID: commandID,
+                role: "candidate"
+            ),
+            commandID: commandID,
+            transcript: transcript
+        )
+        let candidateRevision = manifest.revision + 1
+        let receipt = AppliedCommandRecord(
+            commandID: commandID,
+            payloadFingerprint: fingerprint,
+            resultingRevision: candidateRevision
+        )
+        let awaitingResponse = SessionManifest(
+            sessionID: manifest.sessionID,
+            activityID: manifest.activityID,
+            phase: .interviewerProcessing,
+            turnMode: manifest.turnMode,
+            turns: manifest.turns + [.candidate(candidate)],
+            revision: candidateRevision,
+            appliedCommands: manifest.appliedCommands + [receipt]
+        )
+        try await persist(awaitingResponse)
+
+        return try await completeInterviewerResponse(
+            for: candidate
+        )
+    }
+
+    private func retryInterviewerResponse(
+        commandID: CommandID,
+        fingerprint: String
+    ) async throws -> InterviewRoomSnapshot {
+        guard manifest.phase == .interviewerProcessing,
+              case .candidate(let candidate) = manifest.turns.last else {
+            throw invalidTransition("retryInterviewerResponse")
+        }
+        let receipt = AppliedCommandRecord(
+            commandID: commandID,
+            payloadFingerprint: fingerprint,
+            resultingRevision: manifest.revision + 1
+        )
+        let pendingRetry = SessionManifest(
+            sessionID: manifest.sessionID,
+            activityID: manifest.activityID,
+            phase: .interviewerProcessing,
+            turnMode: manifest.turnMode,
+            turns: manifest.turns,
+            revision: manifest.revision + 1,
+            appliedCommands: manifest.appliedCommands + [receipt]
+        )
+        try await persist(pendingRetry)
+
+        return try await completeInterviewerResponse(
+            for: candidate
+        )
+    }
+
+    private func completeInterviewerResponse(
+        for candidate: CandidateTurn
+    ) async throws -> InterviewRoomSnapshot {
+        let request = InterviewerRequest(
+            sessionID: manifest.sessionID,
+            activityID: manifest.activityID,
+            candidateTurn: candidate,
+            precedingTurns: Array(manifest.turns.dropLast())
+        )
+        let response = try await interviewerRuntime.respond(to: request)
+        guard !response.displayMarkdown.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !response.spokenText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw InterviewRoomSessionError.invalidInterviewerResponse
+        }
+
+        let interviewer = InterviewerTurn(
+            id: Self.turnID(
+                sessionID: manifest.sessionID,
+                commandID: candidate.commandID,
+                role: "interviewer"
+            ),
+            commandID: candidate.commandID,
+            replyToTurnID: candidate.id,
+            response: response
+        )
+        let completed = SessionManifest(
+            sessionID: manifest.sessionID,
+            activityID: manifest.activityID,
+            phase: .interviewerTurn,
+            turnMode: manifest.turnMode,
+            turns: manifest.turns + [.interviewer(interviewer)],
+            revision: manifest.revision + 1,
+            appliedCommands: manifest.appliedCommands
+        )
+        try await persist(completed)
+        return InterviewRoomSnapshot(manifest: completed)
+    }
+
+    private func persist(_ next: SessionManifest) async throws {
+        try await manifestStore.save(next, expectedRevision: manifest.revision)
+        manifest = next
+    }
+
+    private func invalidTransition(_ command: String) -> InterviewRoomSessionError {
+        .invalidTransition(command: command, phase: manifest.phase)
+    }
+
+    private static func fingerprint(for command: InterviewRoomCommand) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let encodedCommand: Data
+        do {
+            encodedCommand = try encoder.encode(command)
+        } catch {
+            throw InterviewRoomSessionError.commandEncodingFailed
+        }
+        var versionedPayload = Data("interview-room-command:v1\n".utf8)
+        versionedPayload.append(encodedCommand)
+        let digest = SHA256.hash(data: versionedPayload)
+        return "sha256:v1:" + digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func turnID(
+        sessionID: SessionID,
+        commandID: CommandID,
+        role: String
+    ) -> TurnID {
+        var tuple = Data()
+        for field in [
+            "interview-room-turn-id",
+            "v1",
+            sessionID.rawValue,
+            commandID.rawValue,
+            role,
+        ] {
+            appendLengthPrefixed(field, to: &tuple)
+        }
+        let digest = SHA256.hash(data: tuple)
+        let hex = digest.map { String(format: "%02x", $0) }.joined()
+        return TurnID("turn:sha256:v1:\(hex)")
+    }
+
+    private static func appendLengthPrefixed(_ value: String, to data: inout Data) {
+        let bytes = Data(value.utf8)
+        let count = UInt64(bytes.count)
+        for shift in stride(from: 56, through: 0, by: -8) {
+            data.append(UInt8((count >> UInt64(shift)) & 0xff))
+        }
+        data.append(bytes)
+    }
+
+    private static func validateIdentifier(_ value: String, name: String) throws {
+        guard !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw InterviewRoomSessionError.emptyIdentifier(name: name)
+        }
+    }
+
+    private static func validate(_ manifest: SessionManifest) throws {
+        try validateIdentifier(manifest.sessionID.rawValue, name: "sessionID")
+        try validateIdentifier(manifest.activityID, name: "activityID")
+        guard manifest.revision >= 0 else {
+            throw InterviewRoomSessionError.invalidManifest(reason: "negative revision")
+        }
+
+        var index = 0
+        while index + 1 < manifest.turns.count {
+            guard case .candidate(let candidate) = manifest.turns[index],
+                  case .interviewer(let interviewer) = manifest.turns[index + 1],
+                  interviewer.replyToTurnID == candidate.id,
+                  interviewer.commandID == candidate.commandID else {
+                throw InterviewRoomSessionError.invalidManifest(
+                    reason: "turns must be ordered candidate then matching interviewer"
+                )
+            }
+            index += 2
+        }
+
+        if index < manifest.turns.count {
+            guard manifest.phase == .interviewerProcessing,
+                  index == manifest.turns.count - 1,
+                  case .candidate = manifest.turns[index] else {
+                throw InterviewRoomSessionError.invalidManifest(
+                    reason: "only an interviewer-processing session may end with a candidate"
+                )
+            }
+        } else if manifest.phase == .interviewerProcessing {
+            throw InterviewRoomSessionError.invalidManifest(
+                reason: "interviewer-processing phase requires a pending candidate"
+            )
+        }
+
+        let commandIDs = manifest.appliedCommands.map(\.commandID)
+        guard Set(commandIDs).count == commandIDs.count,
+              manifest.appliedCommands.allSatisfy({
+                  $0.resultingRevision > 0 && $0.resultingRevision <= manifest.revision
+              }) else {
+            throw InterviewRoomSessionError.invalidManifest(reason: "invalid command receipts")
+        }
+
+        if manifest.phase == .ready && !manifest.turns.isEmpty {
+            throw InterviewRoomSessionError.invalidManifest(
+                reason: "ready session cannot contain turns"
+            )
+        }
+        if manifest.phase == .interviewerTurn && manifest.turns.isEmpty {
+            throw InterviewRoomSessionError.invalidManifest(
+                reason: "interviewer phase requires a completed turn pair"
+            )
+        }
+    }
+}

--- a/Sources/InterviewArcLiveCore/LivePaths.swift
+++ b/Sources/InterviewArcLiveCore/LivePaths.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+public enum LivePathError: Error, Equatable, Sendable {
+    case applicationSupportDirectoryUnavailable
+}
+
+/// Live-owned runtime paths, derived at runtime so no personal path enters
+/// source or durable manifests.
+public enum LivePaths {
+    public static let applicationSupportDirectoryName = "InterviewArcLive"
+
+    public static func applicationSupportRoot(
+        fileManager: FileManager = .default
+    ) throws -> URL {
+        guard let base = fileManager.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first else {
+            throw LivePathError.applicationSupportDirectoryUnavailable
+        }
+
+        return base.appendingPathComponent(
+            applicationSupportDirectoryName,
+            isDirectory: true
+        )
+    }
+
+    public static func sessionManifestsDirectory(
+        fileManager: FileManager = .default
+    ) throws -> URL {
+        try applicationSupportRoot(fileManager: fileManager)
+            .appendingPathComponent("SessionManifests", isDirectory: true)
+    }
+}

--- a/Sources/InterviewArcLiveCore/ProviderContracts.swift
+++ b/Sources/InterviewArcLiveCore/ProviderContracts.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Input presented to the Interviewer Runtime Seam after an explicit Hand off.
+public struct InterviewerRequest: Sendable, Equatable {
+    public let sessionID: SessionID
+    public let activityID: String
+    public let candidateTurn: CandidateTurn
+    public let precedingTurns: [InterviewTurn]
+
+    public init(
+        sessionID: SessionID,
+        activityID: String,
+        candidateTurn: CandidateTurn,
+        precedingTurns: [InterviewTurn]
+    ) {
+        self.sessionID = sessionID
+        self.activityID = activityID
+        self.candidateTurn = candidateTurn
+        self.precedingTurns = precedingTurns
+    }
+}
+
+/// Seam for producing one canonical Interviewer Turn response.
+public protocol InterviewerRuntime: Sendable {
+    func respond(to request: InterviewerRequest) async throws -> CanonicalInterviewerResponse
+}
+
+/// Deterministic Adapter used by the tracer-bullet room and behavior tests.
+public struct DeterministicInterviewerRuntime: InterviewerRuntime {
+    private let response: CanonicalInterviewerResponse
+
+    public init(response: CanonicalInterviewerResponse) {
+        self.response = response
+    }
+
+    public func respond(to request: InterviewerRequest) async throws -> CanonicalInterviewerResponse {
+        response
+    }
+}

--- a/Sources/InterviewArcLiveCore/SemanticEndpointClassifier.swift
+++ b/Sources/InterviewArcLiveCore/SemanticEndpointClassifier.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+/// Classifies whether the current Candidate Turn appears ready for Hand off.
+///
+/// A proposal is evidence for turn-taking policy. It never commits a turn or
+/// mutates an Interview Room Session by itself.
+public protocol SemanticEndpointClassifying: Sendable {
+  func classify(_ context: SemanticEndpointContext) async throws -> SemanticEndpointProposal
+}
+
+public struct SemanticEndpointContext: Sendable, Equatable {
+  public let interviewerQuestion: String
+  public let requestedParts: [String]
+  public let accumulatedAnswer: String
+  public let latestSegment: String
+  public let silenceDurationMilliseconds: Int
+  public let specialty: String
+  public let stage: String
+  public let explicitCue: Bool
+  public let workspaceActivity: [SemanticEndpointWorkspaceActivity]
+
+  public init(
+    interviewerQuestion: String,
+    requestedParts: [String],
+    accumulatedAnswer: String,
+    latestSegment: String,
+    silenceDurationMilliseconds: Int,
+    specialty: String,
+    stage: String,
+    explicitCue: Bool,
+    workspaceActivity: [SemanticEndpointWorkspaceActivity]
+  ) {
+    self.interviewerQuestion = interviewerQuestion
+    self.requestedParts = requestedParts
+    self.accumulatedAnswer = accumulatedAnswer
+    self.latestSegment = latestSegment
+    self.silenceDurationMilliseconds = silenceDurationMilliseconds
+    self.specialty = specialty
+    self.stage = stage
+    self.explicitCue = explicitCue
+    self.workspaceActivity = workspaceActivity
+  }
+}
+
+public struct SemanticEndpointWorkspaceActivity: Sendable, Equatable {
+  public let kind: String
+  public let millisecondsAgo: Int
+  public let summary: String
+
+  public init(kind: String, millisecondsAgo: Int, summary: String) {
+    self.kind = kind
+    self.millisecondsAgo = millisecondsAgo
+    self.summary = summary
+  }
+}
+
+public enum SemanticEndpointDecision: String, Sendable, Equatable, CaseIterable {
+  case likelyContinue = "likely_continue"
+  case likelyEnd = "likely_end"
+  case ambiguous
+}
+
+public enum SemanticEndpointReasonCode: String, Sendable, Equatable, CaseIterable {
+  case explicitHandoffCue = "explicit_handoff_cue"
+  case answerResolvesQuestion = "answer_resolves_question"
+  case unfinishedThought = "unfinished_thought"
+  case requestedPartUnanswered = "requested_part_unanswered"
+  case recentWorkspaceActivity = "recent_workspace_activity"
+  case insufficientEvidence = "insufficient_evidence"
+}
+
+public struct SemanticEndpointProposal: Sendable, Equatable {
+  public let decision: SemanticEndpointDecision
+  public let reasonCode: SemanticEndpointReasonCode
+
+  public init(decision: SemanticEndpointDecision, reasonCode: SemanticEndpointReasonCode) {
+    self.decision = decision
+    self.reasonCode = reasonCode
+  }
+}
+
+/// A deterministic Adapter used by fixtures and tests at the same Seam as the
+/// production Groq Adapter.
+public struct DeterministicSemanticEndpointClassifier: SemanticEndpointClassifying {
+  private let proposal: SemanticEndpointProposal
+
+  public init(proposal: SemanticEndpointProposal) {
+    self.proposal = proposal
+  }
+
+  public func classify(_ context: SemanticEndpointContext) async throws -> SemanticEndpointProposal
+  {
+    proposal
+  }
+}

--- a/Sources/InterviewArcLiveCore/SessionManifest.swift
+++ b/Sources/InterviewArcLiveCore/SessionManifest.swift
@@ -1,0 +1,188 @@
+import Foundation
+
+public struct SessionID: RawRepresentable, Codable, Hashable, Sendable, CustomStringConvertible {
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public var description: String { rawValue }
+}
+
+public struct CommandID: RawRepresentable, Codable, Hashable, Sendable, CustomStringConvertible {
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public var description: String { rawValue }
+}
+
+public struct TurnID: RawRepresentable, Codable, Hashable, Sendable, CustomStringConvertible {
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public var description: String { rawValue }
+}
+
+public enum InterviewRoomPhase: String, Codable, Sendable, Equatable {
+    case ready
+    case candidateFloor
+    case interviewerProcessing
+    case interviewerTurn
+    case completed
+}
+
+public enum TurnMode: String, Codable, Sendable, Equatable {
+    case cueOnly
+    case patientAuto
+    case manual
+}
+
+public enum TranscriptQuality: String, Codable, Sendable, Equatable {
+    case verified
+    case bestAvailable = "best_available"
+    case possibleContamination = "possible_contamination"
+}
+
+/// The best nonempty transcript candidate and the quality label attached to it.
+/// The body is retained verbatim; the session Module never rewrites speech.
+public struct CandidateTranscript: Codable, Sendable, Equatable {
+    public let body: String
+    public let quality: TranscriptQuality
+
+    public init(body: String, quality: TranscriptQuality) {
+        self.body = body
+        self.quality = quality
+    }
+}
+
+public struct CandidateTurn: Codable, Sendable, Equatable {
+    public let id: TurnID
+    public let commandID: CommandID
+    public let transcript: CandidateTranscript
+
+    public init(id: TurnID, commandID: CommandID, transcript: CandidateTranscript) {
+        self.id = id
+        self.commandID = commandID
+        self.transcript = transcript
+    }
+}
+
+/// The canonical response value returned by an Interviewer Runtime Adapter.
+/// Both representations must be generated together and remain one identity.
+public struct CanonicalInterviewerResponse: Codable, Sendable, Equatable {
+    public let displayMarkdown: String
+    public let spokenText: String
+
+    public init(displayMarkdown: String, spokenText: String) {
+        self.displayMarkdown = displayMarkdown
+        self.spokenText = spokenText
+    }
+}
+
+public struct InterviewerTurn: Codable, Sendable, Equatable {
+    public let id: TurnID
+    public let commandID: CommandID
+    public let replyToTurnID: TurnID
+    public let response: CanonicalInterviewerResponse
+
+    public init(
+        id: TurnID,
+        commandID: CommandID,
+        replyToTurnID: TurnID,
+        response: CanonicalInterviewerResponse
+    ) {
+        self.id = id
+        self.commandID = commandID
+        self.replyToTurnID = replyToTurnID
+        self.response = response
+    }
+
+    public var displayMarkdown: String { response.displayMarkdown }
+    public var spokenText: String { response.spokenText }
+}
+
+public enum InterviewTurn: Codable, Sendable, Equatable {
+    case candidate(CandidateTurn)
+    case interviewer(InterviewerTurn)
+
+    public var id: TurnID {
+        switch self {
+        case .candidate(let turn): turn.id
+        case .interviewer(let turn): turn.id
+        }
+    }
+}
+
+struct AppliedCommandRecord: Codable, Sendable, Equatable {
+    let commandID: CommandID
+    let payloadFingerprint: String
+    let resultingRevision: Int
+}
+
+/// Canonical, monotonically revisioned recovery state for one Interview Room.
+public struct SessionManifest: Codable, Sendable, Equatable {
+    public let sessionID: SessionID
+    public let activityID: String
+    public let phase: InterviewRoomPhase
+    public let turnMode: TurnMode
+    public let turns: [InterviewTurn]
+    public let revision: Int
+
+    let appliedCommands: [AppliedCommandRecord]
+
+    init(
+        sessionID: SessionID,
+        activityID: String,
+        phase: InterviewRoomPhase,
+        turnMode: TurnMode,
+        turns: [InterviewTurn],
+        revision: Int,
+        appliedCommands: [AppliedCommandRecord]
+    ) {
+        self.sessionID = sessionID
+        self.activityID = activityID
+        self.phase = phase
+        self.turnMode = turnMode
+        self.turns = turns
+        self.revision = revision
+        self.appliedCommands = appliedCommands
+    }
+}
+
+/// Immutable projection returned by the InterviewRoomSession Interface.
+public struct InterviewRoomSnapshot: Sendable, Equatable {
+    public let sessionID: SessionID
+    public let activityID: String
+    public let phase: InterviewRoomPhase
+    public let turnMode: TurnMode
+    public let turns: [InterviewTurn]
+    public let revision: Int
+
+    init(manifest: SessionManifest) {
+        sessionID = manifest.sessionID
+        activityID = manifest.activityID
+        phase = manifest.phase
+        turnMode = manifest.turnMode
+        turns = manifest.turns
+        revision = manifest.revision
+    }
+}

--- a/Sources/InterviewArcLiveCore/SessionManifestStore.swift
+++ b/Sources/InterviewArcLiveCore/SessionManifestStore.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// The persistence Seam for the canonical Session Manifest.
+///
+/// A save is a compare-and-swap operation: `expectedRevision` is `nil` only
+/// when creating a session and otherwise names the exact durable revision the
+/// caller is replacing. Adapters must reject a stale expectation without
+/// changing the previously readable manifest.
+public protocol SessionManifestStore: Sendable {
+    func load(sessionID: SessionID) async throws -> SessionManifest?
+
+    func save(
+        _ manifest: SessionManifest,
+        expectedRevision: Int?
+    ) async throws
+}
+
+public enum SessionManifestStoreError: Error, Equatable, Sendable {
+    case revisionConflict(expected: Int?, actual: Int?)
+    case nonMonotonicRevision(previous: Int, proposed: Int)
+    case sessionIdentityMismatch
+    case fileLockFailed(operation: String, code: Int32)
+}
+
+/// A deterministic Adapter for tests and ephemeral previews.
+public actor InMemorySessionManifestStore: SessionManifestStore {
+    private var manifests: [SessionID: SessionManifest]
+
+    public init(manifests: [SessionManifest] = []) {
+        self.manifests = Dictionary(
+            uniqueKeysWithValues: manifests.map { ($0.sessionID, $0) }
+        )
+    }
+
+    public func load(sessionID: SessionID) -> SessionManifest? {
+        manifests[sessionID]
+    }
+
+    public func save(
+        _ manifest: SessionManifest,
+        expectedRevision: Int?
+    ) throws {
+        let current = manifests[manifest.sessionID]
+        let actualRevision = current?.revision
+
+        guard actualRevision == expectedRevision else {
+            throw SessionManifestStoreError.revisionConflict(
+                expected: expectedRevision,
+                actual: actualRevision
+            )
+        }
+
+        if let actualRevision, manifest.revision <= actualRevision {
+            throw SessionManifestStoreError.nonMonotonicRevision(
+                previous: actualRevision,
+                proposed: manifest.revision
+            )
+        }
+
+        manifests[manifest.sessionID] = manifest
+    }
+}

--- a/Tests/InterviewArcLiveCoreTests/GroqEndpointClassifierTests.swift
+++ b/Tests/InterviewArcLiveCoreTests/GroqEndpointClassifierTests.swift
@@ -1,0 +1,292 @@
+import Foundation
+import XCTest
+
+@testable import InterviewArcLiveCore
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+@MainActor
+final class GroqEndpointClassifierTests: XCTestCase {
+  func testRequestUsesGPTOSSAndPreservesExactBoundedContext() async throws {
+    let transport = RecordingGroqTransport(
+      statusCode: 200,
+      body: responseBody(decision: "likely_continue", reason: "requested_part_unanswered")
+    )
+    let classifier = GroqEndpointClassifier(apiKey: "private-test-key", transport: transport)
+    let context = SemanticEndpointContext(
+      interviewerQuestion: "How are you, and why did you choose BFS?",
+      requestedParts: ["Describe how you are", "Explain the BFS choice"],
+      accumulatedAnswer: "I'm fine, thank you.",
+      latestSegment: "I'm fine, thank you.",
+      silenceDurationMilliseconds: 1_750,
+      specialty: "coding",
+      stage: "candidate_floor",
+      explicitCue: false,
+      workspaceActivity: [
+        .init(kind: "code_edit", millisecondsAgo: 320, summary: "Changed the queue initialization.")
+      ]
+    )
+
+    let proposal = try await classifier.classify(context)
+
+    XCTAssertEqual(
+      proposal,
+      SemanticEndpointProposal(
+        decision: .likelyContinue,
+        reasonCode: .requestedPartUnanswered
+      )
+    )
+
+    let recordedRequest = await transport.recordedRequest()
+    let request = try XCTUnwrap(recordedRequest)
+    XCTAssertEqual(request.url?.absoluteString, "https://api.groq.com/openai/v1/chat/completions")
+    XCTAssertEqual(request.httpMethod, "POST")
+    XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer private-test-key")
+
+    let bodyData = try XCTUnwrap(request.httpBody)
+    let bodyString = try XCTUnwrap(String(data: bodyData, encoding: .utf8))
+    XCTAssertFalse(bodyString.contains("private-test-key"))
+    XCTAssertFalse(bodyString.lowercased().contains("confidence"))
+
+    let body = try jsonDictionary(bodyData)
+    XCTAssertEqual(body["model"] as? String, "openai/gpt-oss-20b")
+    XCTAssertEqual(body["temperature"] as? Int, 0)
+    XCTAssertEqual(body["reasoning_effort"] as? String, "low")
+
+    let messages = try XCTUnwrap(body["messages"] as? [[String: Any]])
+    let userMessage = try XCTUnwrap(messages.first { $0["role"] as? String == "user" })
+    let contextJSON = try XCTUnwrap(userMessage["content"] as? String)
+    let requestContext = try jsonDictionary(Data(contextJSON.utf8))
+
+    XCTAssertEqual(requestContext["interviewer_question"] as? String, context.interviewerQuestion)
+    XCTAssertEqual(requestContext["requested_parts"] as? [String], context.requestedParts)
+    XCTAssertEqual(requestContext["accumulated_answer"] as? String, context.accumulatedAnswer)
+    XCTAssertEqual(requestContext["latest_segment"] as? String, context.latestSegment)
+    XCTAssertEqual(
+      requestContext["silence_duration_ms"] as? Int, context.silenceDurationMilliseconds)
+    XCTAssertEqual(requestContext["specialty"] as? String, context.specialty)
+    XCTAssertEqual(requestContext["stage"] as? String, context.stage)
+    XCTAssertEqual(requestContext["explicit_cue"] as? Bool, context.explicitCue)
+
+    let activity = try XCTUnwrap(requestContext["workspace_activity"] as? [[String: Any]])
+    XCTAssertEqual(activity.first?["kind"] as? String, "code_edit")
+    XCTAssertEqual(activity.first?["milliseconds_ago"] as? Int, 320)
+    XCTAssertEqual(activity.first?["summary"] as? String, "Changed the queue initialization.")
+
+    let responseFormat = try XCTUnwrap(body["response_format"] as? [String: Any])
+    let schemaEnvelope = try XCTUnwrap(responseFormat["json_schema"] as? [String: Any])
+    XCTAssertEqual(schemaEnvelope["strict"] as? Bool, true)
+  }
+
+  func testStrictlyDecodesEverySupportedDecision() async throws {
+    let cases: [(String, String, SemanticEndpointProposal)] = [
+      (
+        "likely_continue",
+        "unfinished_thought",
+        .init(decision: .likelyContinue, reasonCode: .unfinishedThought)
+      ),
+      (
+        "likely_end",
+        "answer_resolves_question",
+        .init(decision: .likelyEnd, reasonCode: .answerResolvesQuestion)
+      ),
+      (
+        "ambiguous",
+        "insufficient_evidence",
+        .init(decision: .ambiguous, reasonCode: .insufficientEvidence)
+      ),
+    ]
+
+    for (decision, reason, expected) in cases {
+      let transport = RecordingGroqTransport(
+        statusCode: 200,
+        body: responseBody(decision: decision, reason: reason)
+      )
+      let classifier = GroqEndpointClassifier(apiKey: "test-key", transport: transport)
+      let actual = try await classifier.classify(validContext)
+      XCTAssertEqual(actual, expected)
+    }
+  }
+
+  func testRejectsAdditionalConfidenceField() async throws {
+    let content = """
+      {"decision":"likely_end","reason_code":"answer_resolves_question","confidence":0.99}
+      """
+    let transport = RecordingGroqTransport(
+      statusCode: 200,
+      body: chatResponse(content: content)
+    )
+    let classifier = GroqEndpointClassifier(apiKey: "test-key", transport: transport)
+
+    await assertClassifierError(.invalidClassification) {
+      try await classifier.classify(validContext)
+    }
+  }
+
+  func testRejectsUnknownClassificationValue() async throws {
+    let transport = RecordingGroqTransport(
+      statusCode: 200,
+      body: responseBody(decision: "done", reason: "answer_resolves_question")
+    )
+    let classifier = GroqEndpointClassifier(apiKey: "test-key", transport: transport)
+
+    await assertClassifierError(.invalidClassification) {
+      try await classifier.classify(validContext)
+    }
+  }
+
+  func testRejectsDecisionAndReasonMismatch() async throws {
+    let transport = RecordingGroqTransport(
+      statusCode: 200,
+      body: responseBody(decision: "likely_end", reason: "unfinished_thought")
+    )
+    let classifier = GroqEndpointClassifier(apiKey: "test-key", transport: transport)
+
+    await assertClassifierError(.invalidClassification) {
+      try await classifier.classify(validContext)
+    }
+  }
+
+  func testOversizedExactQuestionFailsBeforeTransport() async throws {
+    let transport = RecordingGroqTransport(
+      statusCode: 200,
+      body: responseBody(decision: "ambiguous", reason: "insufficient_evidence")
+    )
+    let classifier = GroqEndpointClassifier(apiKey: "test-key", transport: transport)
+    let context = SemanticEndpointContext(
+      interviewerQuestion: String(repeating: "q", count: 16 * 1_024 + 1),
+      requestedParts: [],
+      accumulatedAnswer: "An answer.",
+      latestSegment: "An answer.",
+      silenceDurationMilliseconds: 1_000,
+      specialty: "behavioral",
+      stage: "candidate_floor",
+      explicitCue: false,
+      workspaceActivity: []
+    )
+
+    await assertClassifierError(.contextLimitExceeded(.interviewerQuestion)) {
+      try await classifier.classify(context)
+    }
+    let recordedRequest = await transport.recordedRequest()
+    XCTAssertNil(recordedRequest)
+  }
+
+  func testTransportAndProviderErrorsExposeNoPayloadOrCredential() async throws {
+    let failingTransport = RecordingGroqTransport(failure: true)
+    let transportClassifier = GroqEndpointClassifier(
+      apiKey: "must-never-appear",
+      transport: failingTransport
+    )
+
+    await assertClassifierError(.transportFailure) {
+      try await transportClassifier.classify(validContext)
+    }
+
+    let rejectedTransport = RecordingGroqTransport(
+      statusCode: 429,
+      body: Data("provider diagnostic containing request data".utf8)
+    )
+    let rejectedClassifier = GroqEndpointClassifier(
+      apiKey: "must-never-appear",
+      transport: rejectedTransport
+    )
+    await assertClassifierError(.rejected(statusCode: 429)) {
+      try await rejectedClassifier.classify(validContext)
+    }
+  }
+
+  func testDeterministicAdapterUsesTheSameClassifierSeam() async throws {
+    let expected = SemanticEndpointProposal(
+      decision: .ambiguous,
+      reasonCode: .insufficientEvidence
+    )
+    let classifier: any SemanticEndpointClassifying =
+      DeterministicSemanticEndpointClassifier(proposal: expected)
+
+    let proposal = try await classifier.classify(validContext)
+
+    XCTAssertEqual(proposal, expected)
+  }
+
+  private var validContext: SemanticEndpointContext {
+    SemanticEndpointContext(
+      interviewerQuestion: "Explain your approach.",
+      requestedParts: ["State the invariant", "Analyze complexity"],
+      accumulatedAnswer: "The queue stores the current frontier.",
+      latestSegment: "The queue stores the current frontier.",
+      silenceDurationMilliseconds: 1_200,
+      specialty: "coding",
+      stage: "candidate_floor",
+      explicitCue: false,
+      workspaceActivity: []
+    )
+  }
+
+  private func responseBody(decision: String, reason: String) -> Data {
+    chatResponse(content: "{\"decision\":\"\(decision)\",\"reason_code\":\"\(reason)\"}")
+  }
+
+  private func chatResponse(content: String) -> Data {
+    try! JSONSerialization.data(withJSONObject: [
+      "choices": [
+        ["message": ["content": content]]
+      ]
+    ])
+  }
+
+  private func jsonDictionary(_ data: Data) throws -> [String: Any] {
+    try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+  }
+
+  private func assertClassifierError(
+    _ expected: GroqEndpointClassifierError,
+    operation: () async throws -> SemanticEndpointProposal
+  ) async {
+    do {
+      _ = try await operation()
+      XCTFail("Expected \(expected)")
+    } catch let error as GroqEndpointClassifierError {
+      XCTAssertEqual(error, expected)
+    } catch {
+      XCTFail("Unexpected error type: \(type(of: error))")
+    }
+  }
+}
+
+private actor RecordingGroqTransport: GroqEndpointTransport {
+  private let statusCode: Int
+  private let body: Data
+  private let failure: Bool
+  private var request: URLRequest?
+
+  init(statusCode: Int = 200, body: Data = Data(), failure: Bool = false) {
+    self.statusCode = statusCode
+    self.body = body
+    self.failure = failure
+  }
+
+  func send(_ request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+    self.request = request
+    if failure {
+      throw RecordingTransportError.failure
+    }
+    let response = HTTPURLResponse(
+      url: request.url!,
+      statusCode: statusCode,
+      httpVersion: "HTTP/1.1",
+      headerFields: ["Content-Type": "application/json"]
+    )!
+    return (body, response)
+  }
+
+  func recordedRequest() -> URLRequest? {
+    request
+  }
+}
+
+private enum RecordingTransportError: Error {
+  case failure
+}

--- a/Tests/InterviewArcLiveCoreTests/GroqEndpointClassifierTests.swift
+++ b/Tests/InterviewArcLiveCoreTests/GroqEndpointClassifierTests.swift
@@ -48,12 +48,12 @@ final class GroqEndpointClassifierTests: XCTestCase {
     let bodyData = try XCTUnwrap(request.httpBody)
     let bodyString = try XCTUnwrap(String(data: bodyData, encoding: .utf8))
     XCTAssertFalse(bodyString.contains("private-test-key"))
-    XCTAssertFalse(bodyString.lowercased().contains("confidence"))
 
     let body = try jsonDictionary(bodyData)
     XCTAssertEqual(body["model"] as? String, "openai/gpt-oss-20b")
     XCTAssertEqual(body["temperature"] as? Int, 0)
     XCTAssertEqual(body["reasoning_effort"] as? String, "low")
+    XCTAssertEqual(body["max_completion_tokens"] as? Int, 256)
 
     let messages = try XCTUnwrap(body["messages"] as? [[String: Any]])
     let userMessage = try XCTUnwrap(messages.first { $0["role"] as? String == "user" })
@@ -78,6 +78,10 @@ final class GroqEndpointClassifierTests: XCTestCase {
     let responseFormat = try XCTUnwrap(body["response_format"] as? [String: Any])
     let schemaEnvelope = try XCTUnwrap(responseFormat["json_schema"] as? [String: Any])
     XCTAssertEqual(schemaEnvelope["strict"] as? Bool, true)
+    let schema = try XCTUnwrap(schemaEnvelope["schema"] as? [String: Any])
+    let properties = try XCTUnwrap(schema["properties"] as? [String: Any])
+    XCTAssertEqual(Set(properties.keys), ["decision", "reason_code"])
+    XCTAssertNil(properties["confidence"])
   }
 
   func testStrictlyDecodesEverySupportedDecision() async throws {

--- a/Tests/InterviewArcLiveCoreTests/InterviewRoomSessionTests.swift
+++ b/Tests/InterviewArcLiveCoreTests/InterviewRoomSessionTests.swift
@@ -1,0 +1,480 @@
+import Foundation
+import XCTest
+@testable import InterviewArcLiveCore
+
+@MainActor
+final class InterviewRoomSessionTests: XCTestCase {
+    func testPublicInterfacePersistsCandidateThenCanonicalInterviewerPair() async throws {
+        let store = InMemorySessionManifestStore()
+        let runtime = CountingInterviewerRuntime(
+            response: CanonicalInterviewerResponse(
+                displayMarkdown: "Compare **availability** and consistency.",
+                spokenText: "Compare availability and consistency."
+            )
+        )
+        let sessionID = SessionID("session-fixture-1")
+        let session = try await InterviewRoomSession.start(
+            sessionID: sessionID,
+            activityID: "activity-system-design-1",
+            manifestStore: store,
+            interviewerRuntime: runtime
+        )
+
+        let initial = await session.snapshot()
+        XCTAssertEqual(initial.phase, .ready)
+        XCTAssertEqual(initial.revision, 0)
+
+        let floor = try await session.execute(
+            .giveCandidateFloor(commandID: CommandID("open-floor-1"))
+        )
+        XCTAssertEqual(floor.phase, .candidateFloor)
+        XCTAssertEqual(floor.revision, 1)
+
+        let verbatim = "I would partition by tenant and keep a durable event log."
+        let result = try await session.execute(
+            .handOff(
+                commandID: CommandID("handoff-1"),
+                transcript: CandidateTranscript(
+                    body: verbatim,
+                    quality: .bestAvailable
+                )
+            )
+        )
+
+        XCTAssertEqual(result.phase, .interviewerTurn)
+        XCTAssertEqual(result.revision, 3)
+        XCTAssertEqual(result.turns.count, 2)
+
+        guard case .candidate(let candidate) = result.turns[0],
+              case .interviewer(let interviewer) = result.turns[1] else {
+            return XCTFail("Expected candidate then interviewer ordering")
+        }
+        XCTAssertEqual(candidate.transcript.body, verbatim)
+        XCTAssertEqual(candidate.transcript.quality, .bestAvailable)
+        XCTAssertEqual(interviewer.replyToTurnID, candidate.id)
+        XCTAssertEqual(interviewer.commandID, candidate.commandID)
+        XCTAssertEqual(interviewer.displayMarkdown, "Compare **availability** and consistency.")
+        XCTAssertEqual(interviewer.spokenText, "Compare availability and consistency.")
+        let invocationCount = await runtime.invocationCount()
+        XCTAssertEqual(invocationCount, 1)
+
+        let restored = try await InterviewRoomSession.restore(
+            sessionID: sessionID,
+            manifestStore: store,
+            interviewerRuntime: runtime
+        )
+        let restoredSnapshot = await restored.snapshot()
+        XCTAssertEqual(restoredSnapshot, result)
+
+        let loadedManifest = try await store.load(sessionID: sessionID)
+        let durableManifest = try XCTUnwrap(loadedManifest)
+        XCTAssertTrue(
+            durableManifest.appliedCommands.allSatisfy {
+                $0.payloadFingerprint.hasPrefix("sha256:v1:")
+                    && !$0.payloadFingerprint.contains(verbatim)
+            }
+        )
+    }
+
+    func testDuplicateCommandIDIsIdempotentAndChangedPayloadIsRejected() async throws {
+        let store = InMemorySessionManifestStore()
+        let runtime = CountingInterviewerRuntime(
+            response: CanonicalInterviewerResponse(
+                displayMarkdown: "What fails next?",
+                spokenText: "What fails next?"
+            )
+        )
+        let session = try await makeCandidateFloorSession(store: store, runtime: runtime)
+        let handoffID = CommandID("handoff-stable")
+        let command = InterviewRoomCommand.handOff(
+            commandID: handoffID,
+            transcript: CandidateTranscript(body: "Use a write-ahead log.", quality: .verified)
+        )
+
+        let first = try await session.execute(command)
+        let duplicate = try await session.execute(command)
+
+        XCTAssertEqual(duplicate, first)
+        XCTAssertEqual(duplicate.revision, 3)
+        XCTAssertEqual(duplicate.turns.count, 2)
+        let duplicateInvocationCount = await runtime.invocationCount()
+        XCTAssertEqual(duplicateInvocationCount, 1)
+
+        do {
+            _ = try await session.execute(
+                .handOff(
+                    commandID: handoffID,
+                    transcript: CandidateTranscript(body: "A changed answer.", quality: .verified)
+                )
+            )
+            XCTFail("Expected changed payload under a used command ID to fail")
+        } catch {
+            XCTAssertEqual(error as? InterviewRoomSessionError, .commandIDReused(handoffID))
+        }
+
+        let unchanged = await session.snapshot()
+        let finalInvocationCount = await runtime.invocationCount()
+        XCTAssertEqual(unchanged, first)
+        XCTAssertEqual(finalInvocationCount, 1)
+    }
+
+    func testTurnIDCanonicalTupleEncodingPreventsDelimiterCollision() async throws {
+        // These tuples produced the same ID under the former `session:command:role` format.
+        let firstID = try await completedCandidateTurnID(
+            sessionID: SessionID("room:a"),
+            handoffID: CommandID("b")
+        )
+        let secondID = try await completedCandidateTurnID(
+            sessionID: SessionID("room"),
+            handoffID: CommandID("a:b")
+        )
+
+        XCTAssertNotEqual(firstID, secondID)
+        XCTAssertTrue(firstID.rawValue.hasPrefix("turn:sha256:v1:"))
+        XCTAssertTrue(secondID.rawValue.hasPrefix("turn:sha256:v1:"))
+    }
+
+    func testTranscriptQualityUsesApprovedPersistedVocabulary() throws {
+        XCTAssertEqual(TranscriptQuality.verified.rawValue, "verified")
+        XCTAssertEqual(TranscriptQuality.bestAvailable.rawValue, "best_available")
+        XCTAssertEqual(
+            TranscriptQuality.possibleContamination.rawValue,
+            "possible_contamination"
+        )
+
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+        let encoded = try encoder.encode(TranscriptQuality.bestAvailable)
+        XCTAssertEqual(String(data: encoded, encoding: .utf8), "\"best_available\"")
+        XCTAssertEqual(try decoder.decode(TranscriptQuality.self, from: encoded), .bestAvailable)
+    }
+
+    func testInvalidTransitionAndEmptyTranscriptLeaveDurableStateUnchanged() async throws {
+        let store = InMemorySessionManifestStore()
+        let runtime = DeterministicInterviewerRuntime(
+            response: CanonicalInterviewerResponse(
+                displayMarkdown: "Continue.",
+                spokenText: "Continue."
+            )
+        )
+        let sessionID = SessionID("session-invalid-transition")
+        let session = try await InterviewRoomSession.start(
+            sessionID: sessionID,
+            activityID: "activity-fixture",
+            manifestStore: store,
+            interviewerRuntime: runtime
+        )
+
+        do {
+            _ = try await session.execute(
+                .handOff(
+                    commandID: CommandID("too-early"),
+                    transcript: CandidateTranscript(body: "Answer", quality: .verified)
+                )
+            )
+            XCTFail("Expected Hand off outside the Candidate Floor to fail")
+        } catch {
+            XCTAssertEqual(
+                error as? InterviewRoomSessionError,
+                .invalidTransition(command: "handOff", phase: .ready)
+            )
+        }
+        let afterInvalidTransition = await session.snapshot()
+        let durableAfterInvalidTransition = try await store.load(sessionID: sessionID)
+        XCTAssertEqual(afterInvalidTransition.revision, 0)
+        XCTAssertEqual(durableAfterInvalidTransition?.revision, 0)
+
+        _ = try await session.execute(
+            .giveCandidateFloor(commandID: CommandID("valid-floor"))
+        )
+        do {
+            _ = try await session.execute(
+                .handOff(
+                    commandID: CommandID("empty-answer"),
+                    transcript: CandidateTranscript(body: "  \n", quality: .possibleContamination)
+                )
+            )
+            XCTFail("Expected an empty transcript to fail")
+        } catch {
+            XCTAssertEqual(error as? InterviewRoomSessionError, .emptyCandidateTranscript)
+        }
+
+        let unchanged = await session.snapshot()
+        XCTAssertEqual(unchanged.phase, .candidateFloor)
+        XCTAssertEqual(unchanged.revision, 1)
+        XCTAssertTrue(unchanged.turns.isEmpty)
+        let durableAfterEmptyTranscript = try await store.load(sessionID: sessionID)
+        XCTAssertEqual(durableAfterEmptyTranscript?.revision, 1)
+    }
+
+    func testProviderFailurePersistsCandidateAndRetryAuthorizationBeforeEachAttempt() async throws {
+        let store = InMemorySessionManifestStore()
+        let sessionID = SessionID("session-provider-failure")
+        let failingRuntime = CountingFailingInterviewerRuntime()
+        let session = try await InterviewRoomSession.start(
+            sessionID: sessionID,
+            activityID: "activity-provider-failure",
+            manifestStore: store,
+            interviewerRuntime: failingRuntime
+        )
+        _ = try await session.execute(
+            .giveCandidateFloor(commandID: CommandID("floor-before-failure"))
+        )
+
+        do {
+            _ = try await session.execute(
+                .handOff(
+                    commandID: CommandID("provider-fails"),
+                    transcript: CandidateTranscript(
+                        body: "Keep this logical answer intact.",
+                        quality: .verified
+                    )
+                )
+            )
+            XCTFail("Expected provider failure")
+        } catch {
+            XCTAssertEqual(error as? RuntimeFixtureError, .unavailable)
+        }
+
+        let pending = await session.snapshot()
+        XCTAssertEqual(pending.phase, .interviewerProcessing)
+        XCTAssertEqual(pending.revision, 2)
+        XCTAssertEqual(pending.turns.count, 1)
+        guard case .candidate(let preservedCandidate) = pending.turns[0] else {
+            return XCTFail("Expected the Candidate Turn to survive provider failure")
+        }
+
+        let loaded = try await store.load(sessionID: sessionID)
+        let durable = try XCTUnwrap(loaded)
+        XCTAssertEqual(durable.revision, 2)
+        XCTAssertEqual(durable.turns, pending.turns)
+
+        let duplicate = try await session.execute(
+            .handOff(
+                commandID: CommandID("provider-fails"),
+                transcript: CandidateTranscript(
+                    body: "Keep this logical answer intact.",
+                    quality: .verified
+                )
+            )
+        )
+        XCTAssertEqual(duplicate, pending)
+        let failureCalls = await failingRuntime.invocationCount()
+        XCTAssertEqual(failureCalls, 1, "duplicate Hand off must not silently call the provider")
+
+        let recoveredResponse = CanonicalInterviewerResponse(
+            displayMarkdown: "Recovered **once**.",
+            spokenText: "Recovered once."
+        )
+        let retryRuntime = SequencedInterviewerRuntime(
+            results: [
+                .failure(.unavailable),
+                .success(recoveredResponse),
+            ]
+        )
+        let restored = try await InterviewRoomSession.restore(
+            sessionID: sessionID,
+            manifestStore: store,
+            interviewerRuntime: retryRuntime
+        )
+
+        let firstRetry = InterviewRoomCommand.retryInterviewerResponse(
+            commandID: CommandID("retry-response-1")
+        )
+        do {
+            _ = try await restored.execute(firstRetry)
+            XCTFail("Expected the first explicit retry to fail")
+        } catch {
+            XCTAssertEqual(error as? RuntimeFixtureError, .unavailable)
+        }
+
+        let retryPending = await restored.snapshot()
+        XCTAssertEqual(retryPending.phase, .interviewerProcessing)
+        XCTAssertEqual(retryPending.revision, 3)
+        XCTAssertEqual(retryPending.turns, pending.turns)
+        let durableRetryPending = try await store.load(sessionID: sessionID)
+        XCTAssertEqual(durableRetryPending?.revision, 3)
+
+        let duplicateRetry = try await restored.execute(firstRetry)
+        XCTAssertEqual(duplicateRetry, retryPending)
+        let callsAfterDuplicate = await retryRuntime.invocationCount()
+        XCTAssertEqual(
+            callsAfterDuplicate,
+            1,
+            "the same durable retry ID must not invoke the provider twice"
+        )
+
+        let recovered = try await restored.execute(
+            .retryInterviewerResponse(commandID: CommandID("retry-response-2"))
+        )
+        XCTAssertEqual(recovered.revision, 5)
+        XCTAssertEqual(recovered.turns.count, 2)
+        guard case .candidate(let recoveredCandidate) = recovered.turns[0],
+              case .interviewer(let recoveredInterviewer) = recovered.turns[1] else {
+            return XCTFail("Expected one recovered Candidate/Interviewer pair")
+        }
+        XCTAssertEqual(recoveredCandidate, preservedCandidate)
+        XCTAssertEqual(recoveredInterviewer.replyToTurnID, preservedCandidate.id)
+        XCTAssertEqual(recoveredInterviewer.response, recoveredResponse)
+        let totalRetryCalls = await retryRuntime.invocationCount()
+        XCTAssertEqual(totalRetryCalls, 2)
+    }
+
+    func testPersistenceFailureDoesNotPublishAcceptedTransition() async throws {
+        let backingStore = InMemorySessionManifestStore()
+        let store = FailAfterCreationStore(backing: backingStore)
+        let runtime = DeterministicInterviewerRuntime(
+            response: CanonicalInterviewerResponse(
+                displayMarkdown: "Unused.",
+                spokenText: "Unused."
+            )
+        )
+        let sessionID = SessionID("session-save-failure")
+        let session = try await InterviewRoomSession.start(
+            sessionID: sessionID,
+            activityID: "activity-save-failure",
+            manifestStore: store,
+            interviewerRuntime: runtime
+        )
+
+        do {
+            _ = try await session.execute(
+                .giveCandidateFloor(commandID: CommandID("save-fails"))
+            )
+            XCTFail("Expected persistence failure")
+        } catch {
+            XCTAssertEqual(error as? StoreFixtureError, .writeFailed)
+        }
+
+        let afterFailure = await session.snapshot()
+        let durableAfterFailure = try await backingStore.load(sessionID: sessionID)
+        XCTAssertEqual(afterFailure.revision, 0)
+        XCTAssertEqual(durableAfterFailure?.revision, 0)
+    }
+
+    private func makeCandidateFloorSession(
+        store: InMemorySessionManifestStore,
+        runtime: CountingInterviewerRuntime
+    ) async throws -> InterviewRoomSession {
+        let session = try await InterviewRoomSession.start(
+            sessionID: SessionID("session-idempotency"),
+            activityID: "activity-idempotency",
+            manifestStore: store,
+            interviewerRuntime: runtime
+        )
+        _ = try await session.execute(
+            .giveCandidateFloor(commandID: CommandID("open-idempotency-floor"))
+        )
+        return session
+    }
+
+    private func completedCandidateTurnID(
+        sessionID: SessionID,
+        handoffID: CommandID
+    ) async throws -> TurnID {
+        let store = InMemorySessionManifestStore()
+        let runtime = DeterministicInterviewerRuntime(
+            response: CanonicalInterviewerResponse(
+                displayMarkdown: "Fixture response.",
+                spokenText: "Fixture response."
+            )
+        )
+        let session = try await InterviewRoomSession.start(
+            sessionID: sessionID,
+            activityID: "activity-turn-id-fixture",
+            manifestStore: store,
+            interviewerRuntime: runtime
+        )
+        _ = try await session.execute(
+            .giveCandidateFloor(commandID: CommandID("floor-\(sessionID.rawValue)"))
+        )
+        let snapshot = try await session.execute(
+            .handOff(
+                commandID: handoffID,
+                transcript: CandidateTranscript(body: "Fixture answer.", quality: .verified)
+            )
+        )
+        guard let firstTurn = snapshot.turns.first,
+              case .candidate(let candidate) = firstTurn else {
+            throw TurnIDFixtureError.missingCandidate
+        }
+        return candidate.id
+    }
+}
+
+private enum TurnIDFixtureError: Error {
+    case missingCandidate
+}
+
+private actor CountingInterviewerRuntime: InterviewerRuntime {
+    private let responseValue: CanonicalInterviewerResponse
+    private var calls = 0
+
+    init(response: CanonicalInterviewerResponse) {
+        responseValue = response
+    }
+
+    func respond(to request: InterviewerRequest) -> CanonicalInterviewerResponse {
+        calls += 1
+        return responseValue
+    }
+
+    func invocationCount() -> Int { calls }
+}
+
+private enum RuntimeFixtureError: Error, Equatable, Sendable {
+    case unavailable
+}
+
+private actor CountingFailingInterviewerRuntime: InterviewerRuntime {
+    private var calls = 0
+
+    func respond(to request: InterviewerRequest) async throws -> CanonicalInterviewerResponse {
+        calls += 1
+        throw RuntimeFixtureError.unavailable
+    }
+
+    func invocationCount() -> Int { calls }
+}
+
+private actor SequencedInterviewerRuntime: InterviewerRuntime {
+    private var results: [Result<CanonicalInterviewerResponse, RuntimeFixtureError>]
+    private var calls = 0
+
+    init(results: [Result<CanonicalInterviewerResponse, RuntimeFixtureError>]) {
+        self.results = results
+    }
+
+    func respond(to request: InterviewerRequest) throws -> CanonicalInterviewerResponse {
+        calls += 1
+        guard !results.isEmpty else {
+            throw RuntimeFixtureError.unavailable
+        }
+        return try results.removeFirst().get()
+    }
+
+    func invocationCount() -> Int { calls }
+}
+
+private enum StoreFixtureError: Error, Equatable {
+    case writeFailed
+}
+
+private actor FailAfterCreationStore: SessionManifestStore {
+    private let backing: InMemorySessionManifestStore
+
+    init(backing: InMemorySessionManifestStore) {
+        self.backing = backing
+    }
+
+    func load(sessionID: SessionID) async throws -> SessionManifest? {
+        try await backing.load(sessionID: sessionID)
+    }
+
+    func save(_ manifest: SessionManifest, expectedRevision: Int?) async throws {
+        if expectedRevision != nil {
+            throw StoreFixtureError.writeFailed
+        }
+        try await backing.save(manifest, expectedRevision: expectedRevision)
+    }
+}

--- a/Tests/InterviewArcLiveCoreTests/SessionManifestStoreTests.swift
+++ b/Tests/InterviewArcLiveCoreTests/SessionManifestStoreTests.swift
@@ -238,7 +238,7 @@ final class SessionManifestStoreTests: XCTestCase {
             turns = []
         }
 
-        SessionManifest(
+        return SessionManifest(
             sessionID: sessionID,
             activityID: "public-test-activity",
             phase: phase,

--- a/Tests/InterviewArcLiveCoreTests/SessionManifestStoreTests.swift
+++ b/Tests/InterviewArcLiveCoreTests/SessionManifestStoreTests.swift
@@ -1,0 +1,266 @@
+import Foundation
+import XCTest
+
+@testable import InterviewArcLiveCore
+
+@MainActor
+final class SessionManifestStoreTests: XCTestCase {
+    func testInMemoryAdapterComparesExpectedRevisionAndRestoresLatestManifest() async throws {
+        let sessionID = SessionID("public-test-session")
+        let store = InMemorySessionManifestStore()
+        let initial = manifest(sessionID: sessionID, revision: 0)
+        let next = manifest(sessionID: sessionID, revision: 1, phase: .candidateFloor)
+
+        try await store.save(initial, expectedRevision: nil)
+        try await store.save(next, expectedRevision: 0)
+
+        let restored = try await store.load(sessionID: sessionID)
+        XCTAssertEqual(restored, next)
+
+        do {
+            try await store.save(
+                manifest(sessionID: sessionID, revision: 2, phase: .completed),
+                expectedRevision: 0
+            )
+            XCTFail("Expected a stale revision to be rejected")
+        } catch let error as SessionManifestStoreError {
+            XCTAssertEqual(
+                error,
+                .revisionConflict(expected: 0, actual: 1)
+            )
+        }
+
+        let retained = try await store.load(sessionID: sessionID)
+        XCTAssertEqual(retained, next)
+    }
+
+    func testFileAdapterAtomicallySavesAndRestoresLatestCompleteManifest() async throws {
+        let directory = makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let sessionID = SessionID("public-file-round-trip")
+        let store = FileSessionManifestStore(directoryURL: directory)
+        let initial = manifest(sessionID: sessionID, revision: 0)
+        let next = manifest(sessionID: sessionID, revision: 1, phase: .candidateFloor)
+
+        try await store.save(initial, expectedRevision: nil)
+        try await store.save(next, expectedRevision: 0)
+
+        let relaunchedStore = FileSessionManifestStore(directoryURL: directory)
+        let restored = try await relaunchedStore.load(sessionID: sessionID)
+        XCTAssertEqual(restored, next)
+    }
+
+    func testFileAdapterRejectsStaleWriterWithoutChangingReadableManifest() async throws {
+        let directory = makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let sessionID = SessionID("public-stale-writer")
+        let store = FileSessionManifestStore(directoryURL: directory)
+        let initial = manifest(sessionID: sessionID, revision: 0)
+        let durable = manifest(sessionID: sessionID, revision: 1, phase: .candidateFloor)
+
+        try await store.save(initial, expectedRevision: nil)
+        try await store.save(durable, expectedRevision: 0)
+
+        do {
+            try await store.save(
+                manifest(sessionID: sessionID, revision: 2, phase: .completed),
+                expectedRevision: 0
+            )
+            XCTFail("Expected a stale writer conflict")
+        } catch let error as SessionManifestStoreError {
+            XCTAssertEqual(
+                error,
+                .revisionConflict(expected: 0, actual: 1)
+            )
+        }
+
+        let retained = try await store.load(sessionID: sessionID)
+        XCTAssertEqual(retained, durable)
+    }
+
+    func testReplacementFailurePreservesPriorCompleteManifest() async throws {
+        let directory = makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let sessionID = SessionID("public-failed-replacement")
+        let initial = manifest(sessionID: sessionID, revision: 0)
+        let durableStore = FileSessionManifestStore(directoryURL: directory)
+        try await durableStore.save(initial, expectedRevision: nil)
+
+        let failingStore = FileSessionManifestStore(
+            directoryURL: directory,
+            replace: { _, _ in throw ReplacementFixtureError.expectedFailure }
+        )
+
+        do {
+            try await failingStore.save(
+                manifest(sessionID: sessionID, revision: 1, phase: .completed),
+                expectedRevision: 0
+            )
+            XCTFail("Expected replacement to fail")
+        } catch ReplacementFixtureError.expectedFailure {
+            // Expected: the prepared file never replaced the durable manifest.
+        }
+
+        let relaunchedStore = FileSessionManifestStore(directoryURL: directory)
+        let restored = try await relaunchedStore.load(sessionID: sessionID)
+        XCTAssertEqual(restored, initial)
+    }
+
+    func testDistinctFileAdaptersSerializeRevisionCheckAndReplacement() async throws {
+        let directory = makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let sessionID = SessionID("public-concurrent-writers")
+        let initial = manifest(sessionID: sessionID, revision: 0)
+        let firstCandidate = manifest(
+            sessionID: sessionID,
+            revision: 1,
+            phase: .interviewerProcessing,
+            candidateBody: "Candidate A"
+        )
+        let secondCandidate = manifest(
+            sessionID: sessionID,
+            revision: 1,
+            phase: .interviewerProcessing,
+            candidateBody: "Candidate B"
+        )
+        let firstStore = FileSessionManifestStore(directoryURL: directory)
+        let secondStore = FileSessionManifestStore(directoryURL: directory)
+        try await firstStore.save(initial, expectedRevision: nil)
+
+        let outcomes = await withTaskGroup(
+            of: ConcurrentSaveOutcome.self,
+            returning: [ConcurrentSaveOutcome].self
+        ) { group in
+            group.addTask {
+                do {
+                    try await firstStore.save(firstCandidate, expectedRevision: 0)
+                    return .saved
+                } catch let error as SessionManifestStoreError {
+                    if error == .revisionConflict(expected: 0, actual: 1) {
+                        return .conflict
+                    }
+                    return .unexpected
+                } catch {
+                    return .unexpected
+                }
+            }
+            group.addTask {
+                do {
+                    try await secondStore.save(secondCandidate, expectedRevision: 0)
+                    return .saved
+                } catch let error as SessionManifestStoreError {
+                    if error == .revisionConflict(expected: 0, actual: 1) {
+                        return .conflict
+                    }
+                    return .unexpected
+                } catch {
+                    return .unexpected
+                }
+            }
+
+            var collected: [ConcurrentSaveOutcome] = []
+            for await outcome in group {
+                collected.append(outcome)
+            }
+            return collected
+        }
+
+        XCTAssertEqual(outcomes.filter { $0 == .saved }.count, 1)
+        XCTAssertEqual(outcomes.filter { $0 == .conflict }.count, 1)
+        XCTAssertFalse(outcomes.contains(.unexpected))
+
+        let loaded = try await firstStore.load(sessionID: sessionID)
+        let durable = try XCTUnwrap(loaded)
+        XCTAssertEqual(durable.revision, 1)
+        XCTAssertEqual(durable.turns.count, 1)
+        guard case .candidate(let candidate) = durable.turns[0] else {
+            return XCTFail("Expected exactly one winning Candidate Turn")
+        }
+        XCTAssertTrue(["Candidate A", "Candidate B"].contains(candidate.transcript.body))
+
+        let lockFile = try XCTUnwrap(
+            FileManager.default.contentsOfDirectory(
+                at: directory,
+                includingPropertiesForKeys: nil
+            ).first { $0.pathExtension == "lock" }
+        )
+        let attributes = try FileManager.default.attributesOfItem(atPath: lockFile.path)
+        let permissions = try XCTUnwrap(attributes[.posixPermissions] as? NSNumber)
+        XCTAssertEqual(permissions.intValue, 0o600)
+    }
+
+    func testReplacementMustAdvanceRevision() async throws {
+        let store = InMemorySessionManifestStore()
+        let sessionID = SessionID("public-monotonic-revision")
+        let initial = manifest(sessionID: sessionID, revision: 0)
+        try await store.save(initial, expectedRevision: nil)
+
+        do {
+            try await store.save(initial, expectedRevision: 0)
+            XCTFail("Expected a non-monotonic replacement to fail")
+        } catch let error as SessionManifestStoreError {
+            XCTAssertEqual(
+                error,
+                .nonMonotonicRevision(previous: 0, proposed: 0)
+            )
+        }
+
+        let retained = try await store.load(sessionID: sessionID)
+        XCTAssertEqual(retained, initial)
+    }
+
+    private func manifest(
+        sessionID: SessionID,
+        revision: Int,
+        phase: InterviewRoomPhase = .ready,
+        candidateBody: String? = nil
+    ) -> SessionManifest {
+        let turns: [InterviewTurn]
+        if let candidateBody {
+            let commandID = CommandID("public-concurrent-candidate")
+            turns = [
+                .candidate(
+                    CandidateTurn(
+                        id: TurnID("public-concurrent-candidate-turn"),
+                        commandID: commandID,
+                        transcript: CandidateTranscript(
+                            body: candidateBody,
+                            quality: .verified
+                        )
+                    )
+                ),
+            ]
+        } else {
+            turns = []
+        }
+
+        SessionManifest(
+            sessionID: sessionID,
+            activityID: "public-test-activity",
+            phase: phase,
+            turnMode: .manual,
+            turns: turns,
+            revision: revision,
+            appliedCommands: []
+        )
+    }
+
+    private func makeTemporaryDirectory() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("InterviewArcLiveTests-\(UUID().uuidString)", isDirectory: true)
+    }
+}
+
+private enum ReplacementFixtureError: Error {
+    case expectedFailure
+}
+
+private enum ConcurrentSaveOutcome: Sendable, Equatable {
+    case saved
+    case conflict
+    case unexpected
+}

--- a/docs/adr/0001-separate-live-application.md
+++ b/docs/adr/0001-separate-live-application.md
@@ -1,0 +1,24 @@
+# ADR 0001: Keep Live a separate application
+
+Status: Accepted
+
+## Context
+
+Live is an experimental spoken-interviewer product. Interview Arc Voice is an
+established system-wide dictation and terminal companion with sensitive capture
+and delivery state.
+
+## Decision
+
+Live is a separate public repository, process, Dock application, bundle
+identity, Keychain service, Application Support root, preferences domain,
+hotkey namespace, and microphone owner. It integrates directly with versioned
+Interview Arc hosted state. It may consume explicitly exported VoiceCore
+functionality at an exact revision, but it never reads Voice queues or depends
+on Voice running.
+
+## Consequences
+
+Live can evolve without destabilizing Voice. Shared code requires an explicit
+package seam and compatibility tests. Handoff between clients requires durable
+turn completion and exclusive writer/microphone ownership.

--- a/docs/adr/0002-deep-interview-room-session.md
+++ b/docs/adr/0002-deep-interview-room-session.md
@@ -1,0 +1,28 @@
+# ADR 0002: Center the implementation on a deep Interview Room Session Module
+
+Status: Accepted
+
+## Context
+
+The product combines phase transitions, stable identities, idempotency,
+persistence ordering, recovery, provider work, and two Presentations. Spreading
+those rules across view models and provider callbacks would reduce locality and
+repeat the orchestration problems already observed in sibling codebases.
+
+## Decision
+
+`InterviewRoomSession` is a deep Module. Its small Interface accepts domain
+commands and returns immutable snapshots. Its Implementation owns transition
+validation, stable Turn identity, command idempotency, manifest revisioning,
+persistence order, and recovery.
+
+Persistence and semantic endpointing are Seams because production and
+deterministic-test Adapters are both real. Do not create other provider Seams
+until a second Adapter exists. The Module Interface is the behavior-test
+surface; callers do not mutate stored state directly.
+
+## Consequences
+
+The Interface carries strong ordering and error contracts, but callers gain
+high leverage. State-machine bugs retain locality. SwiftUI Presentations and
+future provider Adapters cannot bypass durable transition rules.

--- a/docs/adr/0003-groq-first-semantic-endpointing.md
+++ b/docs/adr/0003-groq-first-semantic-endpointing.md
@@ -1,0 +1,30 @@
+# ADR 0003: Use Groq GPT-OSS for the first semantic endpoint implementation
+
+Status: Accepted
+
+## Context
+
+Patient interviews require question-aware endpointing. An audio-only detector
+cannot know whether a grammatically complete answer omitted another requested
+part. OpenAI Realtime adds metered duplicate audio processing, and SmartTurn
+does not receive the interviewer question or Work Surface context.
+
+## Decision
+
+The first endpoint pipeline is acoustic VAD, Groq Whisper, then Groq
+`openai/gpt-oss-20b` for semantic classification. The classifier receives the
+exact question and requested parts, accumulated Candidate Turn, latest Segment,
+silence duration, specialty/stage, explicit cue, and recent Work Surface
+activity. Its strict result is `likely_continue`, `likely_end`, or `ambiguous`
+with a reason code; generated confidence is not treated as calibrated.
+
+SmartTurn and OpenAI Realtime are excluded from the first implementation.
+`Hand off` remains available, resumed speech cancels an Endpoint Proposal, and
+Patient Auto begins as an experimental/shadow-tested mode.
+
+## Consequences
+
+The classifier understands multipart questions and Activity context but cannot
+hear prosody independently of transcription. VAD, grace timing, explicit cues,
+and Work Surface signals remain application policy. The Groq Adapter stays
+replaceable and credentials remain outside source.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,13 @@
+# Domain documentation
+
+Interview Arc Live uses a single domain context.
+
+Before exploring or changing code, read:
+
+1. root `CONTEXT.md` for canonical product language;
+2. ADRs under `docs/adr/` that touch the work;
+3. issue #1 and the current implementation issue for approved scope.
+
+Use `CONTEXT.md` terms in issues, source names, tests, and explanations. Add a
+term only when the product has resolved a distinct concept. If a proposal
+contradicts an ADR, name the conflict rather than silently overriding it.

--- a/docs/agents/issue-lifecycle.md
+++ b/docs/agents/issue-lifecycle.md
@@ -1,0 +1,61 @@
+# Interview Arc Live Issue Lifecycle
+
+This contract governs Live issues, implementation, verification, release, and
+closure. Cross-repository changes also follow the owning sibling repository's
+lifecycle and use separate, cross-linked issues and PRs.
+
+## Intake and routing
+
+Live owns its native macOS room, recording, local transcript/session recovery,
+agent/TTS Adapters, compact presentation, specialty work surfaces, signing, and
+installation. Interview Arc owns hosted APIs, D1/R2, website, and publication.
+Interview Arc Voice owns the system-wide dictation application and reusable
+audio code it exports.
+
+Before implementation:
+
+1. inspect current `main` and search open/closed issues;
+2. reproduce bugs safely when applicable;
+3. update an existing issue or create an implementation-ready issue;
+4. record dependencies and paired repository work;
+5. choose Fast, Standard, or Reliability verification.
+
+Reliability is mandatory for recording, transcription, endpointing,
+persistence, synchronization, privacy, credentials, crash recovery, signing,
+or any behavior that could silently lose or corrupt interview work.
+
+## Implementation and PR
+
+- Work on a feature branch and preserve unrelated changes.
+- Link the PR using `Refs #<issue>`; do not auto-close on merge.
+- Keep each vertical slice independently testable and exclude unapproved scope.
+- Update domain terms and ADRs when decisions change.
+- Test through Module Interfaces. Use deterministic, public-safe fixtures.
+- Record changed behavior, verification, risks, rollback, and known limits.
+
+## Verification and release
+
+- Run focused tests locally and require clean hosted CI.
+- A SwiftUI preview or source build is not release evidence.
+- Before distribution, package the exact merged-main tree, sign it with the
+  approved local identity, run a staged smoke, install those exact bytes, and
+  verify the installed application for the selected lane.
+- Do not merge, install, notarize, deploy, or close without the authorization
+  and verification required by the current user request.
+
+## Execution ledger
+
+Implementation PRs and coordinator handoffs keep a chronological ledger of the
+meaningful work actually performed. Record exact Pacific timestamps when
+instrumented, repeated hosted runs and their reason, external waits, artifacts,
+retention, and provider-exposed metered usage. Use `unknown` rather than
+inventing missing request time, duration, or cost. Omit actions that did not
+happen. The ledger is administrative and never enters a practice transcript.
+
+## Resolution
+
+After authorized merge/release verification, comment with the PR, merge
+commit, released artifact, completed date, root cause or design intent, change,
+verification, known limitations, and documentation. Close only after the
+selected lane's required verification. Reopen the same issue for recurrence of
+the same behavior.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,19 @@
+# Issue tracker: GitHub
+
+Issues and PRDs live in the public `Vinosaamaa/interview-arc-live` GitHub
+repository. Use the `gh` CLI from this checkout so repository identity comes
+from the configured remote.
+
+## Conventions
+
+- Search open and closed issues before creating work.
+- Keep issue #1 as the product epic; use linked issues for independently
+  verifiable vertical slices.
+- Include problem, approved behavior, acceptance criteria, test matrix,
+  dependencies, non-goals, and release constraints.
+- Link implementation PRs with `Refs #<number>` rather than an automatic
+  closing keyword.
+- Apply the mapped `ready-for-agent` label only when an issue can be completed
+  from durable repository/GitHub context without private conversation history.
+- Do not publish personal paths, credentials, transcripts, recordings, private
+  identifiers, or unsanitized logs in issues or comments.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,11 @@
+# Triage labels
+
+| Skill role | GitHub label | Meaning |
+| --- | --- | --- |
+| `needs-triage` | `needs-triage` | Maintainer evaluation required |
+| `needs-info` | `needs-info` | Waiting for reporter information |
+| `ready-for-agent` | `ready-for-agent` | Fully specified and agent-ready |
+| `ready-for-human` | `ready-for-human` | Human implementation or judgment required |
+| `wontfix` | `wontfix` | Will not be actioned |
+
+Use these exact labels; do not create synonyms.


### PR DESCRIPTION
## **User description**
Refs #3

## Summary
- establish the Live-owned lifecycle, domain context, and architecture decision records
- add a deep `InterviewRoomSession` command/snapshot module with durable idempotency and crash recovery
- add atomic, cross-process-locked session-manifest adapters
- add a strict Groq GPT-OSS semantic-endpoint adapter with deterministic contract coverage
- add a Turnline Studio system-design tracer UI and macOS Swift CI

## Verification
- aggregate source and test parse: passed
- core module semantic typecheck with warnings as errors: passed
- executable semantic typecheck with warnings as errors: passed
- concurrent two-adapter file-lock smoke: passed (one writer, one revision conflict)
- focused session failure/retry/idempotency smoke: passed
- public-safety and whitespace scans: passed
- local `swift test`: blocked before manifest compilation by the host CommandLineTools compiler/SDK PackageDescription mismatch; hosted macOS CI is authoritative

## Reliability review
A focused independent review found and verified fixes for durable retry receipts, cross-process compare-and-swap locking, processing-state UI recovery, collision-safe turn IDs, transcript-quality vocabulary, and Groq decision/reason consistency. No critical or high blockers remain.

## Risks and rollback
- This remains a fixture-backed tracer: microphone, Whisper, Codex, TTS, and Interview Arc hosted-state integration are intentionally not claimed.
- Rollback is the single squash merge; local manifests are isolated under the Live Application Support root.

## Execution ledger
- 2026-08-09 PDT — repository/domain setup, architecture review, core/store/Groq/UI implementation, focused reliability fixes, and aggregate compiler gate; active engineering time: unknown.
- External wait: hosted CI pending. Provider metered usage: none.


___

## **CodeAnt-AI Description**
Establish a recoverable macOS system-design interview room with durable local sessions

### What Changed
- Adds a native macOS room for “Design a global notification system,” with a transcript, system-design board, session status, and handoff controls
- Candidate answers and interviewer responses are saved locally, restored after relaunch, and shown with clear retry states when interviewer processing fails
- Repeated handoffs do not duplicate turns, and failed interviewer responses can be retried without losing the candidate’s answer
- Local session updates reject stale writers and preserve the last complete session during write failures
- Adds a strict Groq semantic endpoint classifier that considers the question, answer, silence, and workspace activity without accepting unsupported response fields
- Documents the standalone macOS package, its local fixture-backed scope, and supported Swift/macOS requirements

### Impact
`✅ Recoverable interview sessions`
`✅ No lost candidate answers after interviewer failures`
`✅ Duplicate handoffs avoided`
`✅ Safe concurrent local session updates`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
