### PR TITLE
Capture and recover segmented candidate speech

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,11 +11,34 @@ permissions:
 jobs:
   test:
     runs-on: macos-15
-    timeout-minutes: 15
+    timeout-minutes: 45
     steps:
       - name: Check out source
         uses: actions/checkout@v4
       - name: Report Swift toolchain
         run: swift --version
+      - name: Resolve dependency graph
+        run: swift package resolve
+      - name: Export generated dependency lockfile
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: Package-resolved-${{ github.sha }}
+          path: Package.resolved
+          if-no-files-found: error
+          retention-days: 1
       - name: Test package
         run: swift test
+      - name: Package merged application
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: scripts/package-app.sh release
+      - name: Upload merged application
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: InterviewArcLive-${{ github.sha }}
+          path: |
+            dist/Interview Arc Live.app
+            dist/InterviewArcLive.package-manifest.txt
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -19,14 +19,6 @@ jobs:
         run: swift --version
       - name: Resolve dependency graph
         run: swift package resolve
-      - name: Export generated dependency lockfile
-        if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
-        with:
-          name: Package-resolved-${{ github.sha }}
-          path: Package.resolved
-          if-no-files-found: error
-          retention-days: 1
       - name: Test package
         run: swift test
       - name: Package merged application

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .build/
 .swiftpm/
 DerivedData/
+dist/
 *.xcuserstate
 .DS_Store
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -51,6 +51,22 @@ One finalized candidate audio interval with stable identity, timing,
 transcription attempts, and quality. Multiple Segments may belong to one
 Candidate Turn.
 
+### Transcription Attempt
+
+One durably authorized provider request for a Segment. A retry is a new
+Attempt; replaying an existing operation ID never sends audio again.
+
+### Source Recording
+
+The private, session-owned M4A produced for one Segment. It remains canonical
+recovery evidence when transcription fails; provider upload chunks are
+temporary derivatives.
+
+### Best Transcript Candidate
+
+The deterministic selected nonempty provider result for a Segment. Quality
+controls its evidence status, never whether the text remains visible.
+
 ### Turn Mode
 
 The policy controlling Hand off: `Cue Only`, experimental `Patient Auto`, or
@@ -86,5 +102,8 @@ separate recording, model, transcript, or persistence state.
 - Accepted transitions advance the Session Manifest revision monotonically.
 - Every nonempty audio-derived transcript candidate remains visible with an
   explicit quality state.
+- A provider side effect occurs only after its exact Segment or Transcription
+  Attempt authorization is durable.
+- A failed transcription never deletes the Source Recording.
 - No client invents speech, hidden model memory, an Accepted verdict, or a
   durable write receipt.

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,40 @@
+{
+  "originHash" : "3bac04cc4c957ef4c7d5a19f1183588f5f92679393efa70e7dd709b9a04c50f6",
+  "pins" : [
+    {
+      "identity" : "argmax-oss-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/argmaxinc/argmax-oss-swift.git",
+      "state" : {
+        "revision" : "25c62997041c134b03ca82731ce2f6fd2cae1eb9",
+        "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "interview-arc-voice",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Vinosaamaa/interview-arc-voice.git",
+      "state" : {
+        "revision" : "e68767d92431c1b909fc4c8771d79b0b0d3b1ea9"
+      }
+    },
+    {
+      "identity" : "libfvad",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gfreezy/libfvad",
+      "state" : {
+        "revision" : "b685985209f19e9f94c04514e849089869b1d5d5"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.swift
+++ b/Package.swift
@@ -8,15 +8,45 @@ let package = Package(
         .library(name: "InterviewArcLiveCore", targets: ["InterviewArcLiveCore"]),
         .executable(name: "InterviewArcLive", targets: ["InterviewArcLive"]),
     ],
+    dependencies: [
+        .package(
+            url: "https://github.com/Vinosaamaa/interview-arc-voice.git",
+            revision: "e68767d92431c1b909fc4c8771d79b0b0d3b1ea9"
+        ),
+    ],
     targets: [
         .target(name: "InterviewArcLiveCore"),
+        .target(
+            name: "InterviewArcLiveVoiceAdapter",
+            dependencies: [
+                "InterviewArcLiveCore",
+                .product(
+                    name: "InterviewArcVoiceCore",
+                    package: "interview-arc-voice"
+                ),
+            ]
+        ),
         .executableTarget(
             name: "InterviewArcLive",
-            dependencies: ["InterviewArcLiveCore"]
+            dependencies: [
+                "InterviewArcLiveCore",
+                "InterviewArcLiveVoiceAdapter",
+            ]
         ),
         .testTarget(
             name: "InterviewArcLiveCoreTests",
             dependencies: ["InterviewArcLiveCore"]
+        ),
+        .testTarget(
+            name: "InterviewArcLiveVoiceAdapterTests",
+            dependencies: [
+                "InterviewArcLiveCore",
+                "InterviewArcLiveVoiceAdapter",
+                .product(
+                    name: "InterviewArcVoiceCore",
+                    package: "interview-arc-voice"
+                ),
+            ]
         ),
     ]
 )

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDisplayName</key>
+    <string>Interview Arc Live</string>
+    <key>CFBundleExecutable</key>
+    <string>InterviewArcLive</string>
+    <key>CFBundleIdentifier</key>
+    <string>app.interviewarc.live</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>Interview Arc Live</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>14.0</string>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>Interview Arc Live records your spoken mock-interview answers for local transcription and recovery.</string>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+</dict>
+</plist>

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
     <key>LSMinimumSystemVersion</key>
     <string>14.0</string>
     <key>NSMicrophoneUsageDescription</key>
-    <string>Interview Arc Live records your spoken mock-interview answers for local transcription and recovery.</string>
+    <string>Interview Arc Live preserves your mock-interview audio locally and sends it to Groq for transcription only after you choose Stop or Transcribe.</string>
     <key>NSPrincipalClass</key>
     <string>NSApplication</string>
 </dict>

--- a/Sources/InterviewArcLive/CandidateSegmentPresentation+Core.swift
+++ b/Sources/InterviewArcLive/CandidateSegmentPresentation+Core.swift
@@ -1,0 +1,145 @@
+import Foundation
+import InterviewArcLiveCore
+
+extension CandidateSegmentPresentation {
+    init(segment: CandidateSegment) {
+        let selected = segment.selectedCandidate
+        id = segment.id.rawValue
+        ordinal = segment.ordinal + 1
+        lifecycle = Self.presentationLifecycle(for: segment)
+        duration = segment.capturedAudio.map {
+            Self.durationLabel(milliseconds: $0.decodedDurationMilliseconds)
+        }
+        transcript = selected?.body
+        detail = Self.detail(for: segment)
+        quality = selected.map { Self.presentationQuality(for: $0.quality) }
+        canPlay = segment.capturedAudio?.isPlayable == true
+        if segment.canRetryTranscription && selected?.quality != .verified {
+            transcriptionAction = segment.transcriptionAttempts.isEmpty ? .initial : .retry
+        } else {
+            transcriptionAction = nil
+        }
+        canExclude = segment.canExcludeFromAnswer
+    }
+
+    private static func presentationLifecycle(
+        for segment: CandidateSegment
+    ) -> Lifecycle {
+        switch segment.lifecycle {
+        case .captureAuthorized:
+            .preparing
+        case .recording:
+            .recording
+        case .finalizationAuthorized:
+            .finalizing
+        case .audioReady:
+            segment.transcriptionAttempts.isEmpty ? .preserved : .recoverable
+        case .transcribing:
+            .transcribing
+        case .transcribed:
+            segment.capturedAudio?.isPartial == true ? .partial : .ready
+        case .failed:
+            .failed
+        case .excluded:
+            .excluded
+        }
+    }
+
+    private static func presentationQuality(
+        for quality: TranscriptQuality
+    ) -> Quality {
+        switch quality {
+        case .verified: .verified
+        case .bestAvailable: .bestAvailable
+        case .possibleContamination: .possibleContamination
+        }
+    }
+
+    private static func durationLabel(milliseconds: Int64) -> String {
+        let seconds = max(0, milliseconds / 1_000)
+        return String(format: "%lld:%02lld", seconds / 60, seconds % 60)
+    }
+
+    private static func detail(for segment: CandidateSegment) -> String {
+        switch segment.lifecycle {
+        case .captureAuthorized:
+            return "The segment identity is saved. Starting the microphone now."
+        case .recording:
+            return "Recording now. Stop preserves this segment before transcription begins."
+        case .finalizationAuthorized:
+            return "Saving the source recording before contacting Groq."
+        case .audioReady:
+            if let failure = segment.transcriptionAttempts.last?.failure {
+                return transcriptionFailureMessage(failure.reason)
+            }
+            return "Source recording preserved. Groq has not been contacted. Choose Transcribe when ready."
+        case .transcribing:
+            return "Source audio is saved. Groq transcription is in progress."
+        case .transcribed:
+            return segment.capturedAudio?.isPartial == true
+                ? "The playable portion and its best transcript are preserved."
+                : "The selected transcript is preserved verbatim."
+        case .failed:
+            return captureFailureMessage(segment.captureFailureReason)
+        case .excluded:
+            return exclusionMessage(segment.exclusionReason)
+        }
+    }
+
+    private static func exclusionMessage(_ reason: SegmentExclusionReason?) -> String {
+        switch reason {
+        case .userSkipped:
+            "Excluded from Hand off. The source recording remains preserved."
+        case .noUsableTranscript:
+            "Excluded because no usable transcript was selected. The recording remains preserved."
+        case .insufficientSignal:
+            "Excluded because speech signal was insufficient. The recording remains preserved."
+        case .captureFailed:
+            "Excluded after capture failure. Any recovered source evidence remains preserved."
+        case nil:
+            "Excluded from Hand off. Source evidence remains preserved."
+        }
+    }
+
+    private static func transcriptionFailureMessage(
+        _ reason: SegmentTranscriptionFailureReason
+    ) -> String {
+        switch reason {
+        case .missingCredential:
+            "Recording saved. Add a Groq key, then retry the transcript."
+        case .credentialRejected:
+            "Recording saved. Update the Groq key, then retry the transcript."
+        case .invalidAudio:
+            "Recording kept, but Groq could not read its audio. Play it before retrying."
+        case .insufficientSignal:
+            "Recording kept. Groq found too little speech; play it before retrying."
+        case .emptyProviderResult:
+            "Recording kept. Groq returned no words; retry only when you choose."
+        case .providerUnavailable:
+            "Recording kept. Groq was unavailable; retry when the provider recovers."
+        case .interrupted:
+            "Recording kept. The provider attempt was interrupted and was not replayed."
+        }
+    }
+
+    private static func captureFailureMessage(
+        _ reason: SegmentCaptureFailureReason?
+    ) -> String {
+        switch reason {
+        case .microphoneUnavailable:
+            "Microphone access is unavailable. Check macOS access before adding a segment."
+        case .captureStartFailed:
+            "The microphone did not start. No speech was claimed or transcribed."
+        case .captureFinalizationFailed:
+            "The recording could not be finalized. The last durable state remains available."
+        case .noPlayableAudio:
+            "No playable audio was recovered. Add a new segment when ready."
+        case .storageFailed:
+            "Private recording storage failed. No provider request was started."
+        case .interruptedWithoutAudio:
+            "Recording ended before a playable source file was available."
+        case nil:
+            "This segment failed without a playable source recording."
+        }
+    }
+}

--- a/Sources/InterviewArcLive/CandidateSegmentPresentation.swift
+++ b/Sources/InterviewArcLive/CandidateSegmentPresentation.swift
@@ -1,0 +1,237 @@
+import SwiftUI
+
+struct CandidateSegmentPresentation: Identifiable, Equatable {
+    enum Lifecycle: Equatable {
+        case preparing
+        case recording
+        case finalizing
+        case transcribing
+        case ready
+        case partial
+        case preserved
+        case excluded
+        case recoverable
+        case failed
+
+        var title: String {
+            switch self {
+            case .preparing: "Preparing microphone"
+            case .recording: "Recording"
+            case .finalizing: "Saving recording"
+            case .transcribing: "Transcribing"
+            case .ready: "Ready"
+            case .partial: "Recovered partial recording"
+            case .preserved: "Recording preserved"
+            case .excluded: "Excluded · recording preserved"
+            case .recoverable: "Needs attention"
+            case .failed: "Recording unavailable"
+            }
+        }
+
+        var symbol: String {
+            switch self {
+            case .preparing: "mic.badge.plus"
+            case .recording: "waveform"
+            case .finalizing: "tray.and.arrow.down.fill"
+            case .transcribing: "text.badge.star"
+            case .ready: "checkmark.circle.fill"
+            case .partial: "exclamationmark.circle.fill"
+            case .preserved: "waveform.circle.fill"
+            case .excluded: "minus.circle.fill"
+            case .recoverable: "arrow.clockwise.circle.fill"
+            case .failed: "exclamationmark.triangle.fill"
+            }
+        }
+    }
+
+    enum Quality: Equatable {
+        case verified
+        case bestAvailable
+        case possibleContamination
+
+        var title: String {
+            switch self {
+            case .verified: "Verified transcript"
+            case .bestAvailable: "Best available"
+            case .possibleContamination: "Possible contamination"
+            }
+        }
+
+        var symbol: String {
+            switch self {
+            case .verified: "checkmark.seal.fill"
+            case .bestAvailable: "text.magnifyingglass"
+            case .possibleContamination: "exclamationmark.bubble.fill"
+            }
+        }
+    }
+
+    enum TranscriptionAction: Equatable {
+        case initial
+        case retry
+
+        var title: String {
+            switch self {
+            case .initial: "Transcribe"
+            case .retry: "Retry transcript"
+            }
+        }
+
+        var symbol: String {
+            switch self {
+            case .initial: "text.badge.plus"
+            case .retry: "arrow.clockwise"
+            }
+        }
+    }
+
+    let id: String
+    let ordinal: Int
+    let lifecycle: Lifecycle
+    let duration: String?
+    let transcript: String?
+    let detail: String
+    let quality: Quality?
+    let canPlay: Bool
+    let transcriptionAction: TranscriptionAction?
+    let canExclude: Bool
+}
+
+struct CandidateSegmentCard: View {
+    let segment: CandidateSegmentPresentation
+    let isBusy: Bool
+    let onPlay: () -> Void
+    let onTranscribe: () -> Void
+    let onExclude: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                Text("SEGMENT \(segment.ordinal)")
+                    .font(.system(.caption, design: .monospaced, weight: .bold))
+                    .tracking(0.8)
+
+                Label(segment.lifecycle.title, systemImage: segment.lifecycle.symbol)
+                    .font(.system(.caption, design: .rounded, weight: .semibold))
+                    .foregroundStyle(lifecycleColor)
+
+                Spacer(minLength: 8)
+
+                if let duration = segment.duration {
+                    Text(duration)
+                        .font(.system(.caption, design: .monospaced))
+                        .foregroundStyle(LivePalette.muted)
+                }
+            }
+
+            if let transcript = segment.transcript, !transcript.isEmpty {
+                Text(transcript)
+                    .font(.system(.body, design: .rounded))
+                    .textSelection(.enabled)
+                    .fixedSize(horizontal: false, vertical: true)
+            } else {
+                Text(segment.detail)
+                    .font(.system(.subheadline, design: .rounded))
+                    .foregroundStyle(LivePalette.muted)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            if showsFooter {
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack(spacing: 10) {
+                        if let quality = segment.quality {
+                            Label(quality.title, systemImage: quality.symbol)
+                                .font(.system(.caption, design: .rounded, weight: .semibold))
+                                .foregroundStyle(qualityColor(quality))
+                        }
+
+                        Spacer(minLength: 8)
+
+                        if segment.canPlay {
+                            Button(action: onPlay) {
+                                Label("Play", systemImage: "play.fill")
+                            }
+                            .disabled(isBusy)
+                            .accessibilityHint("Plays this preserved source recording")
+                        }
+                    }
+
+                    if segment.transcriptionAction != nil || segment.canExclude {
+                        ViewThatFits(in: .horizontal) {
+                            HStack(spacing: 8) { recoveryActions }
+                            VStack(alignment: .leading, spacing: 8) { recoveryActions }
+                        }
+                    }
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
+        }
+        .padding(14)
+        .background(LivePalette.room.opacity(0.58), in: RoundedRectangle(cornerRadius: 12))
+        .overlay {
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(borderColor, lineWidth: segment.lifecycle == .recording ? 2 : 1)
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Segment \(segment.ordinal), \(segment.lifecycle.title)")
+    }
+
+    private var lifecycleColor: Color {
+        switch segment.lifecycle {
+        case .ready: LivePalette.candidate
+        case .recording: LivePalette.handoff
+        case .partial, .recoverable, .failed: LivePalette.warning
+        case .preserved: LivePalette.interviewer
+        case .excluded: LivePalette.muted
+        case .preparing, .finalizing, .transcribing: LivePalette.interviewer
+        }
+    }
+
+    private var borderColor: Color {
+        segment.lifecycle == .recording
+            ? LivePalette.handoff
+            : LivePalette.line
+    }
+
+    private var showsFooter: Bool {
+        segment.quality != nil
+            || segment.canPlay
+            || segment.transcriptionAction != nil
+            || segment.canExclude
+    }
+
+    @ViewBuilder
+    private var recoveryActions: some View {
+        if let action = segment.transcriptionAction {
+            Button(action: onTranscribe) {
+                Label(action.title, systemImage: action.symbol)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(LivePalette.candidate)
+            .disabled(isBusy)
+            .accessibilityHint(
+                action == .initial
+                    ? "Starts the first explicit Groq transcription request"
+                    : "Starts one explicit Groq transcription retry"
+            )
+        }
+
+        if segment.canExclude {
+            Button(action: onExclude) {
+                Label("Exclude from answer", systemImage: "minus.circle")
+            }
+            .disabled(isBusy)
+            .help("Keeps the source recording but omits this segment from Hand off")
+            .accessibilityHint("Preserves the recording and omits this segment from Hand off")
+        }
+    }
+
+    private func qualityColor(_ quality: CandidateSegmentPresentation.Quality) -> Color {
+        switch quality {
+        case .verified: LivePalette.candidate
+        case .bestAvailable: LivePalette.interviewer
+        case .possibleContamination: LivePalette.warning
+        }
+    }
+}

--- a/Sources/InterviewArcLive/GroqCredentialSetupView.swift
+++ b/Sources/InterviewArcLive/GroqCredentialSetupView.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+
+struct GroqCredentialSetupView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let isSaving: Bool
+    let errorMessage: String?
+    let onSave: (String) async -> Bool
+
+    @State private var key = ""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            HStack(alignment: .top, spacing: 14) {
+                Image(systemName: "key.horizontal.fill")
+                    .font(.system(size: 24, weight: .semibold))
+                    .foregroundStyle(LivePalette.candidate)
+                    .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Connect Groq transcription")
+                        .font(.system(.title2, design: .rounded, weight: .semibold))
+                    Text("Your key is read back from this app’s macOS Keychain after saving and is never shown again.")
+                        .font(.system(.body, design: .rounded))
+                        .foregroundStyle(LivePalette.muted)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Text("After you stop a segment, its audio is sent to Groq for transcription. The source M4A remains in Live’s private local recovery storage.")
+                        .font(.system(.callout, design: .rounded))
+                        .foregroundStyle(LivePalette.muted)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
+            SecureField("Groq API key", text: $key)
+                .textFieldStyle(.roundedBorder)
+                .disabled(isSaving)
+                .onSubmit { save() }
+
+            if let errorMessage {
+                Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
+                    .font(.system(.callout, design: .rounded))
+                    .foregroundStyle(LivePalette.warning)
+                    .accessibilityLabel("Credential setup error: \(errorMessage)")
+            }
+
+            HStack {
+                Text("Existing recordings remain private and recoverable if setup fails.")
+                    .font(.system(.caption, design: .rounded))
+                    .foregroundStyle(LivePalette.muted)
+
+                Spacer()
+
+                Button("Not now") { dismiss() }
+                    .disabled(isSaving)
+
+                Button(action: save) {
+                    if isSaving {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else {
+                        Text("Save key")
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(LivePalette.candidate)
+                .disabled(isSaving || key.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(26)
+        .frame(width: 500)
+        .background(LivePalette.paper)
+    }
+
+    private func save() {
+        let submittedKey = key
+        Task {
+            if await onSave(submittedKey) {
+                key = ""
+                dismiss()
+            }
+        }
+    }
+}

--- a/Sources/InterviewArcLive/InterviewArcLiveApp.swift
+++ b/Sources/InterviewArcLive/InterviewArcLiveApp.swift
@@ -7,8 +7,9 @@ struct InterviewArcLiveApp: App {
     var body: some Scene {
         WindowGroup("Interview Arc Live") {
             SystemDesignRoomView(model: model)
-                .frame(minWidth: 980, minHeight: 640)
+                .frame(minWidth: 1_080, minHeight: 700)
         }
         .windowStyle(.hiddenTitleBar)
+        .defaultSize(width: 1_180, height: 760)
     }
 }

--- a/Sources/InterviewArcLive/SystemDesignRoomModel.swift
+++ b/Sources/InterviewArcLive/SystemDesignRoomModel.swift
@@ -1,131 +1,553 @@
+import AVFoundation
 import Foundation
 import InterviewArcLiveCore
+import InterviewArcLiveVoiceAdapter
 
 @MainActor
 final class SystemDesignRoomModel: ObservableObject {
     @Published private(set) var snapshot: InterviewRoomSnapshot?
+    @Published private(set) var segments: [CandidateSegmentPresentation] = []
     @Published private(set) var isWorking = false
     @Published private(set) var statusMessage = "Restoring local session…"
+    @Published private(set) var errorMessage: String?
+
+    @Published var isCredentialSetupPresented = false
+    @Published private(set) var isSavingCredential = false
+    @Published private(set) var credentialErrorMessage: String?
 
     let question = "Design a global notification system."
 
+    private enum CredentialState {
+        case checking
+        case missing
+        case ready
+        case unusable
+    }
+
     private let sessionID = SessionID("local-system-design-tracer")
-    private var session: InterviewRoomSession?
+    private let credentialStore: LiveGroqCredentialStore
+    private var credentialState: CredentialState = .checking
+    private var coordinator: SegmentSpeechCoordinator?
+    private var audioPlayer: AVAudioPlayer?
+
+    init(credentialStore: LiveGroqCredentialStore = LiveGroqCredentialStore()) {
+        self.credentialStore = credentialStore
+    }
+
+    var needsGroqCredential: Bool {
+        credentialState == .missing || credentialState == .unusable
+    }
+
+    var canStopRecording: Bool {
+        activeCaptureSegment != nil
+    }
+
+    var stopActionTitle: String {
+        activeCaptureSegment?.lifecycle == .recording
+            ? "Stop segment"
+            : "Recover recording"
+    }
+
+    var stopActionIcon: String {
+        activeCaptureSegment?.lifecycle == .recording
+            ? "stop.fill"
+            : "arrow.clockwise.circle.fill"
+    }
+
+    var showsRecordControl: Bool {
+        snapshot?.phase == .candidateFloor && !canStopRecording
+    }
+
+    var canRecordSegment: Bool {
+        guard !isWorking,
+              credentialState == .ready,
+              snapshot?.phase == .candidateFloor else {
+            return false
+        }
+        return !draftSegments.contains {
+            $0.lifecycle == .captureAuthorized
+                || $0.lifecycle == .recording
+                || $0.lifecycle == .finalizationAuthorized
+                || $0.lifecycle == .transcribing
+        }
+    }
+
+    var recordActionTitle: String {
+        draftSegments.isEmpty ? "Record segment" : "Add segment"
+    }
 
     var canAct: Bool {
-        guard !isWorking, let phase = snapshot?.phase else { return false }
-        return phase == .candidateFloor
-            || phase == .interviewerProcessing
-            || phase == .interviewerTurn
+        guard !isWorking, let snapshot else { return false }
+        switch snapshot.phase {
+        case .candidateFloor:
+            let unresolved = draftSegments.contains {
+                $0.lifecycle != .excluded && $0.selectedCandidate == nil
+            }
+            let hasSelected = draftSegments.contains {
+                $0.lifecycle != .excluded && $0.selectedCandidate != nil
+            }
+            return hasSelected && !unresolved
+        case .interviewerProcessing, .interviewerTurn:
+            return true
+        case .ready, .completed:
+            return false
+        }
     }
 
     var actionTitle: String {
         switch snapshot?.phase {
         case .interviewerProcessing: "Retry interviewer"
         case .interviewerTurn: "Give me the floor"
+        case .completed: "Session complete"
         default: "Hand off"
         }
     }
 
     var actionIcon: String {
-        snapshot?.phase == .interviewerProcessing
-            ? "arrow.clockwise.circle.fill"
-            : "arrowshape.right.circle.fill"
+        switch snapshot?.phase {
+        case .interviewerProcessing: "arrow.clockwise.circle.fill"
+        case .interviewerTurn: "arrow.uturn.backward.circle.fill"
+        default: "arrowshape.right.circle.fill"
+        }
     }
 
     func open() async {
-        guard session == nil, !isWorking else { return }
+        guard coordinator == nil, !isWorking else { return }
         isWorking = true
+        errorMessage = nil
         defer { isWorking = false }
 
+        await refreshCredentialReadiness(presentWhenMissing: true)
+
         do {
-            let store = try FileSessionManifestStore()
             let runtime = DeterministicInterviewerRuntime(
                 response: CanonicalInterviewerResponse(
                     displayMarkdown: "Good. How will clients observe delivery without coupling every channel to the request path?",
                     spokenText: "Good. How will clients observe delivery without coupling every channel to the request path?"
                 )
             )
-
-            let openedSession: InterviewRoomSession
-            if try await store.load(sessionID: sessionID) == nil {
-                openedSession = try await InterviewRoomSession.start(
-                    sessionID: sessionID,
-                    activityID: "local-system-design-tracer",
-                    manifestStore: store,
-                    interviewerRuntime: runtime
-                )
-            } else {
-                openedSession = try await InterviewRoomSession.restore(
-                    sessionID: sessionID,
-                    manifestStore: store,
-                    interviewerRuntime: runtime
-                )
+            let opened = try await SegmentSpeechCoordinator.openLocal(
+                sessionID: sessionID,
+                activityID: "local-system-design-tracer",
+                interviewerRuntime: runtime,
+                recording: VoiceCoreSegmentRecorder(),
+                transcriber: VoiceCoreSegmentTranscriber(),
+                credentialReader: credentialStore
+            )
+            coordinator = opened
+            opened.setSnapshotHandler { [weak self, weak opened] nextSnapshot in
+                guard let self,
+                      let opened,
+                      self.coordinator === opened else {
+                    return
+                }
+                self.publish(nextSnapshot)
             }
 
-            session = openedSession
-            var restored = await openedSession.snapshot()
+            var restored = opened.snapshot
+            do {
+                restored = try await opened.resumePendingWork()
+            } catch {
+                restored = opened.snapshot
+                errorMessage = "A recording recovery needs attention. Preserved evidence remains visible below."
+            }
             if restored.phase == .ready {
-                restored = try await openedSession.execute(
-                    .giveCandidateFloor(commandID: CommandID("local-give-floor-0"))
+                restored = try await opened.giveCandidateFloor(
+                    commandID: CommandID("local-give-floor-0")
                 )
             }
-            snapshot = restored
-            statusMessage = status(for: restored)
+            publish(restored)
         } catch {
             statusMessage = "Local session unavailable"
+            errorMessage = safeMessage(for: error)
+        }
+    }
+
+    func recordSegment() async {
+        guard let coordinator else { return }
+        guard credentialState == .ready else {
+            presentCredentialSetup()
+            return
+        }
+        guard canRecordSegment else { return }
+
+        isWorking = true
+        errorMessage = nil
+        statusMessage = "Preparing microphone…"
+        defer { isWorking = false }
+
+        do {
+            let updated = try await coordinator.beginSegment(
+                commandID: commandID("begin-segment")
+            )
+            publish(updated)
+        } catch {
+            publish(coordinator.snapshot)
+            errorMessage = safeMessage(for: error)
+        }
+    }
+
+    func stopRecording() async {
+        guard let coordinator,
+              let activeSegment = activeCaptureSegment,
+              !isWorking else {
+            return
+        }
+
+        isWorking = true
+        errorMessage = nil
+        statusMessage = activeSegment.lifecycle == .recording
+            ? "Saving recording before Groq transcription…"
+            : "Recovering the source recording without contacting Groq…"
+        defer { isWorking = false }
+
+        do {
+            let preserved = try await coordinator.finalizeSegment(
+                commandID: commandID("finalize-segment")
+            )
+            publish(preserved)
+
+            if activeSegment.lifecycle == .recording,
+               let preservedSegment = preserved.segments.first(where: {
+                   $0.id == activeSegment.id
+               }),
+               preservedSegment.canRetryTranscription {
+                statusMessage = "Transcribing with Groq…"
+                let transcribed = try await coordinator.transcribeSegment(
+                    segmentID: activeSegment.id,
+                    commandID: commandID("initial-transcription")
+                )
+                publish(transcribed)
+            }
+        } catch {
+            publish(coordinator.snapshot)
+            handleCredentialFailure(error)
+            errorMessage = safeMessage(for: error)
+        }
+    }
+
+    func transcribeSegment(id: String) async {
+        guard let coordinator, !isWorking else { return }
+        guard credentialState == .ready else {
+            credentialErrorMessage = "Save a Groq API key before retrying this transcript."
+            presentCredentialSetup()
+            return
+        }
+        guard let segment = draftSegments.first(where: { $0.id.rawValue == id }),
+              segment.canRetryTranscription else {
+            return
+        }
+        let isInitial = segment.transcriptionAttempts.isEmpty
+
+        isWorking = true
+        errorMessage = nil
+        statusMessage = isInitial
+            ? "Transcribing preserved recording with Groq…"
+            : "Retrying one transcript with Groq…"
+        defer { isWorking = false }
+
+        do {
+            let updated = try await coordinator.transcribeSegment(
+                segmentID: segment.id,
+                commandID: commandID(
+                    isInitial ? "initial-transcription" : "retry-transcription"
+                )
+            )
+            publish(updated)
+        } catch {
+            publish(coordinator.snapshot)
+            handleCredentialFailure(error)
+            errorMessage = safeMessage(for: error)
+        }
+    }
+
+    func excludeSegment(id: String) async {
+        guard let coordinator, !isWorking else { return }
+        guard let segment = draftSegments.first(where: { $0.id.rawValue == id }),
+              segment.canExcludeFromAnswer else {
+            return
+        }
+
+        isWorking = true
+        errorMessage = nil
+        statusMessage = "Preserving recording and excluding segment…"
+        defer { isWorking = false }
+
+        do {
+            let updated = try await coordinator.excludeSegment(
+                segmentID: segment.id,
+                reason: exclusionReason(for: segment),
+                commandID: commandID("exclude-segment")
+            )
+            publish(updated)
+        } catch {
+            publish(coordinator.snapshot)
+            errorMessage = safeMessage(for: error)
+        }
+    }
+
+    func playSegment(id: String) async {
+        guard let coordinator, !isWorking else { return }
+        guard draftSegments.contains(where: {
+            $0.id.rawValue == id && $0.capturedAudio?.isPlayable == true
+        }) else {
+            return
+        }
+
+        isWorking = true
+        errorMessage = nil
+        defer { isWorking = false }
+
+        do {
+            let url = try await coordinator.playbackURL(segmentID: SegmentID(id))
+            let player = try AVAudioPlayer(contentsOf: url)
+            player.prepareToPlay()
+            guard player.play() else {
+                errorMessage = "The preserved recording could not start playback."
+                return
+            }
+            audioPlayer = player
+            statusMessage = "Playing preserved source recording"
+        } catch {
+            errorMessage = "The preserved recording is unavailable for playback."
         }
     }
 
     func performPrimaryAction() async {
-        guard let session, let snapshot, canAct else { return }
+        guard let coordinator, let snapshot, canAct else { return }
+
         isWorking = true
+        errorMessage = nil
         defer { isWorking = false }
 
         do {
             let updated: InterviewRoomSnapshot
             switch snapshot.phase {
             case .candidateFloor:
-                updated = try await session.execute(
-                    .handOff(
-                        commandID: CommandID("local-handoff-\(snapshot.revision)"),
-                        transcript: CandidateTranscript(
-                            body: "Transactional alerts need a durable path with explicit delivery state.",
-                            quality: .verified
-                        )
-                    )
+                statusMessage = "Saving one ordered answer…"
+                updated = try await coordinator.handOff(
+                    commandID: commandID("hand-off")
                 )
             case .interviewerProcessing:
-                updated = try await session.execute(
-                    .retryInterviewerResponse(
-                        commandID: CommandID(
-                            "local-retry-interviewer-\(snapshot.revision)"
-                        )
-                    )
+                statusMessage = "Retrying interviewer response…"
+                updated = try await coordinator.retryInterviewerResponse(
+                    commandID: commandID("retry-interviewer")
                 )
             case .interviewerTurn:
-                updated = try await session.execute(
-                    .giveCandidateFloor(
-                        commandID: CommandID("local-give-floor-\(snapshot.revision)")
-                    )
+                updated = try await coordinator.giveCandidateFloor(
+                    commandID: commandID("give-floor")
                 )
-            default:
+            case .ready, .completed:
                 return
             }
-
-            self.snapshot = updated
-            statusMessage = status(for: updated)
+            publish(updated)
         } catch {
-            let recovered = await session.snapshot()
-            self.snapshot = recovered
-            statusMessage = status(for: recovered)
+            publish(coordinator.snapshot)
+            errorMessage = safeMessage(for: error)
         }
     }
 
-    private func status(for snapshot: InterviewRoomSnapshot) -> String {
-        if snapshot.phase == .interviewerProcessing {
-            return "Answer saved · interviewer retry available"
+    func presentCredentialSetup() {
+        credentialErrorMessage = nil
+        isCredentialSetupPresented = true
+    }
+
+    func saveGroqCredential(_ value: String) async -> Bool {
+        guard !isSavingCredential else { return false }
+        isSavingCredential = true
+        credentialErrorMessage = nil
+        defer { isSavingCredential = false }
+
+        do {
+            try await credentialStore.saveAndVerify(value)
+            credentialState = .ready
+            statusMessage = segments.contains(where: { $0.transcriptionAction != nil })
+                ? "Groq key saved · transcribe the affected segment"
+                : status(for: snapshot)
+            return true
+        } catch let error as LiveGroqCredentialStoreError {
+            credentialState = .unusable
+            credentialErrorMessage = error.localizedDescription
+            return false
+        } catch {
+            credentialState = .unusable
+            credentialErrorMessage = "macOS Keychain could not save the Groq API key."
+            return false
         }
-        return "Saved locally · revision \(snapshot.revision)"
+    }
+
+    private var draftSegments: [CandidateSegment] {
+        snapshot?.segments.filter { $0.committedTurnID == nil } ?? []
+    }
+
+    private var activeCaptureSegment: CandidateSegment? {
+        draftSegments.first {
+            $0.lifecycle == .captureAuthorized
+                || $0.lifecycle == .recording
+                || $0.lifecycle == .finalizationAuthorized
+        }
+    }
+
+    private func publish(_ snapshot: InterviewRoomSnapshot) {
+        if self.snapshot != snapshot {
+            self.snapshot = snapshot
+            segments = snapshot.segments
+                .filter { $0.committedTurnID == nil }
+                .sorted { $0.ordinal < $1.ordinal }
+                .map(CandidateSegmentPresentation.init(segment:))
+        }
+        statusMessage = status(for: snapshot)
+    }
+
+    private func refreshCredentialReadiness(presentWhenMissing: Bool) async {
+        do {
+            switch try await credentialStore.readiness() {
+            case .ready:
+                credentialState = .ready
+            case .missing:
+                credentialState = .missing
+                if presentWhenMissing {
+                    isCredentialSetupPresented = true
+                }
+            }
+        } catch {
+            credentialState = .unusable
+            credentialErrorMessage = "macOS Keychain is unavailable."
+            if presentWhenMissing {
+                isCredentialSetupPresented = true
+            }
+        }
+    }
+
+    private func status(for snapshot: InterviewRoomSnapshot?) -> String {
+        guard let snapshot else { return "Restoring local session…" }
+        let draft = snapshot.segments.filter { $0.committedTurnID == nil }
+
+        if draft.contains(where: { $0.lifecycle == .captureAuthorized }) {
+            return "Preparing microphone"
+        }
+        if draft.contains(where: { $0.lifecycle == .recording }) {
+            return "Recording segment"
+        }
+        if draft.contains(where: { $0.lifecycle == .finalizationAuthorized }) {
+            return "Saving source recording"
+        }
+        if draft.contains(where: { $0.lifecycle == .transcribing }) {
+            return "Transcribing with Groq"
+        }
+
+        switch snapshot.phase {
+        case .candidateFloor:
+            if credentialState != .ready {
+                return "Groq key required"
+            }
+            if draft.contains(where: {
+                $0.lifecycle == .audioReady && $0.transcriptionAttempts.isEmpty
+            }) {
+                return "Recording preserved · choose Transcribe"
+            }
+            if draft.contains(where: {
+                $0.lifecycle == .audioReady || $0.lifecycle == .failed
+            }) {
+                return "Recording preserved · recovery available"
+            }
+            let selectedCount = draft.filter {
+                $0.lifecycle != .excluded && $0.selectedCandidate != nil
+            }.count
+            return selectedCount == 0
+                ? "Ready to record"
+                : "\(selectedCount) segment\(selectedCount == 1 ? "" : "s") ready"
+        case .interviewerProcessing:
+            return "Answer saved · interviewer retry available"
+        case .interviewerTurn:
+            return "Interviewer response saved"
+        case .completed:
+            return "Session complete"
+        case .ready:
+            return "Preparing candidate floor"
+        }
+    }
+
+    private func commandID(_ operation: String) -> CommandID {
+        CommandID("ui-\(operation)-\(UUID().uuidString.lowercased())")
+    }
+
+    private func exclusionReason(for segment: CandidateSegment) -> SegmentExclusionReason {
+        if segment.captureFailureReason != nil {
+            return .captureFailed
+        }
+        if segment.capturedAudio?.integrityReasons.contains(.insufficientSignal) == true
+            || segment.transcriptionAttempts.last?.failure?.reason == .insufficientSignal {
+            return .insufficientSignal
+        }
+        if segment.selectedCandidate == nil {
+            return .noUsableTranscript
+        }
+        return .userSkipped
+    }
+
+    private func handleCredentialFailure(_ error: Error) {
+        if let coordinatorError = error as? SegmentSpeechCoordinatorError {
+            switch coordinatorError {
+            case .credentialUnavailable:
+                credentialState = .missing
+                credentialErrorMessage = "Save a Groq API key to retry the preserved recording."
+                isCredentialSetupPresented = true
+            case .transcriptionFailed(.credentialRejected):
+                credentialState = .unusable
+                credentialErrorMessage = "Groq rejected this key. Save a different key before retrying."
+                isCredentialSetupPresented = true
+            default:
+                break
+            }
+        } else if let sessionError = error as? InterviewRoomSessionError,
+                  sessionError == .rejectedCredentialUnchanged {
+            credentialState = .unusable
+            credentialErrorMessage = "The rejected Groq key has not changed. Save a different key before retrying."
+            isCredentialSetupPresented = true
+        }
+    }
+
+    private func safeMessage(for error: Error) -> String {
+        if let coordinatorError = error as? SegmentSpeechCoordinatorError {
+            switch coordinatorError {
+            case .noActiveSegment:
+                return "No active recording was available to stop. The latest durable state is shown."
+            case .segmentAudioUnavailable:
+                return "The source recording is unavailable for this segment."
+            case .captureFailed(.microphoneUnavailable),
+                 .captureFailed(.captureStartFailed):
+                return "The microphone did not start. Check macOS microphone access, then add a segment."
+            case .captureFailed:
+                return "Recording stopped with a capture failure. Any recoverable source evidence remains visible."
+            case .credentialUnavailable:
+                return "The source recording is saved. Add a Groq key, then retry its transcript."
+            case .transcriptionFailed(.credentialRejected):
+                return "The source recording is saved. Groq rejected the key; update it before retrying."
+            case .transcriptionFailed(.providerUnavailable):
+                return "The source recording is saved. Groq is unavailable; retry only when you choose."
+            case .transcriptionFailed:
+                return "The source recording is saved, but this transcript attempt failed."
+            }
+        }
+
+        if let sessionError = error as? InterviewRoomSessionError {
+            switch sessionError {
+            case .rejectedCredentialUnchanged:
+                return "The rejected Groq key has not changed. Save a different key before retrying."
+            case .unresolvedSegmentsPreventHandOff:
+                return "Retry or exclude every unresolved segment before Hand off. Recordings remain preserved."
+            case .noTranscribedSegments:
+                return "At least one selected transcript is required before Hand off."
+            case .segmentHasInsufficientSignal:
+                return "This recording has insufficient speech signal. Play it, then exclude it or add another segment."
+            case .commandInProgress:
+                return "Another durable room operation is still in progress."
+            default:
+                return "The room rejected this action. Its latest durable state is still shown."
+            }
+        }
+
+        return "The operation did not complete. The latest durable state is still shown."
     }
 }

--- a/Sources/InterviewArcLive/SystemDesignRoomView.swift
+++ b/Sources/InterviewArcLive/SystemDesignRoomView.swift
@@ -8,6 +8,9 @@ struct SystemDesignRoomView: View {
         VStack(spacing: 0) {
             header
             question
+            if let errorMessage = model.errorMessage {
+                recoveryBanner(errorMessage)
+            }
 
             HSplitView {
                 transcript
@@ -21,6 +24,13 @@ struct SystemDesignRoomView: View {
         .background(LivePalette.room)
         .foregroundStyle(LivePalette.ink)
         .task { await model.open() }
+        .sheet(isPresented: $model.isCredentialSetupPresented) {
+            GroqCredentialSetupView(
+                isSaving: model.isSavingCredential,
+                errorMessage: model.credentialErrorMessage,
+                onSave: model.saveGroqCredential
+            )
+        }
     }
 
     private var header: some View {
@@ -36,10 +46,19 @@ struct SystemDesignRoomView: View {
                 .frame(width: 1, height: 18)
             Text(model.statusMessage)
                 .foregroundStyle(LivePalette.line)
+                .lineLimit(1)
+            if model.needsGroqCredential {
+                Button("Add Groq key") {
+                    model.presentCredentialSetup()
+                }
+                .buttonStyle(.bordered)
+                .tint(LivePalette.liveSignal)
+                .accessibilityHint("Opens secure Groq transcription setup")
+            }
             Rectangle()
                 .fill(LivePalette.line.opacity(0.45))
                 .frame(width: 1, height: 18)
-            Label("Private", systemImage: "lock")
+            Label("Local source · Groq transcript", systemImage: "lock")
         }
         .font(.system(.body, design: .rounded))
         .foregroundStyle(LivePalette.paper)
@@ -69,43 +88,124 @@ struct SystemDesignRoomView: View {
     private var transcript: some View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 0) {
-                if let snapshot = model.snapshot, !snapshot.turns.isEmpty {
+                if let snapshot = model.snapshot {
                     ForEach(snapshot.turns.indices, id: \.self) { index in
                         turnlineEntry(
                             snapshot.turns[index],
                             isLast: index == snapshot.turns.count - 1
+                                && snapshot.phase != .candidateFloor
                         )
                     }
-                } else {
-                    VStack(alignment: .leading, spacing: 10) {
-                        Text("CANDIDATE FLOOR")
-                            .font(.system(.caption, design: .monospaced, weight: .bold))
-                            .foregroundStyle(LivePalette.candidate)
-                        Text("Think aloud, work on the board, then hand off one complete answer.")
-                            .font(.system(.body, design: .rounded))
-                            .foregroundStyle(LivePalette.muted)
+
+                    if snapshot.phase == .candidateFloor {
+                        candidateFloorEntry
+                    } else if snapshot.turns.isEmpty {
+                        preparingEmptyState
                     }
-                    .padding(28)
+                } else {
+                    preparingEmptyState
                 }
             }
         }
         .background(LivePalette.paper)
     }
 
+    private var preparingEmptyState: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("PREPARING ROOM")
+                .font(.system(.caption, design: .monospaced, weight: .bold))
+                .foregroundStyle(LivePalette.interviewer)
+            Text("Restoring the latest complete local session.")
+                .font(.system(.body, design: .rounded))
+                .foregroundStyle(LivePalette.muted)
+        }
+        .padding(28)
+    }
+
+    private var candidateFloorEntry: some View {
+        HStack(alignment: .top, spacing: 18) {
+            VStack(spacing: 0) {
+                Circle()
+                    .fill(LivePalette.candidate)
+                    .frame(width: 11, height: 11)
+                Rectangle()
+                    .fill(Color.clear)
+                    .frame(width: 1)
+                    .frame(minHeight: 82)
+            }
+            .padding(.top, 4)
+            .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 14) {
+                HStack(alignment: .firstTextBaseline) {
+                    Text("YOUR ANSWER DRAFT")
+                        .font(.system(.caption, design: .monospaced, weight: .bold))
+                        .foregroundStyle(LivePalette.candidate)
+                    Spacer()
+                    Text(segmentCountLabel)
+                        .font(.system(.caption, design: .monospaced))
+                        .foregroundStyle(LivePalette.muted)
+                }
+
+                if model.segments.isEmpty {
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("Record your first segment")
+                            .font(.system(.title3, design: .rounded, weight: .semibold))
+                        Text("Working pauses can become separate segments. Only Hand off commits them as one answer.")
+                            .font(.system(.body, design: .rounded))
+                            .foregroundStyle(LivePalette.muted)
+                    }
+                    .padding(14)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(
+                        LivePalette.room.opacity(0.48),
+                        in: RoundedRectangle(cornerRadius: 12)
+                    )
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(LivePalette.line, style: StrokeStyle(lineWidth: 1, dash: [5]))
+                    }
+                } else {
+                    ForEach(model.segments) { segment in
+                        CandidateSegmentCard(
+                            segment: segment,
+                            isBusy: model.isWorking || model.canStopRecording,
+                            onPlay: {
+                                Task { await model.playSegment(id: segment.id) }
+                            },
+                            onTranscribe: {
+                                Task { await model.transcribeSegment(id: segment.id) }
+                            },
+                            onExclude: {
+                                Task { await model.excludeSegment(id: segment.id) }
+                            }
+                        )
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.bottom, 24)
+        }
+        .padding(.horizontal, 28)
+    }
+
     private func turnlineEntry(_ turn: InterviewTurn, isLast: Bool) -> some View {
         let role: String
         let body: String
         let color: Color
+        let rendersMarkdown: Bool
 
         switch turn {
         case .candidate(let candidate):
             role = "YOU"
             body = candidate.transcript.body
             color = LivePalette.candidate
+            rendersMarkdown = false
         case .interviewer(let interviewer):
             role = "MARA"
             body = interviewer.displayMarkdown
             color = LivePalette.interviewer
+            rendersMarkdown = true
         }
 
         return HStack(alignment: .top, spacing: 18) {
@@ -125,7 +225,13 @@ struct SystemDesignRoomView: View {
                 Text(role)
                     .font(.system(.caption, design: .monospaced, weight: .bold))
                     .foregroundStyle(color)
-                Text(.init(body))
+                Group {
+                    if rendersMarkdown {
+                        Text(.init(body))
+                    } else {
+                        Text(body)
+                    }
+                }
                     .font(.system(.title3, design: .rounded))
                     .textSelection(.enabled)
                     .fixedSize(horizontal: false, vertical: true)
@@ -147,8 +253,8 @@ struct SystemDesignRoomView: View {
                 Spacer()
                 Text("Draft revision \(model.snapshot?.revision ?? 0)")
                     .foregroundStyle(LivePalette.muted)
-                Button("Attach revision") {}
-                    .disabled(true)
+                Label("Reference draft · read-only", systemImage: "lock")
+                    .foregroundStyle(LivePalette.muted)
             }
             .padding(.horizontal, 20)
             .frame(height: 52)
@@ -182,6 +288,31 @@ struct SystemDesignRoomView: View {
             Capsule()
                 .fill(LivePalette.liveSignal.opacity(0.72))
                 .frame(height: 3)
+
+            if model.canStopRecording {
+                Button {
+                    Task { await model.stopRecording() }
+                } label: {
+                    Label(model.stopActionTitle, systemImage: model.stopActionIcon)
+                        .font(.system(.body, design: .rounded, weight: .semibold))
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(LivePalette.handoff)
+                .disabled(model.isWorking)
+                .keyboardShortcut(.space, modifiers: [.command])
+            } else if model.showsRecordControl {
+                Button {
+                    Task { await model.recordSegment() }
+                } label: {
+                    Label(model.recordActionTitle, systemImage: "record.circle")
+                        .font(.system(.body, design: .rounded, weight: .semibold))
+                }
+                .buttonStyle(.bordered)
+                .tint(LivePalette.paper)
+                .disabled(!model.canRecordSegment)
+                .keyboardShortcut(.space, modifiers: [.command])
+            }
+
             Button {
                 Task { await model.performPrimaryAction() }
             } label: {
@@ -209,9 +340,37 @@ struct SystemDesignRoomView: View {
         default: "Preparing room"
         }
     }
+
+    private var segmentCountLabel: String {
+        let count = model.segments.count
+        return count == 1 ? "1 SEGMENT" : "\(count) SEGMENTS"
+    }
+
+    private func recoveryBanner(_ message: String) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(LivePalette.warning)
+                .accessibilityHidden(true)
+            Text(message)
+                .font(.system(.callout, design: .rounded, weight: .medium))
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer()
+            if model.needsGroqCredential {
+                Button("Add Groq key") {
+                    model.presentCredentialSetup()
+                }
+            }
+        }
+        .padding(.horizontal, 24)
+        .padding(.vertical, 10)
+        .background(LivePalette.warning.opacity(0.12))
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(LivePalette.warning.opacity(0.5)).frame(height: 1)
+        }
+    }
 }
 
-private enum LivePalette {
+enum LivePalette {
     static let room = Color(red: 232 / 255, green: 239 / 255, blue: 236 / 255)
     static let paper = Color(red: 251 / 255, green: 252 / 255, blue: 250 / 255)
     static let ink = Color(red: 16 / 255, green: 42 / 255, blue: 42 / 255)
@@ -222,6 +381,7 @@ private enum LivePalette {
     static let interviewer = Color(red: 88 / 255, green: 105 / 255, blue: 201 / 255)
     static let handoff = Color(red: 223 / 255, green: 102 / 255, blue: 63 / 255)
     static let liveSignal = Color(red: 185 / 255, green: 219 / 255, blue: 87 / 255)
+    static let warning = Color(red: 176 / 255, green: 78 / 255, blue: 39 / 255)
 }
 
 private struct LiveMark: View {

--- a/Sources/InterviewArcLiveCore/FileSessionManifestStore.swift
+++ b/Sources/InterviewArcLiveCore/FileSessionManifestStore.swift
@@ -8,12 +8,16 @@ import Foundation
 /// complete destination remains readable.
 public actor FileSessionManifestStore: SessionManifestStore {
     private let directoryURL: URL
+    private let privateDirectoryHierarchy: [URL]
     private let replace: @Sendable (_ destination: URL, _ prepared: URL) throws -> Void
     private let encoder: JSONEncoder
     private let decoder: JSONDecoder
 
     public init(directoryURL: URL) {
-        self.init(directoryURL: directoryURL) { destination, prepared in
+        self.init(
+            directoryURL: directoryURL,
+            privateDirectoryHierarchy: [directoryURL]
+        ) { destination, prepared in
             _ = try FileManager.default.replaceItemAt(
                 destination,
                 withItemAt: prepared,
@@ -24,9 +28,22 @@ public actor FileSessionManifestStore: SessionManifestStore {
     }
 
     public init() throws {
-        self.init(
-            directoryURL: try LivePaths.sessionManifestsDirectory()
+        let root = try LivePaths.applicationSupportRoot()
+        let manifests = root.appendingPathComponent(
+            "SessionManifests",
+            isDirectory: true
         )
+        self.init(
+            directoryURL: manifests,
+            privateDirectoryHierarchy: [root, manifests]
+        ) { destination, prepared in
+            _ = try FileManager.default.replaceItemAt(
+                destination,
+                withItemAt: prepared,
+                backupItemName: nil,
+                options: []
+            )
+        }
     }
 
     init(
@@ -36,7 +53,40 @@ public actor FileSessionManifestStore: SessionManifestStore {
             _ prepared: URL
         ) throws -> Void
     ) {
+        self.init(
+            directoryURL: directoryURL,
+            privateDirectoryHierarchy: [directoryURL],
+            replace: replace
+        )
+    }
+
+    init(
+        directoryURL: URL,
+        privateDirectoryHierarchy: [URL]
+    ) {
+        self.init(
+            directoryURL: directoryURL,
+            privateDirectoryHierarchy: privateDirectoryHierarchy
+        ) { destination, prepared in
+            _ = try FileManager.default.replaceItemAt(
+                destination,
+                withItemAt: prepared,
+                backupItemName: nil,
+                options: []
+            )
+        }
+    }
+
+    init(
+        directoryURL: URL,
+        privateDirectoryHierarchy: [URL],
+        replace: @escaping @Sendable (
+            _ destination: URL,
+            _ prepared: URL
+        ) throws -> Void
+    ) {
         self.directoryURL = directoryURL
+        self.privateDirectoryHierarchy = privateDirectoryHierarchy
         self.replace = replace
 
         let encoder = JSONEncoder()
@@ -57,6 +107,7 @@ public actor FileSessionManifestStore: SessionManifestStore {
         guard FileManager.default.fileExists(atPath: manifestURL.path) else {
             return nil
         }
+        try securePrivateFile(manifestURL)
 
         let manifest = try decoder.decode(
             SessionManifest.self,
@@ -113,7 +164,12 @@ public actor FileSessionManifestStore: SessionManifestStore {
         }
 
         try encoder.encode(manifest).write(to: prepared, options: [.atomic])
+        try securePrivateFile(prepared)
 
+        // Both the existing destination (secured by `loadUnlocked`) and the
+        // prepared replacement are already 0600. Do not add a fallible chmod
+        // after the atomic commit, which could report failure after new state
+        // is durable.
         if current == nil {
             try FileManager.default.moveItem(at: prepared, to: destination)
         } else {
@@ -122,10 +178,23 @@ public actor FileSessionManifestStore: SessionManifestStore {
     }
 
     private func prepareDirectory() throws {
-        try FileManager.default.createDirectory(
-            at: directoryURL,
-            withIntermediateDirectories: true,
-            attributes: [.posixPermissions: 0o700]
+        for directory in privateDirectoryHierarchy {
+            try FileManager.default.createDirectory(
+                at: directory,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700]
+            )
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o700],
+                ofItemAtPath: directory.path
+            )
+        }
+    }
+
+    private func securePrivateFile(_ url: URL) throws {
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600],
+            ofItemAtPath: url.path
         )
     }
 

--- a/Sources/InterviewArcLiveCore/InterviewRoomSession.swift
+++ b/Sources/InterviewArcLiveCore/InterviewRoomSession.swift
@@ -1,9 +1,34 @@
-import Foundation
 import CryptoKit
+import Foundation
 
 public enum InterviewRoomCommand: Codable, Sendable, Equatable {
     case giveCandidateFloor(commandID: CommandID)
     case setTurnMode(commandID: CommandID, mode: TurnMode)
+    case beginSegment(commandID: CommandID)
+    case finalizeSegment(commandID: CommandID, segmentID: SegmentID)
+    case recordSegmentCaptureOutcome(
+        commandID: CommandID,
+        segmentID: SegmentID,
+        outcome: SegmentCaptureOutcome
+    )
+    case authorizeSegmentTranscription(
+        commandID: CommandID,
+        segmentID: SegmentID,
+        kind: SegmentTranscriptionKind,
+        credentialFingerprint: String
+    )
+    case recordSegmentTranscriptionOutcome(
+        commandID: CommandID,
+        segmentID: SegmentID,
+        attemptID: TranscriptionAttemptID,
+        outcome: SegmentTranscriptionOutcome
+    )
+    case excludeSegment(
+        commandID: CommandID,
+        segmentID: SegmentID,
+        reason: SegmentExclusionReason
+    )
+    case handOffSegments(commandID: CommandID)
     case handOff(commandID: CommandID, transcript: CandidateTranscript)
     case retryInterviewerResponse(commandID: CommandID)
     case finish(commandID: CommandID)
@@ -12,11 +37,36 @@ public enum InterviewRoomCommand: Codable, Sendable, Equatable {
         switch self {
         case .giveCandidateFloor(let commandID),
              .setTurnMode(let commandID, _),
+             .beginSegment(let commandID),
+             .finalizeSegment(let commandID, _),
+             .recordSegmentCaptureOutcome(let commandID, _, _),
+             .authorizeSegmentTranscription(let commandID, _, _, _),
+             .recordSegmentTranscriptionOutcome(let commandID, _, _, _),
+             .excludeSegment(let commandID, _, _),
+             .handOffSegments(let commandID),
              .handOff(let commandID, _),
              .retryInterviewerResponse(let commandID),
              .finish(let commandID):
             commandID
         }
+    }
+}
+
+public enum InterviewRoomCommandDisposition: Sendable, Equatable {
+    case accepted
+    case alreadyApplied
+}
+
+/// A command receipt lets the coordinator distinguish a newly persisted
+/// authorization from an idempotent replay before invoking an external side
+/// effect.
+public struct InterviewRoomCommandApplication: Sendable, Equatable {
+    public let snapshot: InterviewRoomSnapshot
+    public let disposition: InterviewRoomCommandDisposition
+
+    init(snapshot: InterviewRoomSnapshot, disposition: InterviewRoomCommandDisposition) {
+        self.snapshot = snapshot
+        self.disposition = disposition
     }
 }
 
@@ -31,11 +81,26 @@ public enum InterviewRoomSessionError: Error, Sendable, Equatable {
     case commandIDReused(CommandID)
     case commandInProgress
     case commandEncodingFailed
+    case segmentAlreadyActive(SegmentID)
+    case segmentNotFound(SegmentID)
+    case invalidSegmentTransition(segmentID: SegmentID, lifecycle: CandidateSegmentLifecycle)
+    case invalidCapturedAudio
+    case transcriptionAlreadyInProgress(TranscriptionAttemptID)
+    case transcriptionAttemptNotFound(TranscriptionAttemptID)
+    case invalidTranscriptionAttemptKind
+    case invalidCredentialFingerprint
+    case rejectedCredentialUnchanged
+    case segmentHasInsufficientSignal(SegmentID)
+    case invalidTranscriptionOutcome
+    case noTranscribedSegments
+    case unresolvedSegmentsPreventHandOff([SegmentID])
+    case uncommittedSegmentsRequireSegmentHandOff
 }
 
-/// Deep Module owning Interview Room ordering, transitions, idempotency, and
-/// persist-before-publish behavior. Callers submit commands and receive only
-/// immutable snapshots; they cannot mutate the Session Manifest directly.
+/// Deep Module owning Interview Room ordering, transitions, idempotency,
+/// deterministic candidate selection, and persist-before-side-effect rules.
+/// Callers receive immutable snapshots and command receipts; SwiftUI never
+/// mutates the Session Manifest or orchestrates providers directly.
 public actor InterviewRoomSession {
     private var manifest: SessionManifest
     private let manifestStore: any SessionManifestStore
@@ -73,6 +138,7 @@ public actor InterviewRoomSession {
             phase: .ready,
             turnMode: turnMode,
             turns: [],
+            segments: [],
             revision: 0,
             appliedCommands: []
         )
@@ -109,9 +175,18 @@ public actor InterviewRoomSession {
         InterviewRoomSnapshot(manifest: manifest)
     }
 
-    /// Applies one command serially. An accepted transition is persisted before
-    /// it becomes observable through `snapshot()` or this return value.
+    /// Compatibility Interface for callers that do not own an external side
+    /// effect. New capture/transcription orchestration uses `apply(_:)` so it
+    /// can inspect the durable authorization disposition.
     public func execute(_ command: InterviewRoomCommand) async throws -> InterviewRoomSnapshot {
+        try await apply(command).snapshot
+    }
+
+    /// Applies one command serially and reports whether this invocation wrote
+    /// the authorization or merely observed a prior identical command.
+    public func apply(
+        _ command: InterviewRoomCommand
+    ) async throws -> InterviewRoomCommandApplication {
         guard !isExecutingCommand else {
             throw InterviewRoomSessionError.commandInProgress
         }
@@ -127,26 +202,44 @@ public actor InterviewRoomSession {
             guard applied.payloadFingerprint == fingerprint else {
                 throw InterviewRoomSessionError.commandIDReused(command.commandID)
             }
-            return InterviewRoomSnapshot(manifest: manifest)
+            return InterviewRoomCommandApplication(
+                snapshot: InterviewRoomSnapshot(manifest: manifest),
+                disposition: .alreadyApplied
+            )
         }
 
+        let snapshot: InterviewRoomSnapshot
         switch command {
         case .handOff(let commandID, let transcript):
-            return try await handOff(
+            snapshot = try await handOff(
                 commandID: commandID,
                 transcript: transcript,
+                segmentIDs: [],
                 fingerprint: fingerprint
             )
-        case .retryInterviewerResponse(let commandID):
-            return try await retryInterviewerResponse(
+
+        case .handOffSegments(let commandID):
+            snapshot = try await handOffSegments(
                 commandID: commandID,
                 fingerprint: fingerprint
             )
+
+        case .retryInterviewerResponse(let commandID):
+            snapshot = try await retryInterviewerResponse(
+                commandID: commandID,
+                fingerprint: fingerprint
+            )
+
         default:
             let next = try applyingImmediate(command, fingerprint: fingerprint)
             try await persist(next)
-            return InterviewRoomSnapshot(manifest: next)
+            snapshot = InterviewRoomSnapshot(manifest: next)
         }
+
+        return InterviewRoomCommandApplication(
+            snapshot: snapshot,
+            disposition: .accepted
+        )
     }
 
     private func applyingImmediate(
@@ -155,7 +248,7 @@ public actor InterviewRoomSession {
     ) throws -> SessionManifest {
         var phase = manifest.phase
         var mode = manifest.turnMode
-        let turns = manifest.turns
+        var segments = manifest.segments
 
         switch command {
         case .giveCandidateFloor:
@@ -170,7 +263,132 @@ public actor InterviewRoomSession {
             }
             mode = selectedMode
 
-        case .handOff, .retryInterviewerResponse:
+        case .beginSegment(let commandID):
+            guard phase == .candidateFloor else {
+                throw invalidTransition("beginSegment")
+            }
+            if let active = segments.first(where: Self.isActiveSegment) {
+                throw InterviewRoomSessionError.segmentAlreadyActive(active.id)
+            }
+            let segmentID = Self.segmentID(
+                sessionID: manifest.sessionID,
+                commandID: commandID
+            )
+            let identity = try SegmentAudioIdentity(
+                validating: Self.segmentFileName(segmentID: segmentID)
+            )
+            segments.append(
+                CandidateSegment(
+                    id: segmentID,
+                    ordinal: segments.count,
+                    reservationCommandID: commandID,
+                    reservedAudioIdentity: identity,
+                    lifecycle: .captureAuthorized
+                )
+            )
+
+        case .finalizeSegment(_, let segmentID):
+            let index = try segmentIndex(segmentID, in: segments)
+            guard segments[index].lifecycle == .captureAuthorized
+                    || segments[index].lifecycle == .recording
+                    || segments[index].lifecycle == .finalizationAuthorized else {
+                throw InterviewRoomSessionError.invalidSegmentTransition(
+                    segmentID: segmentID,
+                    lifecycle: segments[index].lifecycle
+                )
+            }
+            segments[index].lifecycle = .finalizationAuthorized
+
+        case .recordSegmentCaptureOutcome(_, let segmentID, let outcome):
+            let index = try segmentIndex(segmentID, in: segments)
+            try applyCaptureOutcome(outcome, to: &segments[index])
+
+        case .authorizeSegmentTranscription(
+            let commandID,
+            let segmentID,
+            let kind,
+            let credentialFingerprint
+        ):
+            try Self.validateCredentialFingerprint(credentialFingerprint)
+            if let activeAttempt = segments.lazy
+                .flatMap(\.transcriptionAttempts)
+                .first(where: { $0.state == .authorized }) {
+                throw InterviewRoomSessionError.transcriptionAlreadyInProgress(activeAttempt.id)
+            }
+
+            let index = try segmentIndex(segmentID, in: segments)
+            guard let capturedAudio = segments[index].capturedAudio,
+                  capturedAudio.isPlayable,
+                  segments[index].lifecycle == .audioReady
+                    || segments[index].lifecycle == .transcribed else {
+                throw InterviewRoomSessionError.invalidSegmentTransition(
+                    segmentID: segmentID,
+                    lifecycle: segments[index].lifecycle
+                )
+            }
+            if capturedAudio.integrityReasons.contains(.insufficientSignal) {
+                throw InterviewRoomSessionError.segmentHasInsufficientSignal(segmentID)
+            }
+
+            let attempts = segments[index].transcriptionAttempts
+            switch kind {
+            case .initial where !attempts.isEmpty,
+                 .retry where attempts.isEmpty:
+                throw InterviewRoomSessionError.invalidTranscriptionAttemptKind
+            default:
+                break
+            }
+
+            if kind == .retry,
+               attempts.contains(where: {
+                   $0.failure?.reason == .credentialRejected
+                       && $0.credentialFingerprint == credentialFingerprint
+               }) {
+                throw InterviewRoomSessionError.rejectedCredentialUnchanged
+            }
+
+            let attemptID = Self.attemptID(
+                sessionID: manifest.sessionID,
+                segmentID: segmentID,
+                commandID: commandID
+            )
+            segments[index].transcriptionAttempts.append(
+                SegmentTranscriptionAttempt(
+                    id: attemptID,
+                    authorizationCommandID: commandID,
+                    kind: kind,
+                    credentialFingerprint: credentialFingerprint
+                )
+            )
+            segments[index].lifecycle = .transcribing
+
+        case .recordSegmentTranscriptionOutcome(
+            _,
+            let segmentID,
+            let attemptID,
+            let outcome
+        ):
+            let index = try segmentIndex(segmentID, in: segments)
+            try applyTranscriptionOutcome(
+                outcome,
+                attemptID: attemptID,
+                to: &segments[index]
+            )
+
+        case .excludeSegment(_, let segmentID, let reason):
+            let index = try segmentIndex(segmentID, in: segments)
+            guard segments[index].committedTurnID == nil,
+                  !Self.isActiveSegment(segments[index]),
+                  segments[index].lifecycle != .transcribing else {
+                throw InterviewRoomSessionError.invalidSegmentTransition(
+                    segmentID: segmentID,
+                    lifecycle: segments[index].lifecycle
+                )
+            }
+            segments[index].lifecycle = .excluded
+            segments[index].exclusionReason = reason
+
+        case .handOff, .handOffSegments, .retryInterviewerResponse:
             preconditionFailure("Provider commands use their durable two-stage paths")
 
         case .finish:
@@ -180,37 +398,194 @@ public actor InterviewRoomSession {
             phase = .completed
         }
 
-        let nextRevision = manifest.revision + 1
-        let applied = AppliedCommandRecord(
-            commandID: command.commandID,
-            payloadFingerprint: fingerprint,
-            resultingRevision: nextRevision
-        )
-        return SessionManifest(
-            sessionID: manifest.sessionID,
-            activityID: manifest.activityID,
+        return appendingReceipt(
+            command: command,
+            fingerprint: fingerprint,
             phase: phase,
             turnMode: mode,
-            turns: turns,
-            revision: nextRevision,
-            appliedCommands: manifest.appliedCommands + [applied]
+            turns: manifest.turns,
+            segments: segments
         )
     }
 
-    /// Hand off is deliberately two durable transitions. The Candidate Turn is
-    /// saved before provider work starts, so a provider failure cannot erase an
-    /// accepted answer. Retrying the same Hand off only returns that pending
-    /// state; response recovery is an explicit command.
-    private func handOff(
+    private func applyCaptureOutcome(
+        _ outcome: SegmentCaptureOutcome,
+        to segment: inout CandidateSegment
+    ) throws {
+        switch outcome {
+        case .recordingStarted:
+            guard segment.lifecycle == .captureAuthorized else {
+                throw InterviewRoomSessionError.invalidSegmentTransition(
+                    segmentID: segment.id,
+                    lifecycle: segment.lifecycle
+                )
+            }
+            segment.lifecycle = .recording
+
+        case .finalized(let capture):
+            guard segment.lifecycle == .finalizationAuthorized,
+                  capture.isPlayable,
+                  capture.byteCount > 0,
+                  capture.startedAtMilliseconds >= 0,
+                  capture.endedAtMilliseconds >= capture.startedAtMilliseconds,
+                  capture.durationMilliseconds >= 0,
+                  capture.decodedDurationMilliseconds > 0 else {
+                throw InterviewRoomSessionError.invalidCapturedAudio
+            }
+            segment.capturedAudio = capture
+            segment.captureFailureReason = nil
+            segment.lifecycle = .audioReady
+
+        case .failed(let reason):
+            guard segment.lifecycle == .captureAuthorized
+                    || segment.lifecycle == .recording
+                    || segment.lifecycle == .finalizationAuthorized else {
+                throw InterviewRoomSessionError.invalidSegmentTransition(
+                    segmentID: segment.id,
+                    lifecycle: segment.lifecycle
+                )
+            }
+            segment.captureFailureReason = reason
+            segment.lifecycle = .failed
+        }
+    }
+
+    private func applyTranscriptionOutcome(
+        _ outcome: SegmentTranscriptionOutcome,
+        attemptID: TranscriptionAttemptID,
+        to segment: inout CandidateSegment
+    ) throws {
+        guard let attemptIndex = segment.transcriptionAttempts.firstIndex(where: {
+            $0.id == attemptID
+        }) else {
+            throw InterviewRoomSessionError.transcriptionAttemptNotFound(attemptID)
+        }
+        guard segment.lifecycle == .transcribing,
+              segment.transcriptionAttempts[attemptIndex].state == .authorized else {
+            throw InterviewRoomSessionError.invalidSegmentTransition(
+                segmentID: segment.id,
+                lifecycle: segment.lifecycle
+            )
+        }
+
+        switch outcome {
+        case .candidate(let result):
+            guard !result.body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                throw InterviewRoomSessionError.invalidTranscriptionOutcome
+            }
+            let candidateID = Self.candidateID(attemptID: attemptID)
+            let candidate = SegmentTranscriptCandidate(
+                id: candidateID,
+                attemptID: attemptID,
+                body: result.body,
+                quality: result.quality,
+                integrityReasons: result.integrityReasons
+            )
+            segment.transcriptCandidates.append(candidate)
+            segment.transcriptionAttempts[attemptIndex].state = .candidateStored
+            segment.transcriptionAttempts[attemptIndex].candidateID = candidateID
+            segment.transcriptionAttempts[attemptIndex].failure = nil
+            segment.selectedCandidateID = Self.bestCandidate(
+                in: segment.transcriptCandidates
+            )?.id
+            segment.lifecycle = .transcribed
+
+        case .failed(let failure):
+            let attempt = segment.transcriptionAttempts[attemptIndex]
+            if let persistedFingerprint = failure.credentialFingerprint,
+               persistedFingerprint != attempt.credentialFingerprint {
+                throw InterviewRoomSessionError.invalidTranscriptionOutcome
+            }
+            segment.transcriptionAttempts[attemptIndex].state = .failed
+            segment.transcriptionAttempts[attemptIndex].failure = failure
+            segment.lifecycle = segment.selectedCandidateID == nil ? .audioReady : .transcribed
+        }
+    }
+
+    private func handOffSegments(
         commandID: CommandID,
-        transcript: CandidateTranscript,
         fingerprint: String
     ) async throws -> InterviewRoomSnapshot {
         guard manifest.phase == .candidateFloor else {
-            throw invalidTransition("handOff")
+            throw invalidTransition("handOffSegments")
+        }
+        guard !manifest.segments.contains(where: Self.isActiveSegment),
+              !manifest.segments.contains(where: { $0.lifecycle == .transcribing }) else {
+            throw invalidTransition("handOffSegments")
+        }
+
+        let selectedSegments = manifest.segments
+            .filter {
+                $0.committedTurnID == nil
+                    && $0.lifecycle != .excluded
+                    && $0.selectedCandidate != nil
+            }
+            .sorted { $0.ordinal < $1.ordinal }
+        let excludedSegments = manifest.segments
+            .filter { $0.committedTurnID == nil && $0.lifecycle == .excluded }
+            .sorted { $0.ordinal < $1.ordinal }
+        let unresolved = manifest.segments
+            .filter {
+                $0.committedTurnID == nil
+                    && $0.lifecycle != .excluded
+                    && $0.selectedCandidate == nil
+            }
+            .map(\.id)
+        guard unresolved.isEmpty else {
+            throw InterviewRoomSessionError.unresolvedSegmentsPreventHandOff(unresolved)
+        }
+        guard !selectedSegments.isEmpty else {
+            throw InterviewRoomSessionError.noTranscribedSegments
+        }
+
+        let bodies = selectedSegments.compactMap { segment in
+            segment.selectedCandidate?.body.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        guard bodies.count == selectedSegments.count,
+              bodies.allSatisfy({ !$0.isEmpty }) else {
+            throw InterviewRoomSessionError.emptyCandidateTranscript
+        }
+
+        let qualities = selectedSegments.compactMap { $0.selectedCandidate?.quality }
+        let quality: TranscriptQuality
+        if qualities.contains(.possibleContamination) {
+            quality = .possibleContamination
+        } else if qualities.contains(.bestAvailable) {
+            quality = .bestAvailable
+        } else {
+            quality = .verified
+        }
+
+        return try await handOff(
+            commandID: commandID,
+            transcript: CandidateTranscript(
+                body: bodies.joined(separator: "\n\n"),
+                quality: quality
+            ),
+            segmentIDs: (selectedSegments + excludedSegments)
+                .sorted { $0.ordinal < $1.ordinal }
+                .map(\.id),
+            fingerprint: fingerprint
+        )
+    }
+
+    /// Hand off is deliberately two durable transitions. The Candidate Turn
+    /// and its Segment associations are saved before provider work starts.
+    private func handOff(
+        commandID: CommandID,
+        transcript: CandidateTranscript,
+        segmentIDs: [SegmentID],
+        fingerprint: String
+    ) async throws -> InterviewRoomSnapshot {
+        guard manifest.phase == .candidateFloor else {
+            throw invalidTransition(segmentIDs.isEmpty ? "handOff" : "handOffSegments")
         }
         guard !transcript.body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw InterviewRoomSessionError.emptyCandidateTranscript
+        }
+        if segmentIDs.isEmpty,
+           manifest.segments.contains(where: { $0.committedTurnID == nil }) {
+            throw InterviewRoomSessionError.uncommittedSegmentsRequireSegmentHandOff
         }
 
         let candidate = CandidateTurn(
@@ -220,8 +595,20 @@ public actor InterviewRoomSession {
                 role: "candidate"
             ),
             commandID: commandID,
-            transcript: transcript
+            transcript: transcript,
+            segmentIDs: segmentIDs
         )
+        var segments = manifest.segments
+        for segmentID in segmentIDs {
+            let index = try segmentIndex(segmentID, in: segments)
+            guard segments[index].committedTurnID == nil else {
+                throw InterviewRoomSessionError.invalidManifest(
+                    reason: "segment cannot be committed twice"
+                )
+            }
+            segments[index].committedTurnID = candidate.id
+        }
+
         let candidateRevision = manifest.revision + 1
         let receipt = AppliedCommandRecord(
             commandID: commandID,
@@ -234,14 +621,13 @@ public actor InterviewRoomSession {
             phase: .interviewerProcessing,
             turnMode: manifest.turnMode,
             turns: manifest.turns + [.candidate(candidate)],
+            segments: segments,
             revision: candidateRevision,
             appliedCommands: manifest.appliedCommands + [receipt]
         )
         try await persist(awaitingResponse)
 
-        return try await completeInterviewerResponse(
-            for: candidate
-        )
+        return try await completeInterviewerResponse(for: candidate)
     }
 
     private func retryInterviewerResponse(
@@ -263,14 +649,13 @@ public actor InterviewRoomSession {
             phase: .interviewerProcessing,
             turnMode: manifest.turnMode,
             turns: manifest.turns,
+            segments: manifest.segments,
             revision: manifest.revision + 1,
             appliedCommands: manifest.appliedCommands + [receipt]
         )
         try await persist(pendingRetry)
 
-        return try await completeInterviewerResponse(
-            for: candidate
-        )
+        return try await completeInterviewerResponse(for: candidate)
     }
 
     private func completeInterviewerResponse(
@@ -304,6 +689,7 @@ public actor InterviewRoomSession {
             phase: .interviewerTurn,
             turnMode: manifest.turnMode,
             turns: manifest.turns + [.interviewer(interviewer)],
+            segments: manifest.segments,
             revision: manifest.revision + 1,
             appliedCommands: manifest.appliedCommands
         )
@@ -311,13 +697,106 @@ public actor InterviewRoomSession {
         return InterviewRoomSnapshot(manifest: completed)
     }
 
+    private func appendingReceipt(
+        command: InterviewRoomCommand,
+        fingerprint: String,
+        phase: InterviewRoomPhase,
+        turnMode: TurnMode,
+        turns: [InterviewTurn],
+        segments: [CandidateSegment]
+    ) -> SessionManifest {
+        let nextRevision = manifest.revision + 1
+        let applied = AppliedCommandRecord(
+            commandID: command.commandID,
+            payloadFingerprint: fingerprint,
+            resultingRevision: nextRevision
+        )
+        return SessionManifest(
+            sessionID: manifest.sessionID,
+            activityID: manifest.activityID,
+            phase: phase,
+            turnMode: turnMode,
+            turns: turns,
+            segments: segments,
+            revision: nextRevision,
+            appliedCommands: manifest.appliedCommands + [applied]
+        )
+    }
+
     private func persist(_ next: SessionManifest) async throws {
         try await manifestStore.save(next, expectedRevision: manifest.revision)
         manifest = next
     }
 
+    private func segmentIndex(
+        _ segmentID: SegmentID,
+        in segments: [CandidateSegment]
+    ) throws -> Int {
+        guard let index = segments.firstIndex(where: { $0.id == segmentID }) else {
+            throw InterviewRoomSessionError.segmentNotFound(segmentID)
+        }
+        return index
+    }
+
     private func invalidTransition(_ command: String) -> InterviewRoomSessionError {
         .invalidTransition(command: command, phase: manifest.phase)
+    }
+
+    private static func isActiveSegment(_ segment: CandidateSegment) -> Bool {
+        segment.lifecycle == .captureAuthorized
+            || segment.lifecycle == .recording
+            || segment.lifecycle == .finalizationAuthorized
+    }
+
+    private static func bestCandidate(
+        in candidates: [SegmentTranscriptCandidate]
+    ) -> SegmentTranscriptCandidate? {
+        var best: SegmentTranscriptCandidate?
+        for candidate in candidates {
+            guard let current = best else {
+                best = candidate
+                continue
+            }
+            if isBetter(candidate, than: current) {
+                best = candidate
+            }
+        }
+        return best
+    }
+
+    private static func isBetter(
+        _ candidate: SegmentTranscriptCandidate,
+        than current: SegmentTranscriptCandidate
+    ) -> Bool {
+        let candidateScore = transcriptScore(candidate)
+        let currentScore = transcriptScore(current)
+        if candidateScore.quality != currentScore.quality {
+            return candidateScore.quality > currentScore.quality
+        }
+        if candidateScore.words != currentScore.words {
+            return candidateScore.words > currentScore.words
+        }
+        if candidateScore.characters != currentScore.characters {
+            return candidateScore.characters > currentScore.characters
+        }
+        return false
+    }
+
+    private static func transcriptScore(
+        _ candidate: SegmentTranscriptCandidate
+    ) -> (quality: Int, words: Int, characters: Int) {
+        let quality: Int
+        switch candidate.quality {
+        case .verified: quality = 3
+        case .bestAvailable: quality = 2
+        case .possibleContamination: quality = 1
+        }
+        let normalized = candidate.body.trimmingCharacters(in: .whitespacesAndNewlines)
+        return (
+            quality,
+            normalized.split(whereSeparator: { $0.isWhitespace }).count,
+            normalized.count
+        )
     }
 
     private static func fingerprint(for command: InterviewRoomCommand) throws -> String {
@@ -331,8 +810,57 @@ public actor InterviewRoomSession {
         }
         var versionedPayload = Data("interview-room-command:v1\n".utf8)
         versionedPayload.append(encodedCommand)
-        let digest = SHA256.hash(data: versionedPayload)
-        return "sha256:v1:" + digest.map { String(format: "%02x", $0) }.joined()
+        return digest(versionedPayload, namespace: "command")
+    }
+
+    static func credentialFingerprint(_ credential: String) -> String {
+        digest(Data(credential.utf8), namespace: "groq-credential")
+    }
+
+    static func derivedCommandID(
+        source: CommandID,
+        operation: String
+    ) -> CommandID {
+        CommandID(stableIdentity(
+            namespace: "derived-command",
+            fields: [source.rawValue, operation]
+        ))
+    }
+
+    private static func segmentID(
+        sessionID: SessionID,
+        commandID: CommandID
+    ) -> SegmentID {
+        SegmentID(stableIdentity(
+            namespace: "segment",
+            fields: [sessionID.rawValue, commandID.rawValue]
+        ))
+    }
+
+    private static func segmentFileName(segmentID: SegmentID) -> String {
+        let suffix = segmentID.rawValue.split(separator: ":").last.map(String.init)
+            ?? segmentID.rawValue
+        return "segment-\(suffix).m4a"
+    }
+
+    private static func attemptID(
+        sessionID: SessionID,
+        segmentID: SegmentID,
+        commandID: CommandID
+    ) -> TranscriptionAttemptID {
+        TranscriptionAttemptID(stableIdentity(
+            namespace: "transcription-attempt",
+            fields: [sessionID.rawValue, segmentID.rawValue, commandID.rawValue]
+        ))
+    }
+
+    private static func candidateID(
+        attemptID: TranscriptionAttemptID
+    ) -> TranscriptCandidateID {
+        TranscriptCandidateID(stableIdentity(
+            namespace: "transcript-candidate",
+            fields: [attemptID.rawValue]
+        ))
     }
 
     private static func turnID(
@@ -340,19 +868,34 @@ public actor InterviewRoomSession {
         commandID: CommandID,
         role: String
     ) -> TurnID {
+        TurnID(stableIdentity(
+            namespace: "turn",
+            fields: [sessionID.rawValue, commandID.rawValue, role]
+        ))
+    }
+
+    private static func stableIdentity(
+        namespace: String,
+        fields: [String]
+    ) -> String {
         var tuple = Data()
-        for field in [
-            "interview-room-turn-id",
-            "v1",
-            sessionID.rawValue,
-            commandID.rawValue,
-            role,
-        ] {
+        for field in ["interview-arc-live", namespace, "v1"] + fields {
             appendLengthPrefixed(field, to: &tuple)
         }
-        let digest = SHA256.hash(data: tuple)
-        let hex = digest.map { String(format: "%02x", $0) }.joined()
-        return TurnID("turn:sha256:v1:\(hex)")
+        return "\(namespace):sha256:v1:\(hexDigest(tuple))"
+    }
+
+    private static func digest(_ data: Data, namespace: String) -> String {
+        var versioned = Data()
+        appendLengthPrefixed("interview-arc-live", to: &versioned)
+        appendLengthPrefixed(namespace, to: &versioned)
+        appendLengthPrefixed("v1", to: &versioned)
+        versioned.append(data)
+        return "sha256:v1:\(hexDigest(versioned))"
+    }
+
+    private static func hexDigest(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
     }
 
     private static func appendLengthPrefixed(_ value: String, to data: inout Data) {
@@ -367,6 +910,16 @@ public actor InterviewRoomSession {
     private static func validateIdentifier(_ value: String, name: String) throws {
         guard !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw InterviewRoomSessionError.emptyIdentifier(name: name)
+        }
+    }
+
+    private static func validateCredentialFingerprint(_ value: String) throws {
+        let prefix = "sha256:v1:"
+        let suffix = value.dropFirst(prefix.count)
+        guard value.hasPrefix(prefix),
+              suffix.count == 64,
+              suffix.allSatisfy({ $0.isHexDigit }) else {
+            throw InterviewRoomSessionError.invalidCredentialFingerprint
         }
     }
 
@@ -410,6 +963,87 @@ public actor InterviewRoomSession {
                   $0.resultingRevision > 0 && $0.resultingRevision <= manifest.revision
               }) else {
             throw InterviewRoomSessionError.invalidManifest(reason: "invalid command receipts")
+        }
+
+        let segmentIDs = manifest.segments.map(\.id)
+        guard Set(segmentIDs).count == segmentIDs.count,
+              manifest.segments.enumerated().allSatisfy({ $0.offset == $0.element.ordinal }),
+              manifest.segments.filter(isActiveSegment).count <= 1 else {
+            throw InterviewRoomSessionError.invalidManifest(reason: "invalid segment ordering")
+        }
+
+        let candidateTurns: [CandidateTurn] = manifest.turns.compactMap {
+            guard case .candidate(let candidate) = $0 else { return nil }
+            return candidate
+        }
+        let candidateTurnIDs = candidateTurns.map(\.id)
+        guard Set(candidateTurnIDs).count == candidateTurnIDs.count else {
+            throw InterviewRoomSessionError.invalidManifest(
+                reason: "duplicate Candidate Turn IDs"
+            )
+        }
+        let turnByID = Dictionary(uniqueKeysWithValues: candidateTurns.map { ($0.id, $0) })
+        var referencedSegmentIDs = Set<SegmentID>()
+        let segmentByID = Dictionary(uniqueKeysWithValues: manifest.segments.map { ($0.id, $0) })
+        for turn in candidateTurns {
+            guard Set(turn.segmentIDs).count == turn.segmentIDs.count else {
+                throw InterviewRoomSessionError.invalidManifest(
+                    reason: "Candidate Turn references a Segment more than once"
+                )
+            }
+            let referenced = try turn.segmentIDs.map { segmentID -> CandidateSegment in
+                guard let segment = segmentByID[segmentID] else {
+                    throw InterviewRoomSessionError.invalidManifest(
+                        reason: "Candidate Turn references a missing Segment"
+                    )
+                }
+                return segment
+            }
+            guard referenced.map(\.ordinal) == referenced.map(\.ordinal).sorted() else {
+                throw InterviewRoomSessionError.invalidManifest(
+                    reason: "Candidate Turn Segment membership is out of order"
+                )
+            }
+            for segment in referenced {
+                guard referencedSegmentIDs.insert(segment.id).inserted,
+                      segment.committedTurnID == turn.id,
+                      segment.lifecycle == .excluded || segment.selectedCandidate != nil else {
+                    throw InterviewRoomSessionError.invalidManifest(
+                        reason: "Candidate Turn Segment membership is inconsistent"
+                    )
+                }
+            }
+        }
+        for segment in manifest.segments {
+            let attemptIDs = segment.transcriptionAttempts.map(\.id)
+            let candidateIDs = segment.transcriptCandidates.map(\.id)
+            guard Set(attemptIDs).count == attemptIDs.count,
+                  Set(candidateIDs).count == candidateIDs.count,
+                  segment.transcriptionAttempts.filter({ $0.state == .authorized }).count <= 1,
+                  segment.transcriptCandidates.allSatisfy({ attemptIDs.contains($0.attemptID) }) else {
+                throw InterviewRoomSessionError.invalidManifest(
+                    reason: "invalid transcription attempt history"
+                )
+            }
+            if let selected = segment.selectedCandidateID,
+               !candidateIDs.contains(selected) {
+                throw InterviewRoomSessionError.invalidManifest(
+                    reason: "selected candidate does not exist"
+                )
+            }
+            if let committedTurnID = segment.committedTurnID {
+                guard let turn = turnByID[committedTurnID],
+                      turn.segmentIDs.contains(segment.id),
+                      referencedSegmentIDs.contains(segment.id) else {
+                    throw InterviewRoomSessionError.invalidManifest(
+                        reason: "segment commitment does not match Candidate Turn"
+                    )
+                }
+            } else if referencedSegmentIDs.contains(segment.id) {
+                throw InterviewRoomSessionError.invalidManifest(
+                    reason: "uncommitted Segment is referenced by a Candidate Turn"
+                )
+            }
         }
 
         if manifest.phase == .ready && !manifest.turns.isEmpty {

--- a/Sources/InterviewArcLiveCore/InterviewRoomSession.swift
+++ b/Sources/InterviewArcLiveCore/InterviewRoomSession.swift
@@ -424,17 +424,25 @@ public actor InterviewRoomSession {
 
         case .finalized(let capture):
             guard segment.lifecycle == .finalizationAuthorized,
-                  capture.isPlayable,
-                  capture.byteCount > 0,
+                  capture.byteCount >= 0,
                   capture.startedAtMilliseconds >= 0,
                   capture.endedAtMilliseconds >= capture.startedAtMilliseconds,
                   capture.durationMilliseconds >= 0,
-                  capture.decodedDurationMilliseconds > 0 else {
+                  capture.decodedDurationMilliseconds >= 0 else {
                 throw InterviewRoomSessionError.invalidCapturedAudio
             }
             segment.capturedAudio = capture
-            segment.captureFailureReason = nil
-            segment.lifecycle = .audioReady
+            if capture.isPlayable {
+                guard capture.byteCount > 0,
+                      capture.decodedDurationMilliseconds > 0 else {
+                    throw InterviewRoomSessionError.invalidCapturedAudio
+                }
+                segment.captureFailureReason = nil
+                segment.lifecycle = .audioReady
+            } else {
+                segment.captureFailureReason = .noPlayableAudio
+                segment.lifecycle = .failed
+            }
 
         case .failed(let reason):
             guard segment.lifecycle == .captureAuthorized

--- a/Sources/InterviewArcLiveCore/SegmentDomain.swift
+++ b/Sources/InterviewArcLiveCore/SegmentDomain.swift
@@ -1,0 +1,465 @@
+import Foundation
+
+public struct SegmentID: RawRepresentable, Codable, Hashable, Sendable, CustomStringConvertible {
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public var description: String { rawValue }
+}
+
+public struct TranscriptionAttemptID: RawRepresentable, Codable, Hashable, Sendable,
+    CustomStringConvertible
+{
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public var description: String { rawValue }
+}
+
+public struct TranscriptCandidateID: RawRepresentable, Codable, Hashable, Sendable,
+    CustomStringConvertible
+{
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public var description: String { rawValue }
+}
+
+public enum SegmentAudioIdentityError: Error, Codable, Sendable, Equatable {
+    case invalidFileName
+}
+
+/// A portable identity for one Live-owned source M4A.
+///
+/// It is deliberately a filename rather than a path. The recording Adapter
+/// resolves it beneath the session-private root; manifests never contain an
+/// absolute or caller-constructed path.
+public struct SegmentAudioIdentity: Hashable, Sendable, Equatable {
+    public let fileName: String
+
+    public init(validating fileName: String) throws {
+        guard Self.isValid(fileName) else {
+            throw SegmentAudioIdentityError.invalidFileName
+        }
+        self.fileName = fileName
+    }
+
+    private static func isValid(_ fileName: String) -> Bool {
+        guard !fileName.isEmpty,
+              fileName.utf8.count <= 200,
+              !fileName.hasPrefix("."),
+              fileName.lowercased().hasSuffix(".m4a") else {
+            return false
+        }
+
+        let allowed = CharacterSet(
+            charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_ ."
+        )
+        return fileName.unicodeScalars.allSatisfy(allowed.contains)
+            && !fileName.contains(" ")
+            && !fileName.contains("..")
+            && !fileName.contains("/")
+            && !fileName.contains("\\")
+    }
+}
+
+extension SegmentAudioIdentity: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        try self.init(validating: container.decode(String.self))
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(fileName)
+    }
+}
+
+public struct SegmentIntegrityReason: RawRepresentable, Codable, Hashable, Sendable,
+    CustomStringConvertible
+{
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public var description: String { rawValue }
+
+    public static let insufficientSignal = SegmentIntegrityReason("insufficientSignal")
+}
+
+public struct SegmentCaptureRequest: Sendable, Equatable {
+    public let sessionID: SessionID
+    public let segmentID: SegmentID
+    public let reservedAudioIdentity: SegmentAudioIdentity
+
+    public init(
+        sessionID: SessionID,
+        segmentID: SegmentID,
+        reservedAudioIdentity: SegmentAudioIdentity
+    ) {
+        self.sessionID = sessionID
+        self.segmentID = segmentID
+        self.reservedAudioIdentity = reservedAudioIdentity
+    }
+}
+
+/// Live-owned metadata for the source M4A after the recording Adapter has
+/// adopted the authoritative recorder URL beneath its private session root.
+public struct CapturedAudioSegment: Codable, Sendable, Equatable {
+    public let audioIdentity: SegmentAudioIdentity
+    public let startedAtMilliseconds: Int64
+    public let endedAtMilliseconds: Int64
+    public let durationMilliseconds: Int64
+    public let decodedDurationMilliseconds: Int64
+    public let byteCount: Int64
+    public let isPlayable: Bool
+    public let isPartial: Bool
+    public let integrityReasons: [SegmentIntegrityReason]
+
+    public init(
+        audioIdentity: SegmentAudioIdentity,
+        startedAtMilliseconds: Int64,
+        endedAtMilliseconds: Int64,
+        durationMilliseconds: Int64,
+        decodedDurationMilliseconds: Int64,
+        byteCount: Int64,
+        isPlayable: Bool,
+        isPartial: Bool,
+        integrityReasons: [SegmentIntegrityReason] = []
+    ) {
+        self.audioIdentity = audioIdentity
+        self.startedAtMilliseconds = startedAtMilliseconds
+        self.endedAtMilliseconds = endedAtMilliseconds
+        self.durationMilliseconds = durationMilliseconds
+        self.decodedDurationMilliseconds = decodedDurationMilliseconds
+        self.byteCount = byteCount
+        self.isPlayable = isPlayable
+        self.isPartial = isPartial
+        self.integrityReasons = integrityReasons
+    }
+}
+
+public enum SegmentCaptureFailureReason: String, Codable, Sendable, Equatable {
+    case microphoneUnavailable = "microphone_unavailable"
+    case captureStartFailed = "capture_start_failed"
+    case captureFinalizationFailed = "capture_finalization_failed"
+    case noPlayableAudio = "no_playable_audio"
+    case storageFailed = "storage_failed"
+    case interruptedWithoutAudio = "interrupted_without_audio"
+}
+
+public enum SegmentCaptureOutcome: Codable, Sendable, Equatable {
+    case recordingStarted
+    case finalized(CapturedAudioSegment)
+    case failed(SegmentCaptureFailureReason)
+}
+
+public enum SegmentTranscriptionKind: String, Codable, Sendable, Equatable {
+    case initial
+    case retry
+}
+
+public struct SegmentTranscriptionRequest: Sendable, Equatable {
+    public let sessionID: SessionID
+    public let segmentID: SegmentID
+    public let attemptID: TranscriptionAttemptID
+    public let kind: SegmentTranscriptionKind
+    public let audioIdentity: SegmentAudioIdentity
+
+    public init(
+        sessionID: SessionID,
+        segmentID: SegmentID,
+        attemptID: TranscriptionAttemptID,
+        kind: SegmentTranscriptionKind,
+        audioIdentity: SegmentAudioIdentity
+    ) {
+        self.sessionID = sessionID
+        self.segmentID = segmentID
+        self.attemptID = attemptID
+        self.kind = kind
+        self.audioIdentity = audioIdentity
+    }
+}
+
+/// One exact provider result. The caller persists it before authorizing any
+/// later attempt; the session Module never paraphrases a nonempty body.
+public struct SegmentTranscriptionResult: Codable, Sendable, Equatable {
+    public let body: String
+    public let quality: TranscriptQuality
+    public let integrityReasons: [SegmentIntegrityReason]
+
+    public init(
+        body: String,
+        quality: TranscriptQuality,
+        integrityReasons: [SegmentIntegrityReason] = []
+    ) {
+        self.body = body
+        self.quality = quality
+        self.integrityReasons = integrityReasons
+    }
+}
+
+public enum SegmentTranscriptionFailureReason: String, Codable, Sendable, Equatable {
+    case missingCredential = "missing_credential"
+    case credentialRejected = "credential_rejected"
+    case invalidAudio = "invalid_audio"
+    case insufficientSignal = "insufficient_signal"
+    case emptyProviderResult = "empty_provider_result"
+    case providerUnavailable = "provider_unavailable"
+    case interrupted = "interrupted"
+}
+
+public enum SegmentTranscriptionProviderCode: String, Codable, Sendable, Equatable {
+    case unauthorized
+    case rateLimited = "rate_limited"
+    case invalidRequest = "invalid_request"
+    case unavailable
+    case unknown
+}
+
+/// Privacy-safe provider failure metadata. `credentialFingerprint` is a
+/// one-way SHA-256 identity used only to prevent an unchanged rejected key
+/// from being retried forever; a credential value is never persisted.
+public struct SegmentTranscriptionFailure: Codable, Sendable, Equatable {
+    public let reason: SegmentTranscriptionFailureReason
+    public let providerCode: SegmentTranscriptionProviderCode?
+    public let credentialFingerprint: String?
+
+    public init(
+        reason: SegmentTranscriptionFailureReason,
+        providerCode: SegmentTranscriptionProviderCode? = nil,
+        credentialFingerprint: String? = nil
+    ) {
+        self.reason = reason
+        self.providerCode = providerCode
+        self.credentialFingerprint = credentialFingerprint
+    }
+}
+
+/// A domain-safe failure an Adapter may throw without exposing provider body,
+/// prompt, credential, or transcript data to diagnostics.
+public struct SegmentTranscriptionAdapterFailure: Error, Sendable, Equatable {
+    public let reason: SegmentTranscriptionFailureReason
+    public let providerCode: SegmentTranscriptionProviderCode?
+
+    public init(
+        reason: SegmentTranscriptionFailureReason,
+        providerCode: SegmentTranscriptionProviderCode? = nil
+    ) {
+        self.reason = reason
+        self.providerCode = providerCode
+    }
+}
+
+public enum SegmentTranscriptionOutcome: Codable, Sendable, Equatable {
+    case candidate(SegmentTranscriptionResult)
+    case failed(SegmentTranscriptionFailure)
+}
+
+public enum CandidateSegmentLifecycle: String, Codable, Sendable, Equatable {
+    case captureAuthorized = "capture_authorized"
+    case recording
+    case finalizationAuthorized = "finalization_authorized"
+    case audioReady = "audio_ready"
+    case transcribing
+    case transcribed
+    case failed
+    case excluded
+}
+
+public enum SegmentExclusionReason: String, Codable, Sendable, Equatable {
+    case userSkipped = "user_skipped"
+    case noUsableTranscript = "no_usable_transcript"
+    case insufficientSignal = "insufficient_signal"
+    case captureFailed = "capture_failed"
+}
+
+public enum SegmentTranscriptionAttemptState: String, Codable, Sendable, Equatable {
+    case authorized
+    case candidateStored = "candidate_stored"
+    case failed
+}
+
+public struct SegmentTranscriptCandidate: Codable, Sendable, Equatable, Identifiable {
+    public let id: TranscriptCandidateID
+    public let attemptID: TranscriptionAttemptID
+    public let body: String
+    public let quality: TranscriptQuality
+    public let integrityReasons: [SegmentIntegrityReason]
+
+    public init(
+        id: TranscriptCandidateID,
+        attemptID: TranscriptionAttemptID,
+        body: String,
+        quality: TranscriptQuality,
+        integrityReasons: [SegmentIntegrityReason]
+    ) {
+        self.id = id
+        self.attemptID = attemptID
+        self.body = body
+        self.quality = quality
+        self.integrityReasons = integrityReasons
+    }
+}
+
+public struct SegmentTranscriptionAttempt: Codable, Sendable, Equatable, Identifiable {
+    public let id: TranscriptionAttemptID
+    public let authorizationCommandID: CommandID
+    public let kind: SegmentTranscriptionKind
+    public internal(set) var state: SegmentTranscriptionAttemptState
+    public internal(set) var candidateID: TranscriptCandidateID?
+    public internal(set) var credentialFingerprint: String
+    public internal(set) var failure: SegmentTranscriptionFailure?
+
+    init(
+        id: TranscriptionAttemptID,
+        authorizationCommandID: CommandID,
+        kind: SegmentTranscriptionKind,
+        state: SegmentTranscriptionAttemptState = .authorized,
+        candidateID: TranscriptCandidateID? = nil,
+        credentialFingerprint: String,
+        failure: SegmentTranscriptionFailure? = nil
+    ) {
+        self.id = id
+        self.authorizationCommandID = authorizationCommandID
+        self.kind = kind
+        self.state = state
+        self.candidateID = candidateID
+        self.credentialFingerprint = credentialFingerprint
+        self.failure = failure
+    }
+}
+
+public struct CandidateSegment: Codable, Sendable, Equatable, Identifiable {
+    public let id: SegmentID
+    public let ordinal: Int
+    public let reservationCommandID: CommandID
+    public let reservedAudioIdentity: SegmentAudioIdentity
+    public internal(set) var lifecycle: CandidateSegmentLifecycle
+    public internal(set) var capturedAudio: CapturedAudioSegment?
+    public internal(set) var captureFailureReason: SegmentCaptureFailureReason?
+    public internal(set) var transcriptionAttempts: [SegmentTranscriptionAttempt]
+    public internal(set) var transcriptCandidates: [SegmentTranscriptCandidate]
+    public internal(set) var selectedCandidateID: TranscriptCandidateID?
+    public internal(set) var committedTurnID: TurnID?
+    public internal(set) var exclusionReason: SegmentExclusionReason?
+
+    init(
+        id: SegmentID,
+        ordinal: Int,
+        reservationCommandID: CommandID,
+        reservedAudioIdentity: SegmentAudioIdentity,
+        lifecycle: CandidateSegmentLifecycle,
+        capturedAudio: CapturedAudioSegment? = nil,
+        captureFailureReason: SegmentCaptureFailureReason? = nil,
+        transcriptionAttempts: [SegmentTranscriptionAttempt] = [],
+        transcriptCandidates: [SegmentTranscriptCandidate] = [],
+        selectedCandidateID: TranscriptCandidateID? = nil,
+        committedTurnID: TurnID? = nil,
+        exclusionReason: SegmentExclusionReason? = nil
+    ) {
+        self.id = id
+        self.ordinal = ordinal
+        self.reservationCommandID = reservationCommandID
+        self.reservedAudioIdentity = reservedAudioIdentity
+        self.lifecycle = lifecycle
+        self.capturedAudio = capturedAudio
+        self.captureFailureReason = captureFailureReason
+        self.transcriptionAttempts = transcriptionAttempts
+        self.transcriptCandidates = transcriptCandidates
+        self.selectedCandidateID = selectedCandidateID
+        self.committedTurnID = committedTurnID
+        self.exclusionReason = exclusionReason
+    }
+
+    public var selectedCandidate: SegmentTranscriptCandidate? {
+        guard let selectedCandidateID else { return nil }
+        return transcriptCandidates.first { $0.id == selectedCandidateID }
+    }
+
+    public var selectedTranscript: CandidateTranscript? {
+        selectedCandidate.map {
+            CandidateTranscript(body: $0.body, quality: $0.quality)
+        }
+    }
+
+    public var canRetryTranscription: Bool {
+        capturedAudio?.isPlayable == true
+            && capturedAudio?.integrityReasons.contains(.insufficientSignal) == false
+            && !transcriptionAttempts.contains(where: { $0.state == .authorized })
+            && lifecycle != .failed
+            && lifecycle != .excluded
+    }
+
+    public var canExcludeFromAnswer: Bool {
+        committedTurnID == nil
+            && lifecycle != .captureAuthorized
+            && lifecycle != .recording
+            && lifecycle != .finalizationAuthorized
+            && lifecycle != .transcribing
+            && lifecycle != .excluded
+    }
+}
+
+/// Deep capture Adapter: it owns private-root path resolution and adopts the
+/// recorder's authoritative returned URL before exposing only a validated
+/// identity to Core. SwiftUI never constructs or persists file paths.
+@MainActor
+public protocol SegmentRecording: AnyObject {
+    func setUnexpectedTerminationHandler(
+        _ handler: (@MainActor @Sendable () -> Void)?
+    )
+
+    func beginCapture(_ request: SegmentCaptureRequest) async throws
+
+    func finishCapture() async throws -> CapturedAudioSegment
+
+    /// Inspects/adopts an interrupted source without replaying capture or a
+    /// provider request. Nil means no playable partial exists.
+    func recoverCapture(_ request: SegmentCaptureRequest) async throws -> CapturedAudioSegment?
+
+    func playbackURL(
+        sessionID: SessionID,
+        audioIdentity: SegmentAudioIdentity
+    ) async throws -> URL
+}
+
+/// One invocation means one provider request. An Adapter must not hide a
+/// retry inside this call; retry authorization belongs to the session Module.
+public protocol SegmentTranscribing: Sendable {
+    func transcribe(
+        _ request: SegmentTranscriptionRequest,
+        credential: String
+    ) async throws -> SegmentTranscriptionResult
+}
+
+public protocol GroqCredentialReading: Sendable {
+    func readGroqCredential() async throws -> String
+}

--- a/Sources/InterviewArcLiveCore/SegmentSpeechCoordinator.swift
+++ b/Sources/InterviewArcLiveCore/SegmentSpeechCoordinator.swift
@@ -1,0 +1,641 @@
+import Foundation
+
+public enum SegmentSpeechCoordinatorError: Error, Sendable, Equatable {
+    case noActiveSegment
+    case segmentAudioUnavailable(SegmentID)
+    case captureFailed(SegmentCaptureFailureReason)
+    case credentialUnavailable
+    case transcriptionFailed(SegmentTranscriptionFailureReason)
+}
+
+/// UI-facing deep Module for segmented candidate speech. It is the sole owner
+/// of capture/transcription orchestration: durable command authorization is
+/// always observed before an Adapter side effect, and an idempotent replay is
+/// never interpreted as permission to invoke that side effect again.
+@MainActor
+public final class SegmentSpeechCoordinator {
+    public private(set) var snapshot: InterviewRoomSnapshot
+
+    private let session: InterviewRoomSession
+    private let recording: any SegmentRecording
+    private let transcriber: any SegmentTranscribing
+    private let credentialReader: any GroqCredentialReading
+    private var snapshotHandler: (@MainActor @Sendable (InterviewRoomSnapshot) -> Void)?
+    private var isFinalizing = false
+
+    private init(
+        session: InterviewRoomSession,
+        initialSnapshot: InterviewRoomSnapshot,
+        recording: any SegmentRecording,
+        transcriber: any SegmentTranscribing,
+        credentialReader: any GroqCredentialReading
+    ) {
+        self.session = session
+        snapshot = initialSnapshot
+        self.recording = recording
+        self.transcriber = transcriber
+        self.credentialReader = credentialReader
+        installUnexpectedTerminationHandler()
+    }
+
+    /// Observes the canonical persisted Session projection. Registration
+    /// immediately emits the current Snapshot; every later persisted
+    /// transition emits again, including background capture recovery.
+    public func setSnapshotHandler(
+        _ handler: (@MainActor @Sendable (InterviewRoomSnapshot) -> Void)?
+    ) {
+        snapshotHandler = handler
+        handler?(snapshot)
+    }
+
+    /// Opens one canonical Session, hiding start-versus-restore and recovery
+    /// ordering from the app model.
+    public static func open(
+        sessionID: SessionID,
+        activityID: String,
+        turnMode: TurnMode = .manual,
+        manifestStore: any SessionManifestStore,
+        interviewerRuntime: any InterviewerRuntime,
+        recording: any SegmentRecording,
+        transcriber: any SegmentTranscribing,
+        credentialReader: any GroqCredentialReading
+    ) async throws -> SegmentSpeechCoordinator {
+        let session: InterviewRoomSession
+        if try await manifestStore.load(sessionID: sessionID) == nil {
+            session = try await InterviewRoomSession.start(
+                sessionID: sessionID,
+                activityID: activityID,
+                turnMode: turnMode,
+                manifestStore: manifestStore,
+                interviewerRuntime: interviewerRuntime
+            )
+        } else {
+            session = try await InterviewRoomSession.restore(
+                sessionID: sessionID,
+                manifestStore: manifestStore,
+                interviewerRuntime: interviewerRuntime
+            )
+        }
+
+        return SegmentSpeechCoordinator(
+            session: session,
+            initialSnapshot: await session.snapshot(),
+            recording: recording,
+            transcriber: transcriber,
+            credentialReader: credentialReader
+        )
+    }
+
+    /// Production convenience factory. The Adapter still owns private audio
+    /// location/adoption; this factory owns only the canonical Manifest store.
+    public static func openLocal(
+        sessionID: SessionID,
+        activityID: String,
+        turnMode: TurnMode = .manual,
+        interviewerRuntime: any InterviewerRuntime,
+        recording: any SegmentRecording,
+        transcriber: any SegmentTranscribing,
+        credentialReader: any GroqCredentialReading
+    ) async throws -> SegmentSpeechCoordinator {
+        try await open(
+            sessionID: sessionID,
+            activityID: activityID,
+            turnMode: turnMode,
+            manifestStore: FileSessionManifestStore(),
+            interviewerRuntime: interviewerRuntime,
+            recording: recording,
+            transcriber: transcriber,
+            credentialReader: credentialReader
+        )
+    }
+
+    @discardableResult
+    public func giveCandidateFloor(
+        commandID: CommandID
+    ) async throws -> InterviewRoomSnapshot {
+        try await applyAndPublish(.giveCandidateFloor(commandID: commandID)).snapshot
+    }
+
+    @discardableResult
+    public func setTurnMode(
+        _ mode: TurnMode,
+        commandID: CommandID
+    ) async throws -> InterviewRoomSnapshot {
+        try await applyAndPublish(.setTurnMode(commandID: commandID, mode: mode)).snapshot
+    }
+
+    @discardableResult
+    public func retryInterviewerResponse(
+        commandID: CommandID
+    ) async throws -> InterviewRoomSnapshot {
+        try await applyAndPublish(.retryInterviewerResponse(commandID: commandID)).snapshot
+    }
+
+    @discardableResult
+    public func beginSegment(
+        commandID: CommandID
+    ) async throws -> InterviewRoomSnapshot {
+        let application = try await applyAndPublish(.beginSegment(commandID: commandID))
+        guard application.disposition == .accepted else {
+            return application.snapshot
+        }
+        guard let segment = application.snapshot.segments.first(where: {
+            $0.reservationCommandID == commandID
+        }) else {
+            throw SegmentSpeechCoordinatorError.noActiveSegment
+        }
+
+        let request = SegmentCaptureRequest(
+            sessionID: application.snapshot.sessionID,
+            segmentID: segment.id,
+            reservedAudioIdentity: segment.reservedAudioIdentity
+        )
+        do {
+            try await recording.beginCapture(request)
+        } catch {
+            _ = try await applyAndPublish(
+                .recordSegmentCaptureOutcome(
+                    commandID: InterviewRoomSession.derivedCommandID(
+                        source: commandID,
+                        operation: "capture-start-failed"
+                    ),
+                    segmentID: segment.id,
+                    outcome: .failed(.captureStartFailed)
+                )
+            )
+            throw SegmentSpeechCoordinatorError.captureFailed(.captureStartFailed)
+        }
+
+        do {
+            return try await applyAndPublish(
+                .recordSegmentCaptureOutcome(
+                    commandID: InterviewRoomSession.derivedCommandID(
+                        source: commandID,
+                        operation: "capture-started"
+                    ),
+                    segmentID: segment.id,
+                    outcome: .recordingStarted
+                )
+            ).snapshot
+        } catch {
+            // The microphone side effect already started. Preserve/stop it
+            // without relabeling a persistence failure as capture failure.
+            await preserveCaptureAfterStartPersistenceFailure(
+                segment: segment,
+                sourceCommandID: commandID
+            )
+            throw error
+        }
+    }
+
+    /// Stops and durably preserves the active source M4A without invoking a
+    /// transcription provider. A fresh command ID explicitly retries a prior
+    /// recorder-stop failure while the Segment remains finalization-authorized.
+    @discardableResult
+    public func finalizeSegment(
+        commandID: CommandID
+    ) async throws -> InterviewRoomSnapshot {
+        try await finalizeActiveSegment(commandID: commandID)
+    }
+
+    /// Compatibility convenience for the original Stop-and-transcribe flow.
+    /// New UI orchestration may call `finalizeSegment` and `transcribeSegment`
+    /// separately to expose recovery state between the two operations.
+    @discardableResult
+    public func finishSegment(
+        commandID: CommandID,
+        transcriptionCommandID: CommandID
+    ) async throws -> InterviewRoomSnapshot {
+        guard let segmentID = snapshot.segments.first(where: {
+            $0.lifecycle == .captureAuthorized
+                || $0.lifecycle == .recording
+                || $0.lifecycle == .finalizationAuthorized
+        })?.id else {
+            throw SegmentSpeechCoordinatorError.noActiveSegment
+        }
+        let finalized = try await finalizeSegment(commandID: commandID)
+        guard finalized.segments.first(where: { $0.id == segmentID })?.lifecycle == .audioReady else {
+            return finalized
+        }
+        return try await transcribeSegment(
+            segmentID: segmentID,
+            commandID: transcriptionCommandID
+        )
+    }
+
+    /// User-initiated transcription for either a newly recovered source or a
+    /// prior failed attempt. Core selects the valid attempt kind; presentation
+    /// code does not duplicate lifecycle rules.
+    @discardableResult
+    public func transcribeSegment(
+        segmentID: SegmentID,
+        commandID: CommandID
+    ) async throws -> InterviewRoomSnapshot {
+        guard let segment = snapshot.segments.first(where: { $0.id == segmentID }) else {
+            throw SegmentSpeechCoordinatorError.segmentAudioUnavailable(segmentID)
+        }
+        let kind: SegmentTranscriptionKind = segment.transcriptionAttempts.isEmpty
+            ? .initial
+            : .retry
+        return try await transcribe(
+            segmentID: segmentID,
+            kind: kind,
+            commandID: commandID
+        )
+    }
+
+    @discardableResult
+    public func retryTranscription(
+        segmentID: SegmentID,
+        commandID: CommandID
+    ) async throws -> InterviewRoomSnapshot {
+        try await transcribeSegment(segmentID: segmentID, commandID: commandID)
+    }
+
+    @discardableResult
+    public func excludeSegment(
+        segmentID: SegmentID,
+        reason: SegmentExclusionReason,
+        commandID: CommandID
+    ) async throws -> InterviewRoomSnapshot {
+        try await applyAndPublish(
+            .excludeSegment(commandID: commandID, segmentID: segmentID, reason: reason)
+        ).snapshot
+    }
+
+    @discardableResult
+    public func handOff(
+        commandID: CommandID
+    ) async throws -> InterviewRoomSnapshot {
+        try await applyAndPublish(.handOffSegments(commandID: commandID)).snapshot
+    }
+
+    @discardableResult
+    public func finishSession(
+        commandID: CommandID
+    ) async throws -> InterviewRoomSnapshot {
+        try await applyAndPublish(.finish(commandID: commandID)).snapshot
+    }
+
+    public func playbackURL(segmentID: SegmentID) async throws -> URL {
+        guard let segment = snapshot.segments.first(where: { $0.id == segmentID }),
+              let audio = segment.capturedAudio else {
+            throw SegmentSpeechCoordinatorError.segmentAudioUnavailable(segmentID)
+        }
+        return try await recording.playbackURL(
+            sessionID: snapshot.sessionID,
+            audioIdentity: audio.audioIdentity
+        )
+    }
+
+    /// Reconciles interrupted capture and provider-authorized states. It never
+    /// replays a provider request or automatically transcribes a recovered
+    /// partial; the user must explicitly call `transcribeSegment` afterward.
+    @discardableResult
+    public func resumePendingWork() async throws -> InterviewRoomSnapshot {
+        publish(await session.snapshot())
+
+        let interruptedAttempts = snapshot.segments.compactMap { segment in
+            segment.transcriptionAttempts.first(where: { $0.state == .authorized }).map {
+                (segment.id, $0)
+            }
+        }
+        for (segmentID, attempt) in interruptedAttempts {
+            _ = try await applyAndPublish(
+                .recordSegmentTranscriptionOutcome(
+                    commandID: InterviewRoomSession.derivedCommandID(
+                        source: attempt.authorizationCommandID,
+                        operation: "interrupted-transcription-outcome"
+                    ),
+                    segmentID: segmentID,
+                    attemptID: attempt.id,
+                    outcome: .failed(
+                        SegmentTranscriptionFailure(
+                            reason: .interrupted,
+                            credentialFingerprint: attempt.credentialFingerprint
+                        )
+                    )
+                )
+            )
+        }
+
+        let pending = snapshot.segments.filter {
+            $0.lifecycle == .captureAuthorized
+                || $0.lifecycle == .recording
+                || $0.lifecycle == .finalizationAuthorized
+        }
+
+        for segment in pending {
+            let recoveryRoot = InterviewRoomSession.derivedCommandID(
+                source: segment.reservationCommandID,
+                operation: "capture-recovery-finalization"
+            )
+            let authorization = try await applyAndPublish(
+                .finalizeSegment(commandID: recoveryRoot, segmentID: segment.id)
+            )
+
+            let request = SegmentCaptureRequest(
+                sessionID: authorization.snapshot.sessionID,
+                segmentID: segment.id,
+                reservedAudioIdentity: segment.reservedAudioIdentity
+            )
+            let outcome: SegmentCaptureOutcome
+            do {
+                if let capture = try await recording.recoverCapture(request) {
+                    outcome = .finalized(capture)
+                } else {
+                    outcome = .failed(.interruptedWithoutAudio)
+                }
+            } catch {
+                outcome = .failed(.storageFailed)
+            }
+            _ = try await applyAndPublish(
+                .recordSegmentCaptureOutcome(
+                    commandID: InterviewRoomSession.derivedCommandID(
+                        source: recoveryRoot,
+                        operation: "capture-recovery-outcome"
+                    ),
+                    segmentID: segment.id,
+                    outcome: outcome
+                )
+            )
+        }
+        return snapshot
+    }
+
+    private func finalizeActiveSegment(
+        commandID: CommandID
+    ) async throws -> InterviewRoomSnapshot {
+        guard !isFinalizing else { return snapshot }
+        guard let segment = snapshot.segments.first(where: {
+            $0.lifecycle == .captureAuthorized
+                || $0.lifecycle == .recording
+                || $0.lifecycle == .finalizationAuthorized
+        }) else {
+            throw SegmentSpeechCoordinatorError.noActiveSegment
+        }
+        isFinalizing = true
+        defer { isFinalizing = false }
+
+        let authorization = try await applyAndPublish(
+            .finalizeSegment(commandID: commandID, segmentID: segment.id)
+        )
+        guard authorization.disposition == .accepted else {
+            return authorization.snapshot
+        }
+
+        let request = SegmentCaptureRequest(
+            sessionID: authorization.snapshot.sessionID,
+            segmentID: segment.id,
+            reservedAudioIdentity: segment.reservedAudioIdentity
+        )
+        let capture: CapturedAudioSegment
+        do {
+            capture = try await recording.finishCapture()
+        } catch {
+            if let recovered = try? await recording.recoverCapture(request) {
+                return try await recordFinalizedCapture(
+                    recovered,
+                    segmentID: segment.id,
+                    sourceCommandID: commandID
+                )
+            }
+            // Keep the durable authorization intact. A later explicit Stop
+            // with a fresh command ID may safely retry the recorder side effect.
+            throw SegmentSpeechCoordinatorError.captureFailed(.captureFinalizationFailed)
+        }
+
+        return try await recordFinalizedCapture(
+            capture,
+            segmentID: segment.id,
+            sourceCommandID: commandID
+        )
+    }
+
+    private func recordFinalizedCapture(
+        _ capture: CapturedAudioSegment,
+        segmentID: SegmentID,
+        sourceCommandID: CommandID
+    ) async throws -> InterviewRoomSnapshot {
+        try await applyAndPublish(
+            .recordSegmentCaptureOutcome(
+                commandID: InterviewRoomSession.derivedCommandID(
+                    source: sourceCommandID,
+                    operation: "capture-finalized"
+                ),
+                segmentID: segmentID,
+                outcome: .finalized(capture)
+            )
+        ).snapshot
+    }
+
+    private func preserveCaptureAfterStartPersistenceFailure(
+        segment: CandidateSegment,
+        sourceCommandID: CommandID
+    ) async {
+        let recoveryRoot = InterviewRoomSession.derivedCommandID(
+            source: sourceCommandID,
+            operation: "capture-start-persistence-recovery"
+        )
+        do {
+            _ = try await applyAndPublish(
+                .finalizeSegment(commandID: recoveryRoot, segmentID: segment.id)
+            )
+        } catch {
+            // The durable authorization may still be unavailable. Stop the
+            // microphone best-effort; `resumePendingWork` can adopt the file
+            // from the original capture reservation after restart.
+            _ = try? await recording.finishCapture()
+            publish(await session.snapshot())
+            return
+        }
+
+        guard let capture = try? await recording.finishCapture() else { return }
+        _ = try? await applyAndPublish(
+            .recordSegmentCaptureOutcome(
+                commandID: InterviewRoomSession.derivedCommandID(
+                    source: recoveryRoot,
+                    operation: "capture-finalized"
+                ),
+                segmentID: segment.id,
+                outcome: .finalized(capture)
+            )
+        )
+    }
+
+    private func transcribe(
+        segmentID: SegmentID,
+        kind: SegmentTranscriptionKind,
+        commandID: CommandID
+    ) async throws -> InterviewRoomSnapshot {
+        let credential: String
+        do {
+            credential = try await credentialReader.readGroqCredential()
+        } catch {
+            return try await recordUnavailableCredential(
+                segmentID: segmentID,
+                kind: kind,
+                commandID: commandID
+            )
+        }
+        guard !credential.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return try await recordUnavailableCredential(
+                segmentID: segmentID,
+                kind: kind,
+                commandID: commandID
+            )
+        }
+
+        let fingerprint = InterviewRoomSession.credentialFingerprint(credential)
+        let authorization = try await applyAndPublish(
+            .authorizeSegmentTranscription(
+                commandID: commandID,
+                segmentID: segmentID,
+                kind: kind,
+                credentialFingerprint: fingerprint
+            )
+        )
+        guard authorization.disposition == .accepted else {
+            return authorization.snapshot
+        }
+        guard let segment = authorization.snapshot.segments.first(where: { $0.id == segmentID }),
+              let audio = segment.capturedAudio,
+              let attempt = segment.transcriptionAttempts.first(where: {
+                  $0.authorizationCommandID == commandID
+              }) else {
+            throw SegmentSpeechCoordinatorError.segmentAudioUnavailable(segmentID)
+        }
+
+        let request = SegmentTranscriptionRequest(
+            sessionID: authorization.snapshot.sessionID,
+            segmentID: segmentID,
+            attemptID: attempt.id,
+            kind: kind,
+            audioIdentity: audio.audioIdentity
+        )
+        let outcome: SegmentTranscriptionOutcome
+        do {
+            let result = try await transcriber.transcribe(request, credential: credential)
+            if result.body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                outcome = .failed(
+                    SegmentTranscriptionFailure(
+                        reason: .emptyProviderResult,
+                        credentialFingerprint: fingerprint
+                    )
+                )
+            } else {
+                outcome = .candidate(result)
+            }
+        } catch let failure as SegmentTranscriptionAdapterFailure {
+            outcome = .failed(
+                SegmentTranscriptionFailure(
+                    reason: failure.reason,
+                    providerCode: failure.providerCode,
+                    credentialFingerprint: fingerprint
+                )
+            )
+        } catch {
+            outcome = .failed(
+                SegmentTranscriptionFailure(
+                    reason: .providerUnavailable,
+                    providerCode: .unknown,
+                    credentialFingerprint: fingerprint
+                )
+            )
+        }
+
+        let recorded = try await applyAndPublish(
+            .recordSegmentTranscriptionOutcome(
+                commandID: InterviewRoomSession.derivedCommandID(
+                    source: commandID,
+                    operation: "transcription-outcome"
+                ),
+                segmentID: segmentID,
+                attemptID: attempt.id,
+                outcome: outcome
+            )
+        ).snapshot
+        if case .failed(let failure) = outcome {
+            throw SegmentSpeechCoordinatorError.transcriptionFailed(failure.reason)
+        }
+        return recorded
+    }
+
+    private func recordUnavailableCredential(
+        segmentID: SegmentID,
+        kind: SegmentTranscriptionKind,
+        commandID: CommandID
+    ) async throws -> InterviewRoomSnapshot {
+        let fingerprint = InterviewRoomSession.credentialFingerprint("")
+        let authorization = try await applyAndPublish(
+            .authorizeSegmentTranscription(
+                commandID: commandID,
+                segmentID: segmentID,
+                kind: kind,
+                credentialFingerprint: fingerprint
+            )
+        )
+        guard authorization.disposition == .accepted,
+              let segment = authorization.snapshot.segments.first(where: { $0.id == segmentID }),
+              let attempt = segment.transcriptionAttempts.first(where: {
+                  $0.authorizationCommandID == commandID
+              }) else {
+            return authorization.snapshot
+        }
+        _ = try await applyAndPublish(
+            .recordSegmentTranscriptionOutcome(
+                commandID: InterviewRoomSession.derivedCommandID(
+                    source: commandID,
+                    operation: "missing-credential"
+                ),
+                segmentID: segmentID,
+                attemptID: attempt.id,
+                outcome: .failed(
+                    SegmentTranscriptionFailure(
+                        reason: .missingCredential,
+                        credentialFingerprint: fingerprint
+                    )
+                )
+            )
+        )
+        throw SegmentSpeechCoordinatorError.credentialUnavailable
+    }
+
+    private func applyAndPublish(
+        _ command: InterviewRoomCommand
+    ) async throws -> InterviewRoomCommandApplication {
+        do {
+            let application = try await session.apply(command)
+            publish(application.snapshot)
+            return application
+        } catch {
+            publish(await session.snapshot())
+            throw error
+        }
+    }
+
+    private func publish(_ nextSnapshot: InterviewRoomSnapshot) {
+        snapshot = nextSnapshot
+        snapshotHandler?(nextSnapshot)
+    }
+
+    private func installUnexpectedTerminationHandler() {
+        recording.setUnexpectedTerminationHandler { [weak self] in
+            Task { @MainActor [weak self] in
+                await self?.handleUnexpectedTermination()
+            }
+        }
+    }
+
+    private func handleUnexpectedTermination() async {
+        guard !isFinalizing,
+              let segment = snapshot.segments.first(where: { $0.lifecycle == .recording }) else {
+            return
+        }
+        let finalizeCommand = InterviewRoomSession.derivedCommandID(
+            source: segment.reservationCommandID,
+            operation: "unexpected-finalization"
+        )
+        _ = try? await finalizeActiveSegment(commandID: finalizeCommand)
+    }
+}

--- a/Sources/InterviewArcLiveCore/SessionManifest.swift
+++ b/Sources/InterviewArcLiveCore/SessionManifest.swift
@@ -78,11 +78,41 @@ public struct CandidateTurn: Codable, Sendable, Equatable {
     public let id: TurnID
     public let commandID: CommandID
     public let transcript: CandidateTranscript
+    public let segmentIDs: [SegmentID]
 
-    public init(id: TurnID, commandID: CommandID, transcript: CandidateTranscript) {
+    public init(
+        id: TurnID,
+        commandID: CommandID,
+        transcript: CandidateTranscript,
+        segmentIDs: [SegmentID] = []
+    ) {
         self.id = id
         self.commandID = commandID
         self.transcript = transcript
+        self.segmentIDs = segmentIDs
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case commandID
+        case transcript
+        case segmentIDs
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(TurnID.self, forKey: .id)
+        commandID = try container.decode(CommandID.self, forKey: .commandID)
+        transcript = try container.decode(CandidateTranscript.self, forKey: .transcript)
+        segmentIDs = try container.decodeIfPresent([SegmentID].self, forKey: .segmentIDs) ?? []
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(commandID, forKey: .commandID)
+        try container.encode(transcript, forKey: .transcript)
+        try container.encode(segmentIDs, forKey: .segmentIDs)
     }
 }
 
@@ -145,6 +175,7 @@ public struct SessionManifest: Codable, Sendable, Equatable {
     public let phase: InterviewRoomPhase
     public let turnMode: TurnMode
     public let turns: [InterviewTurn]
+    public let segments: [CandidateSegment]
     public let revision: Int
 
     let appliedCommands: [AppliedCommandRecord]
@@ -155,6 +186,7 @@ public struct SessionManifest: Codable, Sendable, Equatable {
         phase: InterviewRoomPhase,
         turnMode: TurnMode,
         turns: [InterviewTurn],
+        segments: [CandidateSegment] = [],
         revision: Int,
         appliedCommands: [AppliedCommandRecord]
     ) {
@@ -163,8 +195,47 @@ public struct SessionManifest: Codable, Sendable, Equatable {
         self.phase = phase
         self.turnMode = turnMode
         self.turns = turns
+        self.segments = segments
         self.revision = revision
         self.appliedCommands = appliedCommands
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case sessionID
+        case activityID
+        case phase
+        case turnMode
+        case turns
+        case segments
+        case revision
+        case appliedCommands
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        sessionID = try container.decode(SessionID.self, forKey: .sessionID)
+        activityID = try container.decode(String.self, forKey: .activityID)
+        phase = try container.decode(InterviewRoomPhase.self, forKey: .phase)
+        turnMode = try container.decode(TurnMode.self, forKey: .turnMode)
+        turns = try container.decode([InterviewTurn].self, forKey: .turns)
+        segments = try container.decodeIfPresent([CandidateSegment].self, forKey: .segments) ?? []
+        revision = try container.decode(Int.self, forKey: .revision)
+        appliedCommands = try container.decode(
+            [AppliedCommandRecord].self,
+            forKey: .appliedCommands
+        )
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(sessionID, forKey: .sessionID)
+        try container.encode(activityID, forKey: .activityID)
+        try container.encode(phase, forKey: .phase)
+        try container.encode(turnMode, forKey: .turnMode)
+        try container.encode(turns, forKey: .turns)
+        try container.encode(segments, forKey: .segments)
+        try container.encode(revision, forKey: .revision)
+        try container.encode(appliedCommands, forKey: .appliedCommands)
     }
 }
 
@@ -175,6 +246,7 @@ public struct InterviewRoomSnapshot: Sendable, Equatable {
     public let phase: InterviewRoomPhase
     public let turnMode: TurnMode
     public let turns: [InterviewTurn]
+    public let segments: [CandidateSegment]
     public let revision: Int
 
     init(manifest: SessionManifest) {
@@ -183,6 +255,7 @@ public struct InterviewRoomSnapshot: Sendable, Equatable {
         phase = manifest.phase
         turnMode = manifest.turnMode
         turns = manifest.turns
+        segments = manifest.segments
         revision = manifest.revision
     }
 }

--- a/Sources/InterviewArcLiveVoiceAdapter/LiveGroqCredentialStore.swift
+++ b/Sources/InterviewArcLiveVoiceAdapter/LiveGroqCredentialStore.swift
@@ -1,0 +1,89 @@
+import Foundation
+import InterviewArcLiveCore
+import InterviewArcVoiceCore
+
+public enum LiveGroqCredentialReadiness: Equatable, Sendable {
+    case ready
+    case missing
+}
+
+public enum LiveGroqCredentialStoreError: Error, Equatable, LocalizedError, Sendable {
+    case emptyCredential
+    case missingCredential
+    case verificationFailed
+
+    public var errorDescription: String? {
+        switch self {
+        case .emptyCredential:
+            "Enter a Groq API key before saving."
+        case .missingCredential:
+            "Interview Arc Live does not have a Groq API key in Keychain."
+        case .verificationFailed:
+            "Interview Arc Live could not verify the saved Groq API key."
+        }
+    }
+}
+
+public actor LiveGroqCredentialStore: GroqCredentialReading {
+    public static let keychainService = "dev.interviewarc.live"
+
+    private let backend: LiveGroqCredentialBackend
+    private let verificationPolicy = CredentialSaveVerificationPolicy()
+
+    public init() {
+        let keychain = KeychainStore(service: Self.keychainService)
+        backend = LiveGroqCredentialBackend(
+            read: { try keychain.value(for: .groqAPIKey) },
+            save: { try keychain.set($0, for: .groqAPIKey) },
+            remove: { try keychain.remove(.groqAPIKey) }
+        )
+    }
+
+    init(backend: LiveGroqCredentialBackend) {
+        self.backend = backend
+    }
+
+    public func read() throws -> String? {
+        try backend.read()
+    }
+
+    public func readGroqCredential() throws -> String {
+        guard let value = try read(), !value.isEmpty else {
+            throw LiveGroqCredentialStoreError.missingCredential
+        }
+        return value
+    }
+
+    public func saveAndVerify(_ value: String) throws {
+        let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalized.isEmpty else {
+            throw LiveGroqCredentialStoreError.emptyCredential
+        }
+
+        try backend.save(normalized)
+        guard verificationPolicy.isVerified(
+            submittedValue: normalized,
+            retrievedValue: try backend.read()
+        ) else {
+            throw LiveGroqCredentialStoreError.verificationFailed
+        }
+    }
+
+    public func remove() throws {
+        try backend.remove()
+    }
+
+    public func readiness() throws -> LiveGroqCredentialReadiness {
+        guard let value = try read(),
+              !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return .missing
+        }
+        return .ready
+    }
+}
+
+struct LiveGroqCredentialBackend: Sendable {
+    let read: @Sendable () throws -> String?
+    let save: @Sendable (String) throws -> Void
+    let remove: @Sendable () throws -> Void
+}

--- a/Sources/InterviewArcLiveVoiceAdapter/LiveVoicePaths.swift
+++ b/Sources/InterviewArcLiveVoiceAdapter/LiveVoicePaths.swift
@@ -5,6 +5,7 @@ import InterviewArcLiveCore
 enum LiveVoicePathError: Error, Equatable, Sendable {
     case sourceAudioMissing
     case sourceAudioIsNotRegularFile
+    case privateDirectoryIsUnsafe
     case authoritativeCaptureOutsideSessionRoot
     case invalidAuthoritativeAudioIdentity
     case destinationAlreadyExists
@@ -262,11 +263,25 @@ struct LiveVoicePaths: Sendable {
         _ url: URL,
         fileManager: FileManager
     ) throws {
-        try fileManager.createDirectory(
-            at: url,
-            withIntermediateDirectories: false,
-            attributes: [.posixPermissions: 0o700]
-        )
+        do {
+            try fileManager.createDirectory(
+                at: url,
+                withIntermediateDirectories: false,
+                attributes: [.posixPermissions: 0o700]
+            )
+        } catch let error as CocoaError where error.code == .fileWriteFileExists {
+            // The app revisits these roots for every Segment. Existing safe
+            // directories are expected; validate them before chmod instead
+            // of depending on Foundation's platform-specific mkdir behavior.
+        }
+        let values = try url.resourceValues(forKeys: [
+            .isDirectoryKey,
+            .isSymbolicLinkKey,
+        ])
+        guard values.isDirectory == true,
+              values.isSymbolicLink != true else {
+            throw LiveVoicePathError.privateDirectoryIsUnsafe
+        }
         try fileManager.setAttributes(
             [.posixPermissions: 0o700],
             ofItemAtPath: url.path

--- a/Sources/InterviewArcLiveVoiceAdapter/LiveVoicePaths.swift
+++ b/Sources/InterviewArcLiveVoiceAdapter/LiveVoicePaths.swift
@@ -1,0 +1,312 @@
+import CryptoKit
+import Foundation
+import InterviewArcLiveCore
+
+enum LiveVoicePathError: Error, Equatable, Sendable {
+    case sourceAudioMissing
+    case sourceAudioIsNotRegularFile
+    case authoritativeCaptureOutsideSessionRoot
+    case invalidAuthoritativeAudioIdentity
+    case destinationAlreadyExists
+}
+
+struct ProviderScratchCleanupPolicy: Equatable, Sendable {
+    let staleAge: TimeInterval
+    let maximumSessionDirectories: Int
+    let maximumAttemptDirectories: Int
+    let maximumDeletions: Int
+
+    static let production = ProviderScratchCleanupPolicy(
+        staleAge: 24 * 60 * 60,
+        maximumSessionDirectories: 64,
+        maximumAttemptDirectories: 256,
+        maximumDeletions: 64
+    )
+}
+
+struct LiveVoicePaths: Sendable {
+    private let configuredApplicationSupportRoot: URL?
+
+    init(applicationSupportRoot: URL? = nil) {
+        configuredApplicationSupportRoot = applicationSupportRoot
+    }
+
+    func audioURL(
+        sessionID: SessionID,
+        identity: SegmentAudioIdentity,
+        createParentDirectory: Bool,
+        fileManager: FileManager = .default
+    ) throws -> URL {
+        let directory = try sessionAudioDirectory(
+            sessionID: sessionID,
+            create: createParentDirectory,
+            fileManager: fileManager
+        )
+        return directory.appendingPathComponent(
+            identity.fileName,
+            isDirectory: false
+        )
+    }
+
+    func sessionAudioDirectory(
+        sessionID: SessionID,
+        create: Bool,
+        fileManager: FileManager = .default
+    ) throws -> URL {
+        let root = try applicationSupportRoot(fileManager: fileManager)
+        let audioRoot = root.appendingPathComponent("Audio", isDirectory: true)
+        let directory = audioRoot.appendingPathComponent(
+            "session-\(Self.digest(sessionID.rawValue))",
+            isDirectory: true
+        )
+        if create {
+            try ensurePrivateDirectory(root, fileManager: fileManager)
+            try ensurePrivateDirectory(audioRoot, fileManager: fileManager)
+            try ensurePrivateDirectory(directory, fileManager: fileManager)
+        }
+        return directory.standardizedFileURL
+    }
+
+    func transcriptionScratchDirectory(
+        sessionID: SessionID,
+        attemptID: TranscriptionAttemptID,
+        fileManager: FileManager = .default
+    ) throws -> URL {
+        let root = try applicationSupportRoot(fileManager: fileManager)
+        let scratchRoot = root.appendingPathComponent(
+            "ProviderScratch",
+            isDirectory: true
+        )
+        let sessionDirectory = scratchRoot.appendingPathComponent(
+            "session-\(Self.digest(sessionID.rawValue))",
+            isDirectory: true
+        )
+        let directory = sessionDirectory.appendingPathComponent(
+            "attempt-\(Self.digest(attemptID.rawValue))-\(UUID().uuidString.lowercased())",
+            isDirectory: true
+        )
+        try ensurePrivateDirectory(root, fileManager: fileManager)
+        try ensurePrivateDirectory(scratchRoot, fileManager: fileManager)
+        try ensurePrivateDirectory(sessionDirectory, fileManager: fileManager)
+        try ensurePrivateDirectory(directory, fileManager: fileManager)
+        return directory.standardizedFileURL
+    }
+
+    /// Removes only old, Live-shaped attempt directories beneath
+    /// `ProviderScratch`. Enumeration and deletion are deliberately bounded,
+    /// fresh directories are retained as potentially in-flight, and symlinks
+    /// are never traversed or removed.
+    @discardableResult
+    func cleanupStaleTranscriptionScratch(
+        now: Date,
+        policy: ProviderScratchCleanupPolicy = .production,
+        fileManager: FileManager = .default
+    ) throws -> Int {
+        guard policy.maximumSessionDirectories > 0,
+              policy.maximumAttemptDirectories > 0,
+              policy.maximumDeletions > 0 else {
+            return 0
+        }
+
+        let root = try applicationSupportRoot(fileManager: fileManager)
+        let scratchRoot = root.appendingPathComponent(
+            "ProviderScratch",
+            isDirectory: true
+        ).standardizedFileURL
+        guard fileManager.fileExists(atPath: scratchRoot.path) else {
+            return 0
+        }
+        let rootValues = try scratchRoot.resourceValues(forKeys: [
+            .isDirectoryKey,
+            .isSymbolicLinkKey,
+        ])
+        guard rootValues.isDirectory == true,
+              rootValues.isSymbolicLink != true else {
+            return 0
+        }
+
+        let resolvedScratchRoot = scratchRoot.resolvingSymlinksInPath()
+            .standardizedFileURL
+        let cutoff = now.addingTimeInterval(-max(0, policy.staleAge))
+        let sessionDirectories = try fileManager.contentsOfDirectory(
+            at: scratchRoot,
+            includingPropertiesForKeys: [
+                .isDirectoryKey,
+                .isSymbolicLinkKey,
+            ],
+            options: [.skipsHiddenFiles]
+        ).sorted { $0.lastPathComponent < $1.lastPathComponent }
+
+        var inspectedAttempts = 0
+        var deletionCount = 0
+        for sessionDirectory in sessionDirectories.prefix(
+            policy.maximumSessionDirectories
+        ) {
+            guard Self.isSessionScratchDirectoryName(
+                sessionDirectory.lastPathComponent
+            ) else {
+                continue
+            }
+            guard let sessionValues = try? sessionDirectory.resourceValues(
+                forKeys: [
+                    .isDirectoryKey,
+                    .isSymbolicLinkKey,
+                ]
+            ),
+                  sessionValues.isDirectory == true,
+                  sessionValues.isSymbolicLink != true,
+                  Self.isStrictDescendant(
+                      sessionDirectory.resolvingSymlinksInPath().standardizedFileURL,
+                      of: resolvedScratchRoot
+                  ) else {
+                continue
+            }
+
+            guard let attempts = try? fileManager.contentsOfDirectory(
+                at: sessionDirectory,
+                includingPropertiesForKeys: [
+                    .isDirectoryKey,
+                    .isSymbolicLinkKey,
+                    .contentModificationDateKey,
+                ],
+                options: [.skipsHiddenFiles]
+            ).sorted(by: { $0.lastPathComponent < $1.lastPathComponent }) else {
+                continue
+            }
+            for attempt in attempts {
+                guard inspectedAttempts < policy.maximumAttemptDirectories,
+                      deletionCount < policy.maximumDeletions else {
+                    return deletionCount
+                }
+                inspectedAttempts += 1
+
+                guard Self.isAttemptScratchDirectoryName(
+                    attempt.lastPathComponent
+                ) else {
+                    continue
+                }
+                guard let values = try? attempt.resourceValues(forKeys: [
+                    .isDirectoryKey,
+                    .isSymbolicLinkKey,
+                    .contentModificationDateKey,
+                ]),
+                      values.isDirectory == true,
+                      values.isSymbolicLink != true,
+                      let modifiedAt = values.contentModificationDate,
+                      modifiedAt < cutoff,
+                      Self.isStrictDescendant(
+                          attempt.resolvingSymlinksInPath().standardizedFileURL,
+                          of: resolvedScratchRoot
+                      ) else {
+                    continue
+                }
+
+                do {
+                    try fileManager.removeItem(at: attempt)
+                    deletionCount += 1
+                } catch let error as CocoaError where error.code == .fileNoSuchFile {
+                    // Another Live process won the same bounded cleanup race.
+                } catch {
+                    // One inaccessible stale directory must not prevent later
+                    // root-confined candidates from being considered.
+                }
+            }
+        }
+        return deletionCount
+    }
+
+    func validateSourceAudio(
+        at url: URL,
+        fileManager: FileManager = .default
+    ) throws {
+        guard fileManager.fileExists(atPath: url.path) else {
+            throw LiveVoicePathError.sourceAudioMissing
+        }
+        let values = try url.resourceValues(forKeys: [
+            .isRegularFileKey,
+            .isSymbolicLinkKey,
+        ])
+        guard values.isRegularFile == true,
+              values.isSymbolicLink != true else {
+            throw LiveVoicePathError.sourceAudioIsNotRegularFile
+        }
+    }
+
+    func validateAuthoritativeCapture(
+        at url: URL,
+        for sessionID: SessionID,
+        fileManager: FileManager = .default
+    ) throws {
+        let expectedDirectory = try sessionAudioDirectory(
+            sessionID: sessionID,
+            create: false,
+            fileManager: fileManager
+        ).resolvingSymlinksInPath().standardizedFileURL
+        let actualURL = url.resolvingSymlinksInPath().standardizedFileURL
+        guard actualURL.deletingLastPathComponent() == expectedDirectory else {
+            throw LiveVoicePathError.authoritativeCaptureOutsideSessionRoot
+        }
+        try validateSourceAudio(at: actualURL, fileManager: fileManager)
+    }
+
+    private func applicationSupportRoot(
+        fileManager: FileManager
+    ) throws -> URL {
+        if let configuredApplicationSupportRoot {
+            return configuredApplicationSupportRoot.standardizedFileURL
+        }
+        return try LivePaths.applicationSupportRoot(fileManager: fileManager)
+    }
+
+    private func ensurePrivateDirectory(
+        _ url: URL,
+        fileManager: FileManager
+    ) throws {
+        try fileManager.createDirectory(
+            at: url,
+            withIntermediateDirectories: false,
+            attributes: [.posixPermissions: 0o700]
+        )
+        try fileManager.setAttributes(
+            [.posixPermissions: 0o700],
+            ofItemAtPath: url.path
+        )
+    }
+
+    private static func digest(_ value: String) -> String {
+        SHA256.hash(data: Data(value.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
+    }
+
+    private static func isSessionScratchDirectoryName(_ name: String) -> Bool {
+        hasSHA256Suffix(name, prefix: "session-")
+    }
+
+    private static func isAttemptScratchDirectoryName(_ name: String) -> Bool {
+        let prefix = "attempt-"
+        guard name.hasPrefix(prefix) else { return false }
+        let suffix = name.dropFirst(prefix.count)
+        guard suffix.count == 64 + 1 + 36 else { return false }
+        let digestEnd = suffix.index(suffix.startIndex, offsetBy: 64)
+        let digest = suffix[..<digestEnd]
+        guard digest.allSatisfy(\.isHexDigit), suffix[digestEnd] == "-" else {
+            return false
+        }
+        let uuidStart = suffix.index(after: digestEnd)
+        return UUID(uuidString: String(suffix[uuidStart...])) != nil
+    }
+
+    private static func hasSHA256Suffix(_ name: String, prefix: String) -> Bool {
+        guard name.hasPrefix(prefix) else { return false }
+        let suffix = name.dropFirst(prefix.count)
+        return suffix.count == 64 && suffix.allSatisfy(\.isHexDigit)
+    }
+
+    private static func isStrictDescendant(_ candidate: URL, of root: URL) -> Bool {
+        let rootComponents = root.pathComponents
+        let candidateComponents = candidate.pathComponents
+        return candidateComponents.count > rootComponents.count
+            && Array(candidateComponents.prefix(rootComponents.count)) == rootComponents
+    }
+}

--- a/Sources/InterviewArcLiveVoiceAdapter/VoiceCoreRecordingDriver.swift
+++ b/Sources/InterviewArcLiveVoiceAdapter/VoiceCoreRecordingDriver.swift
@@ -1,0 +1,46 @@
+import Foundation
+import InterviewArcVoiceCore
+
+@MainActor
+protocol VoiceCoreRecordingDriving: AnyObject {
+    var onUnexpectedTermination: (@MainActor () -> Void)? { get set }
+
+    func start(
+        at destinationURL: URL,
+        captureBackendDidStart: @escaping @MainActor () -> Void
+    ) async throws
+
+    func stop() throws -> RecordedCapture
+}
+
+@MainActor
+final class AnswerRecorderDriver: VoiceCoreRecordingDriving {
+    private let recorder: AnswerRecorder
+
+    convenience init() {
+        self.init(recorder: AnswerRecorder())
+    }
+
+    init(recorder: AnswerRecorder) {
+        self.recorder = recorder
+    }
+
+    var onUnexpectedTermination: (@MainActor () -> Void)? {
+        get { recorder.onUnexpectedTermination }
+        set { recorder.onUnexpectedTermination = newValue }
+    }
+
+    func start(
+        at destinationURL: URL,
+        captureBackendDidStart: @escaping @MainActor () -> Void
+    ) async throws {
+        try await recorder.start(
+            at: destinationURL,
+            captureBackendDidStart: captureBackendDidStart
+        )
+    }
+
+    func stop() throws -> RecordedCapture {
+        try recorder.stop()
+    }
+}

--- a/Sources/InterviewArcLiveVoiceAdapter/VoiceCoreSegmentRecorder.swift
+++ b/Sources/InterviewArcLiveVoiceAdapter/VoiceCoreSegmentRecorder.swift
@@ -1,0 +1,412 @@
+import Foundation
+import InterviewArcLiveCore
+import InterviewArcVoiceCore
+
+public enum VoiceCoreSegmentRecorderError: Error, Equatable, Sendable {
+    case captureAlreadyActive
+    case noActiveCapture
+    case reservedDestinationAlreadyExists
+    case authoritativeCaptureOutsideSessionRoot
+    case invalidAuthoritativeAudioIdentity
+    case sourceAudioUnavailable
+}
+
+@MainActor
+public final class VoiceCoreSegmentRecorder: SegmentRecording {
+    private struct ActiveCapture {
+        let request: SegmentCaptureRequest
+        let requestedURL: URL
+        var startedAt: Date?
+    }
+
+    private struct RecoveryCandidate {
+        let url: URL
+        let identity: SegmentAudioIdentity
+        let evidence: RecordingIntegrityEvidence
+        let isRecoveredFile: Bool
+        let modifiedAt: Date
+    }
+
+    private let driver: any VoiceCoreRecordingDriving
+    private let paths: LiveVoicePaths
+    private let fileManager: FileManager
+    private let now: @MainActor () -> Date
+    private let inspect: (RecordedCapture) throws -> RecordingIntegrityEvidence
+
+    private var activeCapture: ActiveCapture?
+    private var unexpectedTerminationHandler: (@MainActor @Sendable () -> Void)?
+    private var didReportUnexpectedTermination = false
+
+    public convenience init() {
+        self.init(
+            driver: AnswerRecorderDriver(),
+            paths: LiveVoicePaths(),
+            fileManager: .default,
+            now: Date.init,
+            inspect: RecordingFileInspector.inspect
+        )
+    }
+
+    init(
+        driver: any VoiceCoreRecordingDriving,
+        applicationSupportRoot: URL,
+        fileManager: FileManager = .default,
+        now: @escaping @MainActor () -> Date = Date.init,
+        inspect: @escaping (RecordedCapture) throws -> RecordingIntegrityEvidence
+    ) {
+        self.driver = driver
+        paths = LiveVoicePaths(applicationSupportRoot: applicationSupportRoot)
+        self.fileManager = fileManager
+        self.now = now
+        self.inspect = inspect
+        installDriverTerminationBridge()
+    }
+
+    private init(
+        driver: any VoiceCoreRecordingDriving,
+        paths: LiveVoicePaths,
+        fileManager: FileManager,
+        now: @escaping @MainActor () -> Date,
+        inspect: @escaping (RecordedCapture) throws -> RecordingIntegrityEvidence
+    ) {
+        self.driver = driver
+        self.paths = paths
+        self.fileManager = fileManager
+        self.now = now
+        self.inspect = inspect
+        installDriverTerminationBridge()
+    }
+
+    public func setUnexpectedTerminationHandler(
+        _ handler: (@MainActor @Sendable () -> Void)?
+    ) {
+        unexpectedTerminationHandler = handler
+    }
+
+    public func beginCapture(_ request: SegmentCaptureRequest) async throws {
+        guard activeCapture == nil else {
+            throw VoiceCoreSegmentRecorderError.captureAlreadyActive
+        }
+
+        let destinationURL = try paths.audioURL(
+            sessionID: request.sessionID,
+            identity: request.reservedAudioIdentity,
+            createParentDirectory: true,
+            fileManager: fileManager
+        )
+        guard !fileManager.fileExists(atPath: destinationURL.path) else {
+            throw VoiceCoreSegmentRecorderError.reservedDestinationAlreadyExists
+        }
+
+        activeCapture = ActiveCapture(
+            request: request,
+            requestedURL: destinationURL,
+            startedAt: nil
+        )
+        didReportUnexpectedTermination = false
+        do {
+            try await driver.start(at: destinationURL) { [weak self] in
+                guard let self else { return }
+                self.activeCapture?.startedAt = self.now()
+            }
+            if activeCapture?.startedAt == nil {
+                activeCapture?.startedAt = now()
+            }
+        } catch {
+            activeCapture = nil
+            throw error
+        }
+    }
+
+    public func finishCapture() async throws -> CapturedAudioSegment {
+        guard let activeCapture else {
+            throw VoiceCoreSegmentRecorderError.noActiveCapture
+        }
+
+        let recorded = try driver.stop()
+        let endedAt = now()
+        // Once VoiceCore has finalized, this Adapter must never call stop on
+        // that capture again. Any later adoption/inspection error is surfaced
+        // while the source file remains privately preserved, and a fresh
+        // reservation can start another capture.
+        self.activeCapture = nil
+        didReportUnexpectedTermination = false
+        do {
+            try paths.validateAuthoritativeCapture(
+                at: recorded.url,
+                for: activeCapture.request.sessionID,
+                fileManager: fileManager
+            )
+        } catch LiveVoicePathError.authoritativeCaptureOutsideSessionRoot {
+            throw VoiceCoreSegmentRecorderError.authoritativeCaptureOutsideSessionRoot
+        } catch {
+            throw VoiceCoreSegmentRecorderError.sourceAudioUnavailable
+        }
+
+        let authoritativeIdentity = try adoptIdentity(
+            for: recorded.url,
+            sessionID: activeCapture.request.sessionID
+        )
+        let authoritativeURL = try paths.audioURL(
+            sessionID: activeCapture.request.sessionID,
+            identity: authoritativeIdentity,
+            createParentDirectory: false,
+            fileManager: fileManager
+        )
+        try fileManager.setAttributes(
+            [.posixPermissions: 0o600],
+            ofItemAtPath: authoritativeURL.path
+        )
+
+        let evidence = inspectedEvidence(for: recorded, at: authoritativeURL)
+        let integrity = RecordingIntegrityEvaluator.evaluate(evidence)
+        let isPlayable = evidence.fileSizeBytes >= 512
+            && evidence.decodedFrameCount > 0
+            && evidence.decodedDurationSeconds > 0
+        let startedAt = activeCapture.startedAt
+            ?? endedAt.addingTimeInterval(-max(0, recorded.duration))
+
+        return CapturedAudioSegment(
+            audioIdentity: authoritativeIdentity,
+            startedAtMilliseconds: Self.milliseconds(since1970: startedAt),
+            endedAtMilliseconds: Self.milliseconds(since1970: endedAt),
+            durationMilliseconds: Self.milliseconds(recorded.duration),
+            decodedDurationMilliseconds: Self.milliseconds(
+                evidence.decodedDurationSeconds
+            ),
+            byteCount: Int64(max(0, evidence.fileSizeBytes)),
+            isPlayable: isPlayable,
+            isPartial: !integrity.isComplete,
+            integrityReasons: integrity.reasons.map {
+                SegmentIntegrityReason($0.rawValue)
+            }
+        )
+    }
+
+    public func playbackURL(
+        sessionID: SessionID,
+        audioIdentity: SegmentAudioIdentity
+    ) async throws -> URL {
+        let url = try paths.audioURL(
+            sessionID: sessionID,
+            identity: audioIdentity,
+            createParentDirectory: false,
+            fileManager: fileManager
+        )
+        do {
+            try paths.validateSourceAudio(at: url, fileManager: fileManager)
+        } catch {
+            throw VoiceCoreSegmentRecorderError.sourceAudioUnavailable
+        }
+        return url
+    }
+
+    public func recoverCapture(
+        _ request: SegmentCaptureRequest
+    ) async throws -> CapturedAudioSegment? {
+        guard activeCapture == nil else {
+            throw VoiceCoreSegmentRecorderError.captureAlreadyActive
+        }
+        let directory = try paths.sessionAudioDirectory(
+            sessionID: request.sessionID,
+            create: false,
+            fileManager: fileManager
+        )
+        guard fileManager.fileExists(atPath: directory.path) else {
+            return nil
+        }
+
+        let reservedName = request.reservedAudioIdentity.fileName
+        let reservedStem = URL(fileURLWithPath: reservedName)
+            .deletingPathExtension()
+            .lastPathComponent
+        let recoveredPrefix = "\(reservedStem)-recovered-"
+        let entries = try fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [
+                .isRegularFileKey,
+                .isSymbolicLinkKey,
+                .contentModificationDateKey,
+            ],
+            options: [.skipsHiddenFiles]
+        )
+        let matchingURLs = entries.filter { url in
+            let name = url.lastPathComponent
+            return name == reservedName
+                || (name.hasPrefix(recoveredPrefix)
+                    && name.lowercased().hasSuffix(".m4a"))
+        }
+
+        let candidates = matchingURLs.compactMap { url -> RecoveryCandidate? in
+            guard let identity = try? SegmentAudioIdentity(
+                validating: url.lastPathComponent
+            ),
+            (try? paths.validateAuthoritativeCapture(
+                at: url,
+                for: request.sessionID,
+                fileManager: fileManager
+            )) != nil else {
+                return nil
+            }
+            let recorded = RecordedCapture(
+                url: url,
+                duration: 0,
+                writtenFrameCount: 0,
+                writeErrorDescription: nil
+            )
+            guard let inspected = try? inspect(recorded) else { return nil }
+            let evidence = RecordingIntegrityEvidence(
+                wallDurationSeconds: inspected.decodedDurationSeconds,
+                decodedDurationSeconds: inspected.decodedDurationSeconds,
+                fileSizeBytes: inspected.fileSizeBytes,
+                decodedFrameCount: inspected.decodedFrameCount,
+                writeErrorDescription: inspected.writeErrorDescription,
+                encodedAudioBytes: inspected.encodedAudioBytes,
+                peakPowerDecibels: inspected.peakPowerDecibels
+            )
+            guard evidence.fileSizeBytes >= 512,
+                  evidence.decodedFrameCount > 0,
+                  evidence.decodedDurationSeconds > 0 else {
+                return nil
+            }
+            let modifiedAt = (try? url.resourceValues(
+                forKeys: [.contentModificationDateKey]
+            ).contentModificationDate) ?? Date(timeIntervalSince1970: 0)
+            return RecoveryCandidate(
+                url: url,
+                identity: identity,
+                evidence: evidence,
+                isRecoveredFile: url.lastPathComponent != reservedName,
+                modifiedAt: modifiedAt
+            )
+        }
+        guard let selected = candidates.sorted(by: Self.preferredRecovery).first else {
+            return nil
+        }
+
+        try fileManager.setAttributes(
+            [.posixPermissions: 0o600],
+            ofItemAtPath: selected.url.path
+        )
+        let integrity = RecordingIntegrityEvaluator.evaluate(selected.evidence)
+        let endedAt = selected.modifiedAt
+        let startedAt = endedAt.addingTimeInterval(
+            -selected.evidence.decodedDurationSeconds
+        )
+        return CapturedAudioSegment(
+            audioIdentity: selected.identity,
+            startedAtMilliseconds: Self.milliseconds(since1970: startedAt),
+            endedAtMilliseconds: Self.milliseconds(since1970: endedAt),
+            durationMilliseconds: Self.milliseconds(
+                selected.evidence.decodedDurationSeconds
+            ),
+            decodedDurationMilliseconds: Self.milliseconds(
+                selected.evidence.decodedDurationSeconds
+            ),
+            byteCount: Int64(max(0, selected.evidence.fileSizeBytes)),
+            isPlayable: true,
+            isPartial: true,
+            integrityReasons: integrity.reasons.map {
+                SegmentIntegrityReason($0.rawValue)
+            }
+        )
+    }
+
+    private func installDriverTerminationBridge() {
+        driver.onUnexpectedTermination = { [weak self] in
+            guard let self,
+                  self.activeCapture != nil,
+                  !self.didReportUnexpectedTermination else {
+                return
+            }
+            self.didReportUnexpectedTermination = true
+            self.unexpectedTerminationHandler?()
+        }
+    }
+
+    private func adoptIdentity(
+        for authoritativeURL: URL,
+        sessionID: SessionID
+    ) throws -> SegmentAudioIdentity {
+        if let identity = try? SegmentAudioIdentity(
+            validating: authoritativeURL.lastPathComponent
+        ) {
+            return identity
+        }
+
+        let identity: SegmentAudioIdentity
+        do {
+            identity = try SegmentAudioIdentity(
+                validating: "capture-\(UUID().uuidString.lowercased()).m4a"
+            )
+        } catch {
+            throw VoiceCoreSegmentRecorderError.invalidAuthoritativeAudioIdentity
+        }
+        let adoptedURL = try paths.audioURL(
+            sessionID: sessionID,
+            identity: identity,
+            createParentDirectory: false,
+            fileManager: fileManager
+        )
+        do {
+            try fileManager.moveItem(at: authoritativeURL, to: adoptedURL)
+        } catch {
+            throw VoiceCoreSegmentRecorderError.sourceAudioUnavailable
+        }
+        return identity
+    }
+
+    private func inspectedEvidence(
+        for recorded: RecordedCapture,
+        at authoritativeURL: URL
+    ) -> RecordingIntegrityEvidence {
+        let authoritativeCapture = RecordedCapture(
+            url: authoritativeURL,
+            duration: recorded.duration,
+            writtenFrameCount: recorded.writtenFrameCount,
+            writeErrorDescription: recorded.writeErrorDescription,
+            peakPowerDecibels: recorded.peakPowerDecibels
+        )
+        if let evidence = try? inspect(authoritativeCapture) {
+            return evidence
+        }
+        let byteCount = (try? authoritativeURL.resourceValues(
+            forKeys: [.fileSizeKey]
+        ).fileSize) ?? 0
+        return RecordingIntegrityEvidence(
+            wallDurationSeconds: recorded.duration,
+            decodedDurationSeconds: 0,
+            fileSizeBytes: byteCount,
+            decodedFrameCount: 0,
+            writeErrorDescription: recorded.writeErrorDescription
+                ?? "integrity_inspection_failed",
+            peakPowerDecibels: recorded.peakPowerDecibels
+        )
+    }
+
+    private static func milliseconds(since1970 date: Date) -> Int64 {
+        Int64((date.timeIntervalSince1970 * 1_000).rounded())
+    }
+
+    private static func milliseconds(_ seconds: TimeInterval) -> Int64 {
+        Int64((max(0, seconds) * 1_000).rounded())
+    }
+
+    private static func preferredRecovery(
+        _ lhs: RecoveryCandidate,
+        _ rhs: RecoveryCandidate
+    ) -> Bool {
+        if lhs.isRecoveredFile != rhs.isRecoveredFile {
+            return lhs.isRecoveredFile
+        }
+        if lhs.modifiedAt != rhs.modifiedAt {
+            return lhs.modifiedAt > rhs.modifiedAt
+        }
+        if lhs.evidence.decodedDurationSeconds
+            != rhs.evidence.decodedDurationSeconds {
+            return lhs.evidence.decodedDurationSeconds
+                > rhs.evidence.decodedDurationSeconds
+        }
+        return lhs.identity.fileName < rhs.identity.fileName
+    }
+}

--- a/Sources/InterviewArcLiveVoiceAdapter/VoiceCoreSegmentTranscriber.swift
+++ b/Sources/InterviewArcLiveVoiceAdapter/VoiceCoreSegmentTranscriber.swift
@@ -1,0 +1,269 @@
+import Foundation
+import InterviewArcLiveCore
+import InterviewArcVoiceCore
+
+typealias VoiceCoreTranscriberFactory = @Sendable (String) -> any SpeechTranscribing
+typealias VoiceCoreIntegrityEvaluator = @Sendable (
+    URL,
+    String,
+    TranscriptionResult
+) -> TranscriptionIntegrityResult
+
+public actor VoiceCoreSegmentTranscriber: SegmentTranscribing {
+    private static let vocabularyPrompt =
+        "Preserve punctuation, names, acronyms, and technical terminology."
+
+    private let paths: LiveVoicePaths
+    private let fileManager: FileManager
+    private let makeTranscriber: VoiceCoreTranscriberFactory
+    private let evaluateIntegrity: VoiceCoreIntegrityEvaluator
+    private let scratchCleanupPolicy: ProviderScratchCleanupPolicy
+    private let now: @Sendable () -> Date
+    private var didCompleteInitialScratchCleanup = false
+
+    public init() {
+        paths = LiveVoicePaths()
+        fileManager = .default
+        makeTranscriber = {
+            GroqTranscriber(
+                apiKey: $0,
+                session: URLSession(configuration: .ephemeral)
+            )
+        }
+        evaluateIntegrity = { audioURL, prompt, transcription in
+            Self.productionIntegrityEvaluation(
+                audioURL: audioURL,
+                prompt: prompt,
+                transcription: transcription
+            )
+        }
+        scratchCleanupPolicy = .production
+        now = Date.init
+    }
+
+    init(
+        applicationSupportRoot: URL,
+        fileManager: FileManager = .default,
+        makeTranscriber: @escaping VoiceCoreTranscriberFactory,
+        evaluateIntegrity: @escaping VoiceCoreIntegrityEvaluator,
+        scratchCleanupPolicy: ProviderScratchCleanupPolicy = .production,
+        now: @escaping @Sendable () -> Date = Date.init
+    ) {
+        paths = LiveVoicePaths(applicationSupportRoot: applicationSupportRoot)
+        self.fileManager = fileManager
+        self.makeTranscriber = makeTranscriber
+        self.evaluateIntegrity = evaluateIntegrity
+        self.scratchCleanupPolicy = scratchCleanupPolicy
+        self.now = now
+    }
+
+    public func transcribe(
+        _ request: SegmentTranscriptionRequest,
+        credential: String
+    ) async throws -> SegmentTranscriptionResult {
+        cleanupStaleScratchOnFirstUse()
+
+        let normalizedCredential = credential.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        )
+        guard !normalizedCredential.isEmpty else {
+            throw SegmentTranscriptionAdapterFailure(reason: .missingCredential)
+        }
+
+        let audioURL = try sourceAudioURL(for: request)
+        let scratchURL: URL
+        do {
+            scratchURL = try paths.transcriptionScratchDirectory(
+                sessionID: request.sessionID,
+                attemptID: request.attemptID,
+                fileManager: fileManager
+            )
+        } catch {
+            throw SegmentTranscriptionAdapterFailure(reason: .invalidAudio)
+        }
+        defer { try? fileManager.removeItem(at: scratchURL) }
+
+        let transcriber = makeTranscriber(normalizedCredential)
+        let transcription: TranscriptionResult
+        do {
+            switch request.kind {
+            case .initial:
+                transcription = try await transcriber.transcribe(
+                    fileURL: audioURL,
+                    prompt: Self.vocabularyPrompt,
+                    temporaryDirectory: scratchURL
+                )
+            case .retry:
+                transcription = try await transcriber.transcribeCoverageRecovery(
+                    fileURL: audioURL,
+                    temporaryDirectory: scratchURL
+                )
+            }
+        } catch {
+            throw Self.safeFailure(for: error)
+        }
+
+        guard !transcription.text.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        ).isEmpty else {
+            throw SegmentTranscriptionAdapterFailure(
+                reason: .emptyProviderResult
+            )
+        }
+
+        let integrity = evaluateIntegrity(
+            audioURL,
+            request.kind == .initial ? Self.vocabularyPrompt : "",
+            transcription
+        )
+        let quality: TranscriptQuality
+        if integrity.reasons.contains(.promptLeakage) {
+            quality = .possibleContamination
+        } else if integrity.isSuspicious {
+            quality = .bestAvailable
+        } else {
+            quality = .verified
+        }
+
+        return SegmentTranscriptionResult(
+            body: transcription.text,
+            quality: quality,
+            integrityReasons: integrity.reasons.map {
+                SegmentIntegrityReason($0.rawValue)
+            }
+        )
+    }
+
+    private func cleanupStaleScratchOnFirstUse() {
+        guard !didCompleteInitialScratchCleanup else { return }
+        do {
+            try paths.cleanupStaleTranscriptionScratch(
+                now: now(),
+                policy: scratchCleanupPolicy,
+                fileManager: fileManager
+            )
+            didCompleteInitialScratchCleanup = true
+        } catch {
+            // Cleanup must not discard a requested transcription. Leave the
+            // flag unset so a later explicit attempt gets another bounded try.
+        }
+    }
+
+    private func sourceAudioURL(
+        for request: SegmentTranscriptionRequest
+    ) throws -> URL {
+        do {
+            let url = try paths.audioURL(
+                sessionID: request.sessionID,
+                identity: request.audioIdentity,
+                createParentDirectory: false,
+                fileManager: fileManager
+            )
+            try paths.validateSourceAudio(at: url, fileManager: fileManager)
+            return url
+        } catch {
+            throw SegmentTranscriptionAdapterFailure(reason: .invalidAudio)
+        }
+    }
+
+    private static func productionIntegrityEvaluation(
+        audioURL: URL,
+        prompt: String,
+        transcription: TranscriptionResult
+    ) -> TranscriptionIntegrityResult {
+        let speechEvidence = try? LocalSpeechEvidenceAnalyzer.inspect(audioURL)
+        let audioDuration = speechEvidence?.analyzedDurationSeconds
+            ?? transcription.durationSeconds
+        let trailingSpeech = speechEvidence?.evidence(
+            from: transcription.durationSeconds,
+            to: audioDuration
+        ).hasSustainedSpeech ?? false
+        return TranscriptionIntegrityEvaluator.evaluate(
+            TranscriptionIntegrityEvidence(
+                audioDurationSeconds: audioDuration,
+                providerDurationSeconds: transcription.durationSeconds,
+                expectedChunkCount: transcription.chunkCount,
+                returnedChunkCount: transcription.chunkCount,
+                transcript: transcription.text,
+                prompt: prompt,
+                hasSustainedSpeechAfterProviderCoverage: trailingSpeech
+            )
+        )
+    }
+
+    private static func safeFailure(for error: Error) -> SegmentTranscriptionAdapterFailure {
+        if error is CancellationError {
+            return SegmentTranscriptionAdapterFailure(reason: .interrupted)
+        }
+        guard let voiceError = error as? VoiceBridgeError else {
+            return SegmentTranscriptionAdapterFailure(
+                reason: .providerUnavailable,
+                providerCode: .unknown
+            )
+        }
+        switch voiceError {
+        case .invalidProviderCredential:
+            return SegmentTranscriptionAdapterFailure(
+                reason: .credentialRejected,
+                providerCode: .unauthorized
+            )
+        case .providerPermissionDenied:
+            return SegmentTranscriptionAdapterFailure(
+                reason: .providerUnavailable,
+                providerCode: .invalidRequest
+            )
+        case .providerResponseFailure(let status, _),
+             .invalidResponse(let status, _):
+            if status == 401 {
+                return SegmentTranscriptionAdapterFailure(
+                    reason: .credentialRejected,
+                    providerCode: .unauthorized
+                )
+            }
+            return SegmentTranscriptionAdapterFailure(
+                reason: .providerUnavailable,
+                providerCode: providerCode(for: status)
+            )
+        case .emptyTranscript:
+            return SegmentTranscriptionAdapterFailure(
+                reason: .emptyProviderResult
+            )
+        case .microphoneDenied,
+             .recordingUnavailable,
+             .incompleteRecording:
+            return SegmentTranscriptionAdapterFailure(reason: .invalidAudio)
+        case .missingCredential:
+            return SegmentTranscriptionAdapterFailure(reason: .missingCredential)
+        case .suspiciousTranscript:
+            return SegmentTranscriptionAdapterFailure(
+                reason: .providerUnavailable,
+                providerCode: .unknown
+            )
+        case .noFocusedActivity,
+             .noSpecialist,
+             .protocolMismatch,
+             .codexUnavailable:
+            return SegmentTranscriptionAdapterFailure(
+                reason: .providerUnavailable,
+                providerCode: .unknown
+            )
+        }
+    }
+
+    private static func providerCode(
+        for status: Int
+    ) -> SegmentTranscriptionProviderCode {
+        switch status {
+        case 401:
+            .unauthorized
+        case 429:
+            .rateLimited
+        case 400..<500:
+            .invalidRequest
+        case 500..<600:
+            .unavailable
+        default:
+            .unknown
+        }
+    }
+}

--- a/Tests/InterviewArcLiveCoreTests/SegmentLifecycleTests.swift
+++ b/Tests/InterviewArcLiveCoreTests/SegmentLifecycleTests.swift
@@ -1,0 +1,1109 @@
+import Foundation
+import XCTest
+@testable import InterviewArcLiveCore
+
+@MainActor
+final class SegmentLifecycleTests: XCTestCase {
+    func testTwoOrderedSegmentsBecomeOneCanonicalCandidateTurn() async throws {
+        let store = InMemorySessionManifestStore()
+        let session = try await makeCandidateFloorSession(store: store)
+
+        let first = try await makeTranscribedSegment(
+            session: session,
+            commandStem: "first",
+            body: "  first spoken part  ",
+            quality: .verified
+        )
+        let second = try await makeTranscribedSegment(
+            session: session,
+            commandStem: "second",
+            body: "\nsecond spoken part\n",
+            quality: .possibleContamination
+        )
+
+        let completed = try await session.execute(
+            .handOffSegments(commandID: CommandID("handoff-segments"))
+        )
+
+        XCTAssertEqual(completed.segments.map(\.id), [first, second])
+        XCTAssertEqual(completed.segments.map(\.ordinal), [0, 1])
+        XCTAssertTrue(completed.segments.allSatisfy { $0.committedTurnID != nil })
+        guard case .candidate(let candidate) = completed.turns.first else {
+            return XCTFail("Expected one assembled Candidate Turn")
+        }
+        XCTAssertEqual(candidate.segmentIDs, [first, second])
+        XCTAssertEqual(candidate.transcript.body, "first spoken part\n\nsecond spoken part")
+        XCTAssertEqual(candidate.transcript.quality, .possibleContamination)
+
+        let restored = try await InterviewRoomSession.restore(
+            sessionID: completed.sessionID,
+            manifestStore: store,
+            interviewerRuntime: fixtureRuntime()
+        )
+        let restoredSnapshot = await restored.snapshot()
+        XCTAssertEqual(restoredSnapshot, completed)
+    }
+
+    func testBeginAndAttemptAuthorizationReceiptsAreIdempotent() async throws {
+        let store = InMemorySessionManifestStore()
+        let session = try await makeCandidateFloorSession(store: store)
+        let begin = InterviewRoomCommand.beginSegment(commandID: CommandID("stable-begin"))
+
+        let accepted = try await session.apply(begin)
+        let duplicate = try await session.apply(begin)
+        XCTAssertEqual(accepted.disposition, .accepted)
+        XCTAssertEqual(duplicate.disposition, .alreadyApplied)
+        XCTAssertEqual(duplicate.snapshot.segments.count, 1)
+
+        let segmentID = try XCTUnwrap(duplicate.snapshot.segments.first?.id)
+        try await makeAudioReady(
+            session: session,
+            segmentID: segmentID,
+            commandStem: "stable"
+        )
+        let authorization = InterviewRoomCommand.authorizeSegmentTranscription(
+            commandID: CommandID("stable-attempt"),
+            segmentID: segmentID,
+            kind: .initial,
+            credentialFingerprint: credentialFingerprint("credential-a")
+        )
+        let firstAttempt = try await session.apply(authorization)
+        let duplicateAttempt = try await session.apply(authorization)
+        XCTAssertEqual(firstAttempt.disposition, .accepted)
+        XCTAssertEqual(duplicateAttempt.disposition, .alreadyApplied)
+        XCTAssertEqual(
+            duplicateAttempt.snapshot.segments[0].transcriptionAttempts.count,
+            1
+        )
+    }
+
+    func testSelectionPrefersQualityThenWordsAndRetainsEveryCandidate() async throws {
+        let session = try await makeCandidateFloorSession(
+            store: InMemorySessionManifestStore()
+        )
+        let begin = try await session.execute(
+            .beginSegment(commandID: CommandID("select-begin"))
+        )
+        let segmentID = try XCTUnwrap(begin.segments.first?.id)
+        try await makeAudioReady(session: session, segmentID: segmentID, commandStem: "select")
+
+        try await recordCandidate(
+            session: session,
+            segmentID: segmentID,
+            commandStem: "attempt-one",
+            kind: .initial,
+            body: "many contaminated transcript words survive here",
+            quality: .possibleContamination,
+            credential: "credential-a"
+        )
+        try await recordCandidate(
+            session: session,
+            segmentID: segmentID,
+            commandStem: "attempt-two",
+            kind: .retry,
+            body: "verified short",
+            quality: .verified,
+            credential: "credential-a"
+        )
+        try await recordCandidate(
+            session: session,
+            segmentID: segmentID,
+            commandStem: "attempt-three",
+            kind: .retry,
+            body: "verified answer with more words",
+            quality: .verified,
+            credential: "credential-a"
+        )
+
+        let selectedSnapshot = await session.snapshot()
+        let segment = try XCTUnwrap(selectedSnapshot.segments.first)
+        XCTAssertEqual(segment.transcriptCandidates.count, 3)
+        XCTAssertEqual(segment.selectedCandidate?.body, "verified answer with more words")
+        XCTAssertEqual(segment.selectedCandidate?.quality, .verified)
+    }
+
+    func testRejectedCredentialRequiresChangedFingerprint() async throws {
+        let session = try await makeCandidateFloorSession(
+            store: InMemorySessionManifestStore()
+        )
+        let begin = try await session.execute(
+            .beginSegment(commandID: CommandID("credential-begin"))
+        )
+        let segmentID = try XCTUnwrap(begin.segments.first?.id)
+        try await makeAudioReady(
+            session: session,
+            segmentID: segmentID,
+            commandStem: "credential"
+        )
+        let rejectedFingerprint = credentialFingerprint("rejected-key")
+        let authorized = try await session.execute(
+            .authorizeSegmentTranscription(
+                commandID: CommandID("credential-attempt"),
+                segmentID: segmentID,
+                kind: .initial,
+                credentialFingerprint: rejectedFingerprint
+            )
+        )
+        let attempt = try XCTUnwrap(authorized.segments[0].transcriptionAttempts.first)
+        _ = try await session.execute(
+            .recordSegmentTranscriptionOutcome(
+                commandID: CommandID("credential-outcome"),
+                segmentID: segmentID,
+                attemptID: attempt.id,
+                outcome: .failed(
+                    SegmentTranscriptionFailure(
+                        reason: .credentialRejected,
+                        providerCode: .unauthorized,
+                        credentialFingerprint: rejectedFingerprint
+                    )
+                )
+            )
+        )
+
+        do {
+            _ = try await session.execute(
+                .authorizeSegmentTranscription(
+                    commandID: CommandID("same-credential-retry"),
+                    segmentID: segmentID,
+                    kind: .retry,
+                    credentialFingerprint: rejectedFingerprint
+                )
+            )
+            XCTFail("Expected unchanged rejected credential to be blocked")
+        } catch {
+            XCTAssertEqual(
+                error as? InterviewRoomSessionError,
+                .rejectedCredentialUnchanged
+            )
+        }
+
+        let changed = try await session.execute(
+            .authorizeSegmentTranscription(
+                commandID: CommandID("changed-credential-retry"),
+                segmentID: segmentID,
+                kind: .retry,
+                credentialFingerprint: credentialFingerprint("replacement-key")
+            )
+        )
+        XCTAssertEqual(changed.segments[0].transcriptionAttempts.count, 2)
+        XCTAssertFalse(
+            changed.segments[0].transcriptionAttempts[1].credentialFingerprint
+                .contains("replacement-key")
+        )
+    }
+
+    func testInsufficientSignalNeverAuthorizesProviderAttempt() async throws {
+        let session = try await makeCandidateFloorSession(
+            store: InMemorySessionManifestStore()
+        )
+        let begin = try await session.execute(
+            .beginSegment(commandID: CommandID("silent-begin"))
+        )
+        let segmentID = try XCTUnwrap(begin.segments.first?.id)
+        _ = try await session.execute(
+            .recordSegmentCaptureOutcome(
+                commandID: CommandID("silent-started"),
+                segmentID: segmentID,
+                outcome: .recordingStarted
+            )
+        )
+        _ = try await session.execute(
+            .finalizeSegment(commandID: CommandID("silent-finalize"), segmentID: segmentID)
+        )
+        _ = try await session.execute(
+            .recordSegmentCaptureOutcome(
+                commandID: CommandID("silent-audio"),
+                segmentID: segmentID,
+                outcome: .finalized(
+                    try capturedAudio(
+                        fileName: "silent.m4a",
+                        integrityReasons: [.insufficientSignal]
+                    )
+                )
+            )
+        )
+
+        do {
+            _ = try await session.execute(
+                .authorizeSegmentTranscription(
+                    commandID: CommandID("silent-attempt"),
+                    segmentID: segmentID,
+                    kind: .initial,
+                    credentialFingerprint: credentialFingerprint("credential")
+                )
+            )
+            XCTFail("Expected insufficient-signal audio to stay away from Groq")
+        } catch {
+            XCTAssertEqual(
+                error as? InterviewRoomSessionError,
+                .segmentHasInsufficientSignal(segmentID)
+            )
+        }
+        let unchanged = await session.snapshot()
+        XCTAssertTrue(unchanged.segments[0].transcriptionAttempts.isEmpty)
+    }
+
+    func testUnresolvedSegmentBlocksHandOffAndExplicitExclusionClosesDraft() async throws {
+        let session = try await makeCandidateFloorSession(
+            store: InMemorySessionManifestStore()
+        )
+        let excludedID = try await makeTranscribedSegment(
+            session: session,
+            commandStem: "excluded",
+            body: "do not include this",
+            quality: .verified
+        )
+        let includedID = try await makeTranscribedSegment(
+            session: session,
+            commandStem: "included",
+            body: "include this",
+            quality: .verified
+        )
+        let unresolvedSnapshot = try await session.execute(
+            .beginSegment(commandID: CommandID("unresolved-begin"))
+        )
+        let unresolvedID = try XCTUnwrap(unresolvedSnapshot.segments.last?.id)
+        try await makeAudioReady(
+            session: session,
+            segmentID: unresolvedID,
+            commandStem: "unresolved"
+        )
+
+        do {
+            _ = try await session.execute(
+                .handOffSegments(commandID: CommandID("blocked-handoff"))
+            )
+            XCTFail("Expected playable unresolved speech to block Hand off")
+        } catch {
+            XCTAssertEqual(
+                error as? InterviewRoomSessionError,
+                .unresolvedSegmentsPreventHandOff([unresolvedID])
+            )
+        }
+        _ = try await session.execute(
+            .excludeSegment(
+                commandID: CommandID("exclude-explicitly"),
+                segmentID: excludedID,
+                reason: .userSkipped
+            )
+        )
+        _ = try await session.execute(
+            .excludeSegment(
+                commandID: CommandID("exclude-unresolved"),
+                segmentID: unresolvedID,
+                reason: .noUsableTranscript
+            )
+        )
+
+        let completed = try await session.execute(
+            .handOffSegments(commandID: CommandID("handoff-with-exclusion"))
+        )
+        guard case .candidate(let candidate) = completed.turns.first else {
+            return XCTFail("Expected Candidate Turn")
+        }
+        XCTAssertEqual(candidate.transcript.body, "include this")
+        XCTAssertEqual(candidate.segmentIDs, [excludedID, includedID, unresolvedID])
+        XCTAssertTrue(completed.segments.allSatisfy { $0.committedTurnID == candidate.id })
+
+        _ = try await session.execute(
+            .giveCandidateFloor(commandID: CommandID("new-floor"))
+        )
+        let next = try await session.execute(
+            .beginSegment(commandID: CommandID("new-segment"))
+        )
+        XCTAssertEqual(next.segments.filter { $0.committedTurnID == nil }.count, 1)
+    }
+
+    func testAudioIdentityRejectsAbsoluteAndTraversalPathsDuringConstructionAndRestore() throws {
+        XCTAssertThrowsError(try SegmentAudioIdentity(validating: "../escape.m4a"))
+        XCTAssertThrowsError(try SegmentAudioIdentity(validating: "/tmp/escape.m4a"))
+        XCTAssertThrowsError(try SegmentAudioIdentity(validating: "nested/escape.m4a"))
+        XCTAssertNoThrow(try SegmentAudioIdentity(validating: "segment-safe_01.m4a"))
+
+        let malicious = Data("\"../escape.m4a\"".utf8)
+        XCTAssertThrowsError(try JSONDecoder().decode(SegmentAudioIdentity.self, from: malicious))
+    }
+
+    func testRestoreRejectsCandidateTurnWithMissingSegmentMembership() async throws {
+        let sessionID = SessionID("invalid-membership-session")
+        let candidate = CandidateTurn(
+            id: TurnID("candidate-turn"),
+            commandID: CommandID("handoff"),
+            transcript: CandidateTranscript(body: "answer", quality: .verified),
+            segmentIDs: [SegmentID("missing-segment")]
+        )
+        let manifest = SessionManifest(
+            sessionID: sessionID,
+            activityID: "invalid-membership-activity",
+            phase: .interviewerProcessing,
+            turnMode: .manual,
+            turns: [.candidate(candidate)],
+            segments: [],
+            revision: 1,
+            appliedCommands: []
+        )
+        let store = InMemorySessionManifestStore(manifests: [manifest])
+
+        do {
+            _ = try await InterviewRoomSession.restore(
+                sessionID: sessionID,
+                manifestStore: store,
+                interviewerRuntime: fixtureRuntime()
+            )
+            XCTFail("Expected reverse Segment membership validation to fail")
+        } catch let error as InterviewRoomSessionError {
+            guard case .invalidManifest = error else {
+                return XCTFail("Expected invalidManifest, received \(error)")
+            }
+        }
+    }
+
+    func testCoordinatorDoesNotReplayProviderForDuplicateFailedRetry() async throws {
+        let recorder = StubSegmentRecorder(capture: try capturedAudio(fileName: "coordinator.m4a"))
+        let transcriber = SequencedSegmentTranscriber(
+            results: [
+                .failure(.init(reason: .providerUnavailable, providerCode: .unavailable)),
+                .failure(.init(reason: .providerUnavailable, providerCode: .unavailable)),
+                .success(.init(body: "recovered transcript", quality: .verified)),
+            ]
+        )
+        let coordinator = try await SegmentSpeechCoordinator.open(
+            sessionID: SessionID("coordinator-idempotency"),
+            activityID: "activity-coordinator-idempotency",
+            manifestStore: InMemorySessionManifestStore(),
+            interviewerRuntime: fixtureRuntime(),
+            recording: recorder,
+            transcriber: transcriber,
+            credentialReader: FixedCredentialReader(value: "credential")
+        )
+        _ = try await coordinator.giveCandidateFloor(commandID: CommandID("floor"))
+        _ = try await coordinator.beginSegment(commandID: CommandID("begin"))
+        do {
+            _ = try await coordinator.finishSegment(
+                commandID: CommandID("finish"),
+                transcriptionCommandID: CommandID("initial-attempt")
+            )
+            XCTFail("Expected initial provider failure")
+        } catch {
+            XCTAssertEqual(
+                error as? SegmentSpeechCoordinatorError,
+                .transcriptionFailed(.providerUnavailable)
+            )
+        }
+        let segmentID = try XCTUnwrap(coordinator.snapshot.segments.first?.id)
+
+        let retryID = CommandID("retry-once")
+        do {
+            _ = try await coordinator.retryTranscription(
+                segmentID: segmentID,
+                commandID: retryID
+            )
+            XCTFail("Expected retry provider failure")
+        } catch {
+            XCTAssertEqual(
+                error as? SegmentSpeechCoordinatorError,
+                .transcriptionFailed(.providerUnavailable)
+            )
+        }
+        _ = try await coordinator.retryTranscription(segmentID: segmentID, commandID: retryID)
+        let callsAfterDuplicate = await transcriber.invocationCount()
+        XCTAssertEqual(callsAfterDuplicate, 2)
+
+        let recovered = try await coordinator.retryTranscription(
+            segmentID: segmentID,
+            commandID: CommandID("retry-with-fresh-id")
+        )
+        let callsAfterRecovery = await transcriber.invocationCount()
+        XCTAssertEqual(callsAfterRecovery, 3)
+        XCTAssertEqual(recovered.segments[0].selectedCandidate?.body, "recovered transcript")
+    }
+
+    func testResumePendingWorkRecoversPartialWithoutProviderReplay() async throws {
+        let store = InMemorySessionManifestStore()
+        let session = try await makeCandidateFloorSession(store: store)
+        let begin = try await session.execute(
+            .beginSegment(commandID: CommandID("interrupted-begin"))
+        )
+        let segmentID = try XCTUnwrap(begin.segments.first?.id)
+        _ = try await session.execute(
+            .recordSegmentCaptureOutcome(
+                commandID: CommandID("interrupted-recording"),
+                segmentID: segmentID,
+                outcome: .recordingStarted
+            )
+        )
+
+        let recoveredAudio = try capturedAudio(fileName: "recovered-partial.m4a", isPartial: true)
+        let recorder = StubSegmentRecorder(capture: recoveredAudio, recovery: recoveredAudio)
+        let transcriber = SequencedSegmentTranscriber(results: [])
+        let coordinator = try await SegmentSpeechCoordinator.open(
+            sessionID: begin.sessionID,
+            activityID: begin.activityID,
+            manifestStore: store,
+            interviewerRuntime: fixtureRuntime(),
+            recording: recorder,
+            transcriber: transcriber,
+            credentialReader: FixedCredentialReader(value: "credential")
+        )
+
+        let recovered = try await coordinator.resumePendingWork()
+        XCTAssertEqual(recovered.segments[0].lifecycle, .audioReady)
+        XCTAssertEqual(recovered.segments[0].capturedAudio, recoveredAudio)
+        let recoveryCount = recorder.recoveryCount()
+        let providerCalls = await transcriber.invocationCount()
+        XCTAssertEqual(recoveryCount, 1)
+        XCTAssertEqual(providerCalls, 0)
+    }
+
+    func testResumePendingWorkMarksAuthorizedAttemptInterruptedBeforeExplicitRetry() async throws {
+        let store = InMemorySessionManifestStore()
+        let session = try await makeCandidateFloorSession(store: store)
+        let segmentID = try await makeAudioReadySegment(
+            session: session,
+            commandStem: "interrupted-provider"
+        )
+        let fingerprint = credentialFingerprint("credential")
+        _ = try await session.execute(
+            .authorizeSegmentTranscription(
+                commandID: CommandID("interrupted-provider-authorization"),
+                segmentID: segmentID,
+                kind: .initial,
+                credentialFingerprint: fingerprint
+            )
+        )
+
+        let transcriber = SequencedSegmentTranscriber(
+            results: [
+                .success(
+                    SegmentTranscriptionResult(
+                        body: "explicitly recovered transcript",
+                        quality: .verified
+                    )
+                )
+            ]
+        )
+        let interruptedSnapshot = await session.snapshot()
+        let coordinator = try await SegmentSpeechCoordinator.open(
+            sessionID: interruptedSnapshot.sessionID,
+            activityID: "activity-segment-fixture",
+            manifestStore: store,
+            interviewerRuntime: fixtureRuntime(),
+            recording: StubSegmentRecorder(
+                capture: try capturedAudio(fileName: "unused-interrupted.m4a")
+            ),
+            transcriber: transcriber,
+            credentialReader: FixedCredentialReader(value: "credential")
+        )
+
+        let reconciled = try await coordinator.resumePendingWork()
+        XCTAssertEqual(reconciled.segments[0].lifecycle, .audioReady)
+        XCTAssertEqual(reconciled.segments[0].transcriptionAttempts.count, 1)
+        XCTAssertEqual(reconciled.segments[0].transcriptionAttempts[0].state, .failed)
+        XCTAssertEqual(
+            reconciled.segments[0].transcriptionAttempts[0].failure?.reason,
+            .interrupted
+        )
+        let callsBeforeExplicitRetry = await transcriber.invocationCount()
+        XCTAssertEqual(callsBeforeExplicitRetry, 0)
+
+        let completed = try await coordinator.transcribeSegment(
+            segmentID: segmentID,
+            commandID: CommandID("explicit-provider-retry")
+        )
+        XCTAssertEqual(completed.segments[0].transcriptionAttempts.count, 2)
+        XCTAssertEqual(completed.segments[0].transcriptionAttempts[1].kind, .retry)
+        XCTAssertEqual(
+            completed.segments[0].selectedCandidate?.body,
+            "explicitly recovered transcript"
+        )
+        let callsAfterExplicitRetry = await transcriber.invocationCount()
+        XCTAssertEqual(callsAfterExplicitRetry, 1)
+    }
+
+    func testRecoveredZeroAttemptSegmentUsesInitialExplicitTranscription() async throws {
+        let store = InMemorySessionManifestStore()
+        let session = try await makeCandidateFloorSession(store: store)
+        let begin = try await session.execute(
+            .beginSegment(commandID: CommandID("zero-attempt-begin"))
+        )
+        let segmentID = try XCTUnwrap(begin.segments.first?.id)
+        _ = try await session.execute(
+            .recordSegmentCaptureOutcome(
+                commandID: CommandID("zero-attempt-recording"),
+                segmentID: segmentID,
+                outcome: .recordingStarted
+            )
+        )
+
+        let recoveredAudio = try capturedAudio(fileName: "zero-attempt-recovered.m4a", isPartial: true)
+        let recorder = StubSegmentRecorder(capture: recoveredAudio, recovery: recoveredAudio)
+        let transcriber = SequencedSegmentTranscriber(
+            results: [
+                .success(
+                    SegmentTranscriptionResult(body: "recovered first attempt", quality: .bestAvailable)
+                )
+            ]
+        )
+        let coordinator = try await SegmentSpeechCoordinator.open(
+            sessionID: begin.sessionID,
+            activityID: begin.activityID,
+            manifestStore: store,
+            interviewerRuntime: fixtureRuntime(),
+            recording: recorder,
+            transcriber: transcriber,
+            credentialReader: FixedCredentialReader(value: "credential")
+        )
+        _ = try await coordinator.resumePendingWork()
+
+        let completed = try await coordinator.transcribeSegment(
+            segmentID: segmentID,
+            commandID: CommandID("zero-attempt-transcribe")
+        )
+        XCTAssertEqual(completed.segments[0].transcriptionAttempts.count, 1)
+        XCTAssertEqual(completed.segments[0].transcriptionAttempts[0].kind, .initial)
+        XCTAssertEqual(completed.segments[0].selectedCandidate?.body, "recovered first attempt")
+        let explicitInvocationCount = await transcriber.invocationCount()
+        XCTAssertEqual(explicitInvocationCount, 1)
+    }
+
+    func testUnexpectedTerminationPublishesPreservedAudioWithoutProviderInvocation() async throws {
+        let recorder = StubSegmentRecorder(
+            capture: try capturedAudio(fileName: "unexpected-partial.m4a", isPartial: true)
+        )
+        let transcriber = SequencedSegmentTranscriber(
+            results: [
+                .success(
+                    SegmentTranscriptionResult(
+                        body: "preserved partial answer",
+                        quality: .bestAvailable
+                    )
+                )
+            ]
+        )
+        let coordinator = try await SegmentSpeechCoordinator.open(
+            sessionID: SessionID("unexpected-observer-session"),
+            activityID: "unexpected-observer-activity",
+            manifestStore: InMemorySessionManifestStore(),
+            interviewerRuntime: fixtureRuntime(),
+            recording: recorder,
+            transcriber: transcriber,
+            credentialReader: FixedCredentialReader(value: "credential")
+        )
+        _ = try await coordinator.giveCandidateFloor(commandID: CommandID("observer-floor"))
+        _ = try await coordinator.beginSegment(commandID: CommandID("observer-begin"))
+
+        let completed = expectation(description: "unexpected termination published preserved audio")
+        let observer = SnapshotObserver(completed: completed)
+        coordinator.setSnapshotHandler { snapshot in
+            observer.receive(snapshot)
+        }
+
+        recorder.triggerUnexpectedTermination()
+        await fulfillment(of: [completed], timeout: 2)
+
+        XCTAssertEqual(coordinator.snapshot.segments.first?.lifecycle, .audioReady)
+        XCTAssertNil(coordinator.snapshot.segments.first?.selectedCandidate)
+        let invocationCount = await transcriber.invocationCount()
+        XCTAssertEqual(invocationCount, 0)
+        XCTAssertEqual(
+            observer.lifecycles,
+            [.recording, .finalizationAuthorized, .audioReady]
+        )
+    }
+
+    func testRecorderStopFailureKeepsAuthorizationAndFreshStopRetries() async throws {
+        let recorder = StubSegmentRecorder(
+            capture: try capturedAudio(fileName: "stop-retry.m4a"),
+            finishFailuresRemaining: 1
+        )
+        let coordinator = try await SegmentSpeechCoordinator.open(
+            sessionID: SessionID("stop-retry-session"),
+            activityID: "stop-retry-activity",
+            manifestStore: InMemorySessionManifestStore(),
+            interviewerRuntime: fixtureRuntime(),
+            recording: recorder,
+            transcriber: SequencedSegmentTranscriber(results: []),
+            credentialReader: FixedCredentialReader(value: "credential")
+        )
+        _ = try await coordinator.giveCandidateFloor(commandID: CommandID("stop-retry-floor"))
+        _ = try await coordinator.beginSegment(commandID: CommandID("stop-retry-begin"))
+
+        do {
+            _ = try await coordinator.finalizeSegment(commandID: CommandID("stop-retry-first"))
+            XCTFail("Expected first recorder Stop to fail")
+        } catch {
+            XCTAssertEqual(
+                error as? SegmentSpeechCoordinatorError,
+                .captureFailed(.captureFinalizationFailed)
+            )
+        }
+        XCTAssertEqual(coordinator.snapshot.segments[0].lifecycle, .finalizationAuthorized)
+        XCTAssertNil(coordinator.snapshot.segments[0].captureFailureReason)
+
+        let recovered = try await coordinator.finalizeSegment(
+            commandID: CommandID("stop-retry-second")
+        )
+        XCTAssertEqual(recovered.segments[0].lifecycle, .audioReady)
+        XCTAssertEqual(recorder.finishCount(), 2)
+    }
+
+    func testCompatibilityFinishTranscribesTheActiveSegmentNotOlderAudio() async throws {
+        let recorder = StubSegmentRecorder(
+            capture: try capturedAudio(fileName: "compatibility-active.m4a")
+        )
+        let transcriber = SequencedSegmentTranscriber(
+            results: [
+                .success(
+                    SegmentTranscriptionResult(body: "second segment only", quality: .verified)
+                )
+            ]
+        )
+        let coordinator = try await SegmentSpeechCoordinator.open(
+            sessionID: SessionID("compatibility-active-session"),
+            activityID: "compatibility-active-activity",
+            manifestStore: InMemorySessionManifestStore(),
+            interviewerRuntime: fixtureRuntime(),
+            recording: recorder,
+            transcriber: transcriber,
+            credentialReader: FixedCredentialReader(value: "credential")
+        )
+        _ = try await coordinator.giveCandidateFloor(commandID: CommandID("compatibility-floor"))
+        let firstRecording = try await coordinator.beginSegment(
+            commandID: CommandID("compatibility-first-begin")
+        )
+        let firstID = try XCTUnwrap(firstRecording.segments.first?.id)
+        _ = try await coordinator.finalizeSegment(commandID: CommandID("compatibility-first-stop"))
+
+        let secondRecording = try await coordinator.beginSegment(
+            commandID: CommandID("compatibility-second-begin")
+        )
+        let secondID = try XCTUnwrap(secondRecording.segments.last?.id)
+        let completed = try await coordinator.finishSegment(
+            commandID: CommandID("compatibility-second-stop"),
+            transcriptionCommandID: CommandID("compatibility-second-transcribe")
+        )
+
+        let first = try XCTUnwrap(completed.segments.first { $0.id == firstID })
+        let second = try XCTUnwrap(completed.segments.first { $0.id == secondID })
+        XCTAssertTrue(first.transcriptionAttempts.isEmpty)
+        XCTAssertEqual(second.selectedCandidate?.body, "second segment only")
+    }
+
+    func testMicStartPersistenceFailureStopsAndPreservesCapture() async throws {
+        let store = FailingRevisionSessionManifestStore(
+            failingRevision: 3,
+            failureCount: 2
+        )
+        let capture = try capturedAudio(
+            fileName: "start-persistence-recovery.m4a",
+            isPartial: true
+        )
+        let recorder = StubSegmentRecorder(
+            capture: capture,
+            recovery: capture,
+            finishSucceedsOnlyOnce: true
+        )
+        let coordinator = try await SegmentSpeechCoordinator.open(
+            sessionID: SessionID("start-persistence-session"),
+            activityID: "start-persistence-activity",
+            manifestStore: store,
+            interviewerRuntime: fixtureRuntime(),
+            recording: recorder,
+            transcriber: SequencedSegmentTranscriber(results: []),
+            credentialReader: FixedCredentialReader(value: "credential")
+        )
+        _ = try await coordinator.giveCandidateFloor(commandID: CommandID("start-persistence-floor"))
+
+        do {
+            _ = try await coordinator.beginSegment(commandID: CommandID("start-persistence-begin"))
+            XCTFail("Expected injected recording-start persistence failure")
+        } catch {
+            XCTAssertEqual(error as? InjectedStoreError, .writeFailed)
+        }
+
+        XCTAssertEqual(recorder.beginCount(), 1)
+        XCTAssertEqual(recorder.finishCount(), 1)
+        XCTAssertEqual(coordinator.snapshot.segments[0].lifecycle, .captureAuthorized)
+
+        let recovered = try await coordinator.finalizeSegment(
+            commandID: CommandID("start-persistence-explicit-stop")
+        )
+        XCTAssertEqual(recorder.finishCount(), 2)
+        XCTAssertEqual(recorder.recoveryCount(), 1)
+        XCTAssertEqual(recovered.segments[0].lifecycle, .audioReady)
+        XCTAssertEqual(
+            recovered.segments[0].capturedAudio?.audioIdentity.fileName,
+            "start-persistence-recovery.m4a"
+        )
+        let durable = try await store.load(sessionID: coordinator.snapshot.sessionID)
+        XCTAssertEqual(durable?.segments[0].lifecycle, .audioReady)
+    }
+
+    func testRestoreRejectsDuplicateCandidateTurnIDsWithoutTrapping() async throws {
+        let duplicateID = TurnID("duplicate-candidate-id")
+        let first = CandidateTurn(
+            id: duplicateID,
+            commandID: CommandID("first-candidate"),
+            transcript: CandidateTranscript(body: "first", quality: .verified)
+        )
+        let second = CandidateTurn(
+            id: duplicateID,
+            commandID: CommandID("second-candidate"),
+            transcript: CandidateTranscript(body: "second", quality: .verified)
+        )
+        let turns: [InterviewTurn] = [
+            .candidate(first),
+            .interviewer(
+                InterviewerTurn(
+                    id: TurnID("first-interviewer"),
+                    commandID: first.commandID,
+                    replyToTurnID: duplicateID,
+                    response: CanonicalInterviewerResponse(
+                        displayMarkdown: "First response",
+                        spokenText: "First response"
+                    )
+                )
+            ),
+            .candidate(second),
+            .interviewer(
+                InterviewerTurn(
+                    id: TurnID("second-interviewer"),
+                    commandID: second.commandID,
+                    replyToTurnID: duplicateID,
+                    response: CanonicalInterviewerResponse(
+                        displayMarkdown: "Second response",
+                        spokenText: "Second response"
+                    )
+                )
+            ),
+        ]
+        let manifest = SessionManifest(
+            sessionID: SessionID("duplicate-candidate-session"),
+            activityID: "duplicate-candidate-activity",
+            phase: .interviewerTurn,
+            turnMode: .manual,
+            turns: turns,
+            revision: 1,
+            appliedCommands: []
+        )
+
+        do {
+            _ = try await InterviewRoomSession.restore(
+                sessionID: manifest.sessionID,
+                manifestStore: InMemorySessionManifestStore(manifests: [manifest]),
+                interviewerRuntime: fixtureRuntime()
+            )
+            XCTFail("Expected duplicate Candidate Turn IDs to be rejected")
+        } catch let error as InterviewRoomSessionError {
+            XCTAssertEqual(error, .invalidManifest(reason: "duplicate Candidate Turn IDs"))
+        }
+    }
+
+    private func makeCandidateFloorSession(
+        store: InMemorySessionManifestStore
+    ) async throws -> InterviewRoomSession {
+        let session = try await InterviewRoomSession.start(
+            sessionID: SessionID("session-\(UUID().uuidString)"),
+            activityID: "activity-segment-fixture",
+            manifestStore: store,
+            interviewerRuntime: fixtureRuntime()
+        )
+        _ = try await session.execute(
+            .giveCandidateFloor(commandID: CommandID("floor-\(UUID().uuidString)"))
+        )
+        return session
+    }
+
+    private func fixtureRuntime() -> DeterministicInterviewerRuntime {
+        DeterministicInterviewerRuntime(
+            response: CanonicalInterviewerResponse(
+                displayMarkdown: "What trade-off comes next?",
+                spokenText: "What trade-off comes next?"
+            )
+        )
+    }
+
+    private func makeTranscribedSegment(
+        session: InterviewRoomSession,
+        commandStem: String,
+        body: String,
+        quality: TranscriptQuality
+    ) async throws -> SegmentID {
+        let snapshot = try await session.execute(
+            .beginSegment(commandID: CommandID("\(commandStem)-begin"))
+        )
+        let segmentID = try XCTUnwrap(snapshot.segments.last?.id)
+        try await makeAudioReady(
+            session: session,
+            segmentID: segmentID,
+            commandStem: commandStem
+        )
+        try await recordCandidate(
+            session: session,
+            segmentID: segmentID,
+            commandStem: "\(commandStem)-attempt",
+            kind: .initial,
+            body: body,
+            quality: quality,
+            credential: "credential"
+        )
+        return segmentID
+    }
+
+    private func makeAudioReady(
+        session: InterviewRoomSession,
+        segmentID: SegmentID,
+        commandStem: String
+    ) async throws {
+        _ = try await session.execute(
+            .recordSegmentCaptureOutcome(
+                commandID: CommandID("\(commandStem)-recording"),
+                segmentID: segmentID,
+                outcome: .recordingStarted
+            )
+        )
+        _ = try await session.execute(
+            .finalizeSegment(
+                commandID: CommandID("\(commandStem)-finalize"),
+                segmentID: segmentID
+            )
+        )
+        _ = try await session.execute(
+            .recordSegmentCaptureOutcome(
+                commandID: CommandID("\(commandStem)-audio"),
+                segmentID: segmentID,
+                outcome: .finalized(
+                    try capturedAudio(fileName: "\(commandStem)-audio.m4a")
+                )
+            )
+        )
+    }
+
+    private func makeAudioReadySegment(
+        session: InterviewRoomSession,
+        commandStem: String
+    ) async throws -> SegmentID {
+        let snapshot = try await session.execute(
+            .beginSegment(commandID: CommandID("\(commandStem)-begin"))
+        )
+        let segmentID = try XCTUnwrap(snapshot.segments.last?.id)
+        try await makeAudioReady(
+            session: session,
+            segmentID: segmentID,
+            commandStem: commandStem
+        )
+        return segmentID
+    }
+
+    private func recordCandidate(
+        session: InterviewRoomSession,
+        segmentID: SegmentID,
+        commandStem: String,
+        kind: SegmentTranscriptionKind,
+        body: String,
+        quality: TranscriptQuality,
+        credential: String
+    ) async throws {
+        let authorized = try await session.execute(
+            .authorizeSegmentTranscription(
+                commandID: CommandID("\(commandStem)-authorization"),
+                segmentID: segmentID,
+                kind: kind,
+                credentialFingerprint: credentialFingerprint(credential)
+            )
+        )
+        let segment = try XCTUnwrap(authorized.segments.first { $0.id == segmentID })
+        let attempt = try XCTUnwrap(segment.transcriptionAttempts.last)
+        _ = try await session.execute(
+            .recordSegmentTranscriptionOutcome(
+                commandID: CommandID("\(commandStem)-outcome"),
+                segmentID: segmentID,
+                attemptID: attempt.id,
+                outcome: .candidate(
+                    SegmentTranscriptionResult(body: body, quality: quality)
+                )
+            )
+        )
+    }
+
+    private func credentialFingerprint(_ value: String) -> String {
+        InterviewRoomSession.credentialFingerprint(value)
+    }
+
+    private func capturedAudio(
+        fileName: String,
+        isPartial: Bool = false,
+        integrityReasons: [SegmentIntegrityReason] = []
+    ) throws -> CapturedAudioSegment {
+        CapturedAudioSegment(
+            audioIdentity: try SegmentAudioIdentity(validating: fileName),
+            startedAtMilliseconds: 1_000,
+            endedAtMilliseconds: 2_000,
+            durationMilliseconds: 1_000,
+            decodedDurationMilliseconds: 1_000,
+            byteCount: 4_096,
+            isPlayable: true,
+            isPartial: isPartial,
+            integrityReasons: integrityReasons
+        )
+    }
+}
+
+@MainActor
+private final class StubSegmentRecorder: SegmentRecording {
+    private let capture: CapturedAudioSegment
+    private let recovery: CapturedAudioSegment?
+    private var unexpectedTerminationHandler: (@MainActor @Sendable () -> Void)?
+    private var recoveries = 0
+    private var begins = 0
+    private var finishes = 0
+    private var finishFailuresRemaining: Int
+    private let finishSucceedsOnlyOnce: Bool
+
+    init(
+        capture: CapturedAudioSegment,
+        recovery: CapturedAudioSegment? = nil,
+        finishFailuresRemaining: Int = 0,
+        finishSucceedsOnlyOnce: Bool = false
+    ) {
+        self.capture = capture
+        self.recovery = recovery
+        self.finishFailuresRemaining = finishFailuresRemaining
+        self.finishSucceedsOnlyOnce = finishSucceedsOnlyOnce
+    }
+
+    func setUnexpectedTerminationHandler(
+        _ handler: (@MainActor @Sendable () -> Void)?
+    ) {
+        unexpectedTerminationHandler = handler
+    }
+
+    func beginCapture(_ request: SegmentCaptureRequest) async throws {
+        begins += 1
+    }
+
+    func finishCapture() async throws -> CapturedAudioSegment {
+        finishes += 1
+        if finishFailuresRemaining > 0 {
+            finishFailuresRemaining -= 1
+            throw StubRecorderError.finishFailed
+        }
+        if finishSucceedsOnlyOnce, finishes > 1 {
+            throw StubRecorderError.finishFailed
+        }
+        return capture
+    }
+
+    func recoverCapture(
+        _ request: SegmentCaptureRequest
+    ) async throws -> CapturedAudioSegment? {
+        recoveries += 1
+        return recovery
+    }
+
+    func playbackURL(
+        sessionID: SessionID,
+        audioIdentity: SegmentAudioIdentity
+    ) async throws -> URL {
+        URL(fileURLWithPath: "/private/tmp/\(audioIdentity.fileName)")
+    }
+
+    func recoveryCount() -> Int { recoveries }
+    func beginCount() -> Int { begins }
+    func finishCount() -> Int { finishes }
+
+    func triggerUnexpectedTermination() {
+        unexpectedTerminationHandler?()
+    }
+}
+
+@MainActor
+private final class SnapshotObserver {
+    private(set) var lifecycles: [CandidateSegmentLifecycle] = []
+    private let completed: XCTestExpectation
+    private var didComplete = false
+
+    init(completed: XCTestExpectation) {
+        self.completed = completed
+    }
+
+    func receive(_ snapshot: InterviewRoomSnapshot) {
+        guard let lifecycle = snapshot.segments.first?.lifecycle else { return }
+        lifecycles.append(lifecycle)
+        if lifecycle == .audioReady, !didComplete {
+            didComplete = true
+            completed.fulfill()
+        }
+    }
+}
+
+private actor SequencedSegmentTranscriber: SegmentTranscribing {
+    private var results: [Result<SegmentTranscriptionResult, SegmentTranscriptionAdapterFailure>]
+    private var calls = 0
+
+    init(
+        results: [Result<SegmentTranscriptionResult, SegmentTranscriptionAdapterFailure>]
+    ) {
+        self.results = results
+    }
+
+    func transcribe(
+        _ request: SegmentTranscriptionRequest,
+        credential: String
+    ) throws -> SegmentTranscriptionResult {
+        calls += 1
+        guard !results.isEmpty else {
+            throw SegmentTranscriptionAdapterFailure(reason: .providerUnavailable)
+        }
+        return try results.removeFirst().get()
+    }
+
+    func invocationCount() -> Int { calls }
+}
+
+private struct FixedCredentialReader: GroqCredentialReading {
+    let value: String
+
+    func readGroqCredential() -> String { value }
+}
+
+private enum StubRecorderError: Error {
+    case finishFailed
+}
+
+private enum InjectedStoreError: Error, Equatable {
+    case writeFailed
+}
+
+private actor FailingRevisionSessionManifestStore: SessionManifestStore {
+    private var manifests: [SessionID: SessionManifest] = [:]
+    private let failingRevision: Int
+    private var failuresRemaining: Int
+
+    init(failingRevision: Int, failureCount: Int = 1) {
+        self.failingRevision = failingRevision
+        failuresRemaining = failureCount
+    }
+
+    func load(sessionID: SessionID) -> SessionManifest? {
+        manifests[sessionID]
+    }
+
+    func save(
+        _ manifest: SessionManifest,
+        expectedRevision: Int?
+    ) throws {
+        if manifest.revision == failingRevision, failuresRemaining > 0 {
+            failuresRemaining -= 1
+            throw InjectedStoreError.writeFailed
+        }
+        let current = manifests[manifest.sessionID]
+        guard current?.revision == expectedRevision else {
+            throw SessionManifestStoreError.revisionConflict(
+                expected: expectedRevision,
+                actual: current?.revision
+            )
+        }
+        manifests[manifest.sessionID] = manifest
+    }
+}

--- a/Tests/InterviewArcLiveCoreTests/SegmentLifecycleTests.swift
+++ b/Tests/InterviewArcLiveCoreTests/SegmentLifecycleTests.swift
@@ -647,6 +647,48 @@ final class SegmentLifecycleTests: XCTestCase {
         XCTAssertEqual(recorder.finishCount(), 2)
     }
 
+    func testNonPlayableFinalizationPreservesEvidenceAndAllowsNewSegmentWithoutRelaunch() async throws {
+        let nonPlayable = try capturedAudio(
+            fileName: "non-playable-source.m4a",
+            isPlayable: false,
+            byteCount: 0,
+            decodedDurationMilliseconds: 0
+        )
+        let store = InMemorySessionManifestStore()
+        let recorder = StubSegmentRecorder(capture: nonPlayable)
+        let transcriber = SequencedSegmentTranscriber(results: [])
+        let coordinator = try await SegmentSpeechCoordinator.open(
+            sessionID: SessionID("non-playable-session"),
+            activityID: "non-playable-activity",
+            manifestStore: store,
+            interviewerRuntime: fixtureRuntime(),
+            recording: recorder,
+            transcriber: transcriber,
+            credentialReader: FixedCredentialReader(value: "credential")
+        )
+        _ = try await coordinator.giveCandidateFloor(commandID: CommandID("non-playable-floor"))
+        _ = try await coordinator.beginSegment(commandID: CommandID("non-playable-begin"))
+
+        let finalized = try await coordinator.finalizeSegment(
+            commandID: CommandID("non-playable-finalize")
+        )
+        let failed = try XCTUnwrap(finalized.segments.first)
+        XCTAssertEqual(failed.lifecycle, .failed)
+        XCTAssertEqual(failed.captureFailureReason, .noPlayableAudio)
+        XCTAssertEqual(failed.capturedAudio, nonPlayable)
+        let durable = try await store.load(sessionID: finalized.sessionID)
+        XCTAssertEqual(durable?.segments.first?.capturedAudio, nonPlayable)
+
+        let next = try await coordinator.beginSegment(
+            commandID: CommandID("non-playable-next-begin")
+        )
+        XCTAssertEqual(next.segments.count, 2)
+        XCTAssertEqual(next.segments[0].lifecycle, .failed)
+        XCTAssertEqual(next.segments[1].lifecycle, .recording)
+        let providerCalls = await transcriber.invocationCount()
+        XCTAssertEqual(providerCalls, 0)
+    }
+
     func testCompatibilityFinishTranscribesTheActiveSegmentNotOlderAudio() async throws {
         let recorder = StubSegmentRecorder(
             capture: try capturedAudio(fileName: "compatibility-active.m4a")
@@ -933,16 +975,19 @@ final class SegmentLifecycleTests: XCTestCase {
     private func capturedAudio(
         fileName: String,
         isPartial: Bool = false,
-        integrityReasons: [SegmentIntegrityReason] = []
+        integrityReasons: [SegmentIntegrityReason] = [],
+        isPlayable: Bool = true,
+        byteCount: Int64 = 4_096,
+        decodedDurationMilliseconds: Int64 = 1_000
     ) throws -> CapturedAudioSegment {
         CapturedAudioSegment(
             audioIdentity: try SegmentAudioIdentity(validating: fileName),
             startedAtMilliseconds: 1_000,
             endedAtMilliseconds: 2_000,
             durationMilliseconds: 1_000,
-            decodedDurationMilliseconds: 1_000,
-            byteCount: 4_096,
-            isPlayable: true,
+            decodedDurationMilliseconds: decodedDurationMilliseconds,
+            byteCount: byteCount,
+            isPlayable: isPlayable,
             isPartial: isPartial,
             integrityReasons: integrityReasons
         )

--- a/Tests/InterviewArcLiveCoreTests/SessionManifestStoreTests.swift
+++ b/Tests/InterviewArcLiveCoreTests/SessionManifestStoreTests.swift
@@ -51,6 +51,93 @@ final class SessionManifestStoreTests: XCTestCase {
         XCTAssertEqual(restored, next)
     }
 
+    func testFileAdapterForcesPrivateDirectoryAndManifestModes() async throws {
+        let temporaryRoot = makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: temporaryRoot) }
+
+        let liveRoot = temporaryRoot.appendingPathComponent(
+            "InterviewArcLive",
+            isDirectory: true
+        )
+        let manifestsDirectory = liveRoot.appendingPathComponent(
+            "SessionManifests",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: manifestsDirectory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o777]
+        )
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o777],
+            ofItemAtPath: liveRoot.path
+        )
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o777],
+            ofItemAtPath: manifestsDirectory.path
+        )
+
+        let sessionID = SessionID("public-private-file-modes")
+        let store = FileSessionManifestStore(
+            directoryURL: manifestsDirectory,
+            privateDirectoryHierarchy: [liveRoot, manifestsDirectory]
+        )
+        try await store.save(
+            manifest(sessionID: sessionID, revision: 0),
+            expectedRevision: nil
+        )
+
+        let manifestURL = try XCTUnwrap(
+            FileManager.default.contentsOfDirectory(
+                at: manifestsDirectory,
+                includingPropertiesForKeys: nil
+            ).first { $0.pathExtension == "json" }
+        )
+        let lockURL = try XCTUnwrap(
+            FileManager.default.contentsOfDirectory(
+                at: manifestsDirectory,
+                includingPropertiesForKeys: nil
+            ).first { $0.pathExtension == "lock" }
+        )
+        XCTAssertEqual(try permissions(of: liveRoot), 0o700)
+        XCTAssertEqual(try permissions(of: manifestsDirectory), 0o700)
+        XCTAssertEqual(try permissions(of: manifestURL), 0o600)
+        XCTAssertEqual(try permissions(of: lockURL), 0o600)
+
+        // Simulate permissive creation/replacement defaults. The next save must
+        // repair every private mode before it becomes durable.
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o777],
+            ofItemAtPath: liveRoot.path
+        )
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o777],
+            ofItemAtPath: manifestsDirectory.path
+        )
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o666],
+            ofItemAtPath: manifestURL.path
+        )
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o666],
+            ofItemAtPath: lockURL.path
+        )
+
+        try await store.save(
+            manifest(
+                sessionID: sessionID,
+                revision: 1,
+                phase: .candidateFloor
+            ),
+            expectedRevision: 0
+        )
+
+        XCTAssertEqual(try permissions(of: liveRoot), 0o700)
+        XCTAssertEqual(try permissions(of: manifestsDirectory), 0o700)
+        XCTAssertEqual(try permissions(of: manifestURL), 0o600)
+        XCTAssertEqual(try permissions(of: lockURL), 0o600)
+    }
+
     func testFileAdapterRejectsStaleWriterWithoutChangingReadableManifest() async throws {
         let directory = makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
@@ -252,6 +339,12 @@ final class SessionManifestStoreTests: XCTestCase {
     private func makeTemporaryDirectory() -> URL {
         FileManager.default.temporaryDirectory
             .appendingPathComponent("InterviewArcLiveTests-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    private func permissions(of url: URL) throws -> Int {
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        return try XCTUnwrap(attributes[.posixPermissions] as? NSNumber).intValue
+            & 0o777
     }
 }
 

--- a/Tests/InterviewArcLiveVoiceAdapterTests/LiveGroqCredentialStoreTests.swift
+++ b/Tests/InterviewArcLiveVoiceAdapterTests/LiveGroqCredentialStoreTests.swift
@@ -1,0 +1,98 @@
+import Foundation
+import XCTest
+
+@testable import InterviewArcLiveVoiceAdapter
+
+@MainActor
+final class LiveGroqCredentialStoreTests: XCTestCase {
+    func testLiveUsesAServiceDistinctFromVoice() {
+        XCTAssertEqual(
+            LiveGroqCredentialStore.keychainService,
+            "dev.interviewarc.live"
+        )
+        XCTAssertNotEqual(
+            LiveGroqCredentialStore.keychainService,
+            "dev.interviewarc.voice"
+        )
+    }
+
+    func testSaveVerifiesReadbackAndReportsReadiness() async throws {
+        let fixture = CredentialMemoryFixture()
+        let store = LiveGroqCredentialStore(backend: fixture.backend)
+
+        let initialReadiness = try await store.readiness()
+        XCTAssertEqual(initialReadiness, .missing)
+        try await store.saveAndVerify("  public-test-key  ")
+
+        let readback = try await store.read()
+        let requiredReadback = try await store.readGroqCredential()
+        let readiness = try await store.readiness()
+        XCTAssertEqual(readback, "public-test-key")
+        XCTAssertEqual(requiredReadback, "public-test-key")
+        XCTAssertEqual(readiness, .ready)
+    }
+
+    func testEmptyCredentialIsRejectedWithoutWriting() async throws {
+        let fixture = CredentialMemoryFixture()
+        let store = LiveGroqCredentialStore(backend: fixture.backend)
+
+        do {
+            try await store.saveAndVerify("  \n")
+            XCTFail("Expected an empty credential to fail")
+        } catch let error as LiveGroqCredentialStoreError {
+            XCTAssertEqual(error, .emptyCredential)
+        }
+
+        XCTAssertNil(fixture.value)
+    }
+
+    func testFailedReadbackDoesNotClaimCredentialWasSaved() async throws {
+        let fixture = CredentialMemoryFixture(persistsWrites: false)
+        let store = LiveGroqCredentialStore(backend: fixture.backend)
+
+        do {
+            try await store.saveAndVerify("public-test-key")
+            XCTFail("Expected verification to fail")
+        } catch let error as LiveGroqCredentialStoreError {
+            XCTAssertEqual(error, .verificationFailed)
+        }
+    }
+
+    func testRemoveClearsCredential() async throws {
+        let fixture = CredentialMemoryFixture(value: "public-test-key")
+        let store = LiveGroqCredentialStore(backend: fixture.backend)
+
+        try await store.remove()
+
+        let readiness = try await store.readiness()
+        XCTAssertEqual(readiness, .missing)
+        XCTAssertNil(fixture.value)
+    }
+}
+
+private final class CredentialMemoryFixture: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedValue: String?
+    private let persistsWrites: Bool
+
+    init(value: String? = nil, persistsWrites: Bool = true) {
+        storedValue = value
+        self.persistsWrites = persistsWrites
+    }
+
+    var value: String? {
+        lock.withLock { storedValue }
+    }
+
+    var backend: LiveGroqCredentialBackend {
+        LiveGroqCredentialBackend(
+            read: { [self] in lock.withLock { storedValue } },
+            save: { [self] value in
+                lock.withLock {
+                    if persistsWrites { storedValue = value }
+                }
+            },
+            remove: { [self] in lock.withLock { storedValue = nil } }
+        )
+    }
+}

--- a/Tests/InterviewArcLiveVoiceAdapterTests/VoiceCoreSegmentRecorderTests.swift
+++ b/Tests/InterviewArcLiveVoiceAdapterTests/VoiceCoreSegmentRecorderTests.swift
@@ -1,0 +1,355 @@
+import Foundation
+import InterviewArcLiveCore
+import InterviewArcVoiceCore
+import XCTest
+@testable import InterviewArcLiveVoiceAdapter
+
+@MainActor
+final class VoiceCoreSegmentRecorderTests: XCTestCase {
+    func testAdoptsAuthoritativeRecoveredURLAndPreservesPartialMetadata() async throws {
+        let fixture = try RecordingFixture()
+        defer { fixture.remove() }
+        let driver = RecordingDriverSpy(finalFileName: "answer-recovered-safe.m4a")
+        var dates = [
+            Date(timeIntervalSince1970: 100),
+            Date(timeIntervalSince1970: 105),
+        ]
+        let recorder = VoiceCoreSegmentRecorder(
+            driver: driver,
+            applicationSupportRoot: fixture.root,
+            now: { dates.removeFirst() },
+            inspect: { capture in
+                XCTAssertEqual(
+                    capture.url.lastPathComponent,
+                    "answer-recovered-safe.m4a"
+                )
+                return RecordingIntegrityEvidence(
+                    wallDurationSeconds: 5,
+                    decodedDurationSeconds: 3,
+                    fileSizeBytes: 2_048,
+                    decodedFrameCount: 144_000,
+                    writeErrorDescription: nil
+                )
+            }
+        )
+
+        let request = try fixture.captureRequest(fileName: "answer.m4a")
+        try await recorder.beginCapture(request)
+        let captured = try await recorder.finishCapture()
+
+        XCTAssertEqual(captured.audioIdentity.fileName, "answer-recovered-safe.m4a")
+        XCTAssertEqual(captured.startedAtMilliseconds, 100_000)
+        XCTAssertEqual(captured.endedAtMilliseconds, 105_000)
+        XCTAssertEqual(captured.durationMilliseconds, 5_000)
+        XCTAssertEqual(captured.decodedDurationMilliseconds, 3_000)
+        XCTAssertEqual(captured.byteCount, 2_048)
+        XCTAssertTrue(captured.isPlayable)
+        XCTAssertTrue(captured.isPartial)
+        XCTAssertEqual(
+            captured.integrityReasons,
+            [SegmentIntegrityReason("durationMismatch")]
+        )
+        XCTAssertNotEqual(driver.requestedURL, driver.finalizedURL)
+
+        let playbackURL = try await recorder.playbackURL(
+            sessionID: request.sessionID,
+            audioIdentity: captured.audioIdentity
+        )
+        XCTAssertEqual(playbackURL, driver.finalizedURL?.standardizedFileURL)
+        let permissions = try FileManager.default.attributesOfItem(
+            atPath: playbackURL.path
+        )[.posixPermissions] as? NSNumber
+        XCTAssertEqual((permissions?.intValue ?? 0) & 0o777, 0o600)
+        try fixture.assertPrivateDirectoryPermissions()
+    }
+
+    func testUnexpectedTerminationHandlerIsOneShotPerCapture() async throws {
+        let fixture = try RecordingFixture()
+        defer { fixture.remove() }
+        let driver = RecordingDriverSpy(finalFileName: "answer.m4a")
+        let recorder = VoiceCoreSegmentRecorder(
+            driver: driver,
+            applicationSupportRoot: fixture.root,
+            inspect: { _ in Self.completeEvidence }
+        )
+        var eventCount = 0
+        recorder.setUnexpectedTerminationHandler { eventCount += 1 }
+
+        try await recorder.beginCapture(
+            fixture.captureRequest(fileName: "answer.m4a")
+        )
+        driver.emitUnexpectedTermination()
+        driver.emitUnexpectedTermination()
+
+        XCTAssertEqual(eventCount, 1)
+        _ = try await recorder.finishCapture()
+        driver.emitUnexpectedTermination()
+        XCTAssertEqual(eventCount, 1)
+    }
+
+    func testSuccessfulStopClearsCaptureEvenWhenAuthoritativePathIsRejected() async throws {
+        let fixture = try RecordingFixture()
+        defer { fixture.remove() }
+        let outsideURL = fixture.root
+            .deletingLastPathComponent()
+            .appendingPathComponent("outside-\(UUID().uuidString).m4a")
+        defer { try? FileManager.default.removeItem(at: outsideURL) }
+        let driver = RecordingDriverSpy(finalizedURL: outsideURL)
+        let recorder = VoiceCoreSegmentRecorder(
+            driver: driver,
+            applicationSupportRoot: fixture.root,
+            inspect: { _ in Self.completeEvidence }
+        )
+
+        try await recorder.beginCapture(
+            fixture.captureRequest(fileName: "first.m4a")
+        )
+        do {
+            _ = try await recorder.finishCapture()
+            XCTFail("Expected an out-of-root capture rejection")
+        } catch let error as VoiceCoreSegmentRecorderError {
+            XCTAssertEqual(error, .authoritativeCaptureOutsideSessionRoot)
+        }
+
+        driver.finalFileName = "second.m4a"
+        driver.finalizedURLOverride = nil
+        try await recorder.beginCapture(
+            fixture.captureRequest(fileName: "second.m4a")
+        )
+        _ = try await recorder.finishCapture()
+        XCTAssertEqual(driver.stopCount, 2)
+    }
+
+    func testStopFailureKeepsCaptureAvailableForExplicitFinalizationRetry() async throws {
+        let fixture = try RecordingFixture()
+        defer { fixture.remove() }
+        let driver = RecordingDriverSpy(finalFileName: "answer.m4a")
+        driver.stopFailuresRemaining = 1
+        let recorder = VoiceCoreSegmentRecorder(
+            driver: driver,
+            applicationSupportRoot: fixture.root,
+            inspect: { _ in Self.completeEvidence }
+        )
+
+        try await recorder.beginCapture(
+            fixture.captureRequest(fileName: "answer.m4a")
+        )
+        await XCTAssertThrowsErrorAsync {
+            _ = try await recorder.finishCapture()
+        }
+        _ = try await recorder.finishCapture()
+        XCTAssertEqual(driver.stopCount, 2)
+    }
+
+    func testRecoveryPrefersNewestPlayableRecoveredFileWithoutDeletingSources() async throws {
+        let fixture = try RecordingFixture()
+        defer { fixture.remove() }
+        let paths = LiveVoicePaths(applicationSupportRoot: fixture.root)
+        let request = try fixture.captureRequest(fileName: "answer.m4a")
+        let reservedURL = try paths.audioURL(
+            sessionID: request.sessionID,
+            identity: request.reservedAudioIdentity,
+            createParentDirectory: true
+        )
+        let recoveredIdentity = try SegmentAudioIdentity(
+            validating: "answer-recovered-public.m4a"
+        )
+        let recoveredURL = try paths.audioURL(
+            sessionID: request.sessionID,
+            identity: recoveredIdentity,
+            createParentDirectory: false
+        )
+        try Data(repeating: 1, count: 2_048).write(to: reservedURL)
+        try Data(repeating: 2, count: 4_096).write(to: recoveredURL)
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 200)],
+            ofItemAtPath: reservedURL.path
+        )
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 210)],
+            ofItemAtPath: recoveredURL.path
+        )
+        let recorder = VoiceCoreSegmentRecorder(
+            driver: RecordingDriverSpy(finalFileName: "unused.m4a"),
+            applicationSupportRoot: fixture.root,
+            inspect: { capture in
+                RecordingIntegrityEvidence(
+                    wallDurationSeconds: 0,
+                    decodedDurationSeconds:
+                        capture.url == recoveredURL ? 4 : 3,
+                    fileSizeBytes:
+                        capture.url == recoveredURL ? 4_096 : 2_048,
+                    decodedFrameCount: 192_000,
+                    writeErrorDescription: nil,
+                    peakPowerDecibels:
+                        capture.url == recoveredURL ? -70 : -12
+                )
+            }
+        )
+
+        let recovered = try await recorder.recoverCapture(request)
+
+        XCTAssertEqual(recovered?.audioIdentity, recoveredIdentity)
+        XCTAssertEqual(recovered?.startedAtMilliseconds, 206_000)
+        XCTAssertEqual(recovered?.endedAtMilliseconds, 210_000)
+        XCTAssertEqual(recovered?.durationMilliseconds, 4_000)
+        XCTAssertEqual(recovered?.byteCount, 4_096)
+        XCTAssertEqual(recovered?.isPlayable, true)
+        XCTAssertEqual(recovered?.isPartial, true)
+        XCTAssertTrue(
+            recovered?.integrityReasons.contains(.insufficientSignal) == true
+        )
+        XCTAssertTrue(FileManager.default.fileExists(atPath: reservedURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: recoveredURL.path))
+    }
+
+    func testRecoveryReturnsNilWhenNoValidatedPlayableSourceExists() async throws {
+        let fixture = try RecordingFixture()
+        defer { fixture.remove() }
+        let paths = LiveVoicePaths(applicationSupportRoot: fixture.root)
+        let request = try fixture.captureRequest(fileName: "answer.m4a")
+        let reservedURL = try paths.audioURL(
+            sessionID: request.sessionID,
+            identity: request.reservedAudioIdentity,
+            createParentDirectory: true
+        )
+        try Data(repeating: 1, count: 64).write(to: reservedURL)
+        let recorder = VoiceCoreSegmentRecorder(
+            driver: RecordingDriverSpy(finalFileName: "unused.m4a"),
+            applicationSupportRoot: fixture.root,
+            inspect: { _ in
+                RecordingIntegrityEvidence(
+                    wallDurationSeconds: 0,
+                    decodedDurationSeconds: 0,
+                    fileSizeBytes: 64,
+                    decodedFrameCount: 0,
+                    writeErrorDescription: nil
+                )
+            }
+        )
+
+        let recovered = try await recorder.recoverCapture(request)
+        XCTAssertNil(recovered)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: reservedURL.path))
+    }
+
+    private static let completeEvidence = RecordingIntegrityEvidence(
+        wallDurationSeconds: 2,
+        decodedDurationSeconds: 2,
+        fileSizeBytes: 2_048,
+        decodedFrameCount: 96_000,
+        writeErrorDescription: nil,
+        peakPowerDecibels: -12
+    )
+}
+
+@MainActor
+private final class RecordingDriverSpy: VoiceCoreRecordingDriving {
+    var onUnexpectedTermination: (@MainActor () -> Void)?
+    var finalFileName: String
+    var finalizedURLOverride: URL?
+    var stopFailuresRemaining = 0
+    private(set) var requestedURL: URL?
+    private(set) var finalizedURL: URL?
+    private(set) var stopCount = 0
+
+    init(finalFileName: String) {
+        self.finalFileName = finalFileName
+    }
+
+    init(finalizedURL: URL) {
+        finalFileName = finalizedURL.lastPathComponent
+        finalizedURLOverride = finalizedURL
+    }
+
+    func start(
+        at destinationURL: URL,
+        captureBackendDidStart: @escaping @MainActor () -> Void
+    ) async throws {
+        requestedURL = destinationURL
+        captureBackendDidStart()
+    }
+
+    func stop() throws -> RecordedCapture {
+        stopCount += 1
+        if stopFailuresRemaining > 0 {
+            stopFailuresRemaining -= 1
+            throw VoiceBridgeError.recordingUnavailable
+        }
+        guard let requestedURL else {
+            throw VoiceBridgeError.recordingUnavailable
+        }
+        let url = finalizedURLOverride
+            ?? requestedURL.deletingLastPathComponent().appendingPathComponent(
+                finalFileName
+            )
+        try Data(repeating: 1, count: 2_048).write(to: url, options: .atomic)
+        finalizedURL = url
+        return RecordedCapture(
+            url: url,
+            duration: 5,
+            writtenFrameCount: 144_000,
+            writeErrorDescription: nil,
+            peakPowerDecibels: -12
+        )
+    }
+
+    func emitUnexpectedTermination() {
+        onUnexpectedTermination?()
+    }
+}
+
+private struct RecordingFixture {
+    let root: URL
+    let sessionID = SessionID("public-test-session")
+
+    init() throws {
+        root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "interview-arc-live-recorder-tests-\(UUID().uuidString)",
+            isDirectory: true
+        )
+    }
+
+    func captureRequest(fileName: String) throws -> SegmentCaptureRequest {
+        SegmentCaptureRequest(
+            sessionID: sessionID,
+            segmentID: SegmentID("segment-test"),
+            reservedAudioIdentity: try SegmentAudioIdentity(
+                validating: fileName
+            )
+        )
+    }
+
+    func assertPrivateDirectoryPermissions() throws {
+        let paths = LiveVoicePaths(applicationSupportRoot: root)
+        let audioDirectory = try paths.sessionAudioDirectory(
+            sessionID: sessionID,
+            create: false
+        )
+        for directory in [
+            root,
+            root.appendingPathComponent("Audio", isDirectory: true),
+            audioDirectory,
+        ] {
+            let permissions = try FileManager.default.attributesOfItem(
+                atPath: directory.path
+            )[.posixPermissions] as? NSNumber
+            XCTAssertEqual((permissions?.intValue ?? 0) & 0o777, 0o700)
+        }
+    }
+
+    func remove() {
+        try? FileManager.default.removeItem(at: root)
+    }
+}
+
+private func XCTAssertThrowsErrorAsync(
+    _ expression: () async throws -> Void,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) async {
+    do {
+        try await expression()
+        XCTFail("Expected expression to throw", file: file, line: line)
+    } catch {}
+}

--- a/Tests/InterviewArcLiveVoiceAdapterTests/VoiceCoreSegmentRecorderTests.swift
+++ b/Tests/InterviewArcLiveVoiceAdapterTests/VoiceCoreSegmentRecorderTests.swift
@@ -343,6 +343,7 @@ private struct RecordingFixture {
     }
 }
 
+@MainActor
 private func XCTAssertThrowsErrorAsync(
     _ expression: () async throws -> Void,
     file: StaticString = #filePath,

--- a/Tests/InterviewArcLiveVoiceAdapterTests/VoiceCoreSegmentRecorderTests.swift
+++ b/Tests/InterviewArcLiveVoiceAdapterTests/VoiceCoreSegmentRecorderTests.swift
@@ -173,16 +173,18 @@ final class VoiceCoreSegmentRecorderTests: XCTestCase {
             driver: RecordingDriverSpy(finalFileName: "unused.m4a"),
             applicationSupportRoot: fixture.root,
             inspect: { capture in
-                RecordingIntegrityEvidence(
+                let isRecovered = capture.url.lastPathComponent
+                    == recoveredURL.lastPathComponent
+                return RecordingIntegrityEvidence(
                     wallDurationSeconds: 0,
                     decodedDurationSeconds:
-                        capture.url == recoveredURL ? 4 : 3,
+                        isRecovered ? 4 : 3,
                     fileSizeBytes:
-                        capture.url == recoveredURL ? 4_096 : 2_048,
+                        isRecovered ? 4_096 : 2_048,
                     decodedFrameCount: 192_000,
                     writeErrorDescription: nil,
                     peakPowerDecibels:
-                        capture.url == recoveredURL ? -70 : -12
+                        isRecovered ? -70 : -12
                 )
             }
         )

--- a/Tests/InterviewArcLiveVoiceAdapterTests/VoiceCoreSegmentTranscriberTests.swift
+++ b/Tests/InterviewArcLiveVoiceAdapterTests/VoiceCoreSegmentTranscriberTests.swift
@@ -1,0 +1,440 @@
+import Foundation
+import InterviewArcLiveCore
+import InterviewArcVoiceCore
+import XCTest
+@testable import InterviewArcLiveVoiceAdapter
+
+final class VoiceCoreSegmentTranscriberTests: XCTestCase {
+    func testInitialAttemptMakesOneProviderInvocationAndPreservesBodyVerbatim() async throws {
+        let fixture = try TranscriptionFixture()
+        defer { fixture.remove() }
+        let exactBody = "  Exact candidate with whitespace.\n"
+        let spy = SpeechTranscriberSpy(
+            behavior: .result(Self.result(text: exactBody))
+        )
+        let adapter = fixture.adapter(spy: spy)
+
+        let result = try await adapter.transcribe(
+            fixture.request(kind: .initial),
+            credential: "public-test-key"
+        )
+
+        XCTAssertEqual(result.body, exactBody)
+        XCTAssertEqual(result.quality, .verified)
+        XCTAssertEqual(result.integrityReasons, [])
+        let invocations = await spy.invocations()
+        XCTAssertEqual(invocations, [.initial])
+    }
+
+    func testRetryAttemptUsesExactlyOneCoverageRecoveryCall() async throws {
+        let fixture = try TranscriptionFixture()
+        defer { fixture.remove() }
+        let spy = SpeechTranscriberSpy(
+            behavior: .result(Self.result(text: "Recovered candidate"))
+        )
+        let adapter = fixture.adapter(spy: spy)
+
+        _ = try await adapter.transcribe(
+            fixture.request(kind: .retry),
+            credential: "public-test-key"
+        )
+
+        let invocations = await spy.invocations()
+        XCTAssertEqual(invocations, [.coverageRecovery])
+    }
+
+    func testPromptLeakageCandidateIsPreservedAndMarkedPossibleContamination() async throws {
+        let fixture = try TranscriptionFixture()
+        defer { fixture.remove() }
+        let body = "Thank you for watching"
+        let spy = SpeechTranscriberSpy(
+            behavior: .result(Self.result(text: body))
+        )
+        let adapter = fixture.adapter(spy: spy)
+
+        let result = try await adapter.transcribe(
+            fixture.request(kind: .initial),
+            credential: "public-test-key"
+        )
+
+        XCTAssertEqual(result.body, body)
+        XCTAssertEqual(result.quality, .possibleContamination)
+        XCTAssertTrue(
+            result.integrityReasons.contains(
+                SegmentIntegrityReason("promptLeakage")
+            )
+        )
+        let invocationCount = await spy.invocations().count
+        XCTAssertEqual(invocationCount, 1)
+    }
+
+    func testOtherSuspiciousNonemptyCandidateIsPreservedAsBestAvailable() async throws {
+        let fixture = try TranscriptionFixture()
+        defer { fixture.remove() }
+        let body = "short but nonempty"
+        let spy = SpeechTranscriberSpy(
+            behavior: .result(Self.result(text: body))
+        )
+        let adapter = fixture.adapter(spy: spy) { _, prompt, transcription in
+            TranscriptionIntegrityEvaluator.evaluate(
+                TranscriptionIntegrityEvidence(
+                    audioDurationSeconds: 20,
+                    providerDurationSeconds: 2,
+                    expectedChunkCount: 2,
+                    returnedChunkCount: 1,
+                    transcript: transcription.text,
+                    prompt: prompt,
+                    hasSustainedSpeechAfterProviderCoverage: true
+                )
+            )
+        }
+
+        let result = try await adapter.transcribe(
+            fixture.request(kind: .initial),
+            credential: "public-test-key"
+        )
+
+        XCTAssertEqual(result.body, body)
+        XCTAssertEqual(result.quality, .bestAvailable)
+        XCTAssertTrue(
+            result.integrityReasons.contains(
+                SegmentIntegrityReason("missingSpeechCoverage")
+            )
+        )
+        let invocationCount = await spy.invocations().count
+        XCTAssertEqual(invocationCount, 1)
+    }
+
+    func testEmptyProviderResultFailsWithoutFabricatingCandidate() async throws {
+        let fixture = try TranscriptionFixture()
+        defer { fixture.remove() }
+        let spy = SpeechTranscriberSpy(
+            behavior: .result(Self.result(text: "  \n"))
+        )
+        let adapter = fixture.adapter(spy: spy)
+
+        do {
+            _ = try await adapter.transcribe(
+                fixture.request(kind: .initial),
+                credential: "public-test-key"
+            )
+            XCTFail("Expected an empty-provider-result failure")
+        } catch let failure as SegmentTranscriptionAdapterFailure {
+            XCTAssertEqual(failure.reason, .emptyProviderResult)
+            XCTAssertNil(failure.providerCode)
+        }
+        let invocationCount = await spy.invocations().count
+        XCTAssertEqual(invocationCount, 1)
+    }
+
+    func testUnauthorizedFailureIsDomainSafeAndDoesNotContainCredential() async throws {
+        let fixture = try TranscriptionFixture()
+        defer { fixture.remove() }
+        let spy = SpeechTranscriberSpy(behavior: .invalidCredential)
+        let adapter = fixture.adapter(spy: spy)
+
+        do {
+            _ = try await adapter.transcribe(
+                fixture.request(kind: .initial),
+                credential: "private-test-credential"
+            )
+            XCTFail("Expected a credential rejection")
+        } catch let failure as SegmentTranscriptionAdapterFailure {
+            XCTAssertEqual(failure.reason, .credentialRejected)
+            XCTAssertEqual(failure.providerCode, .unauthorized)
+            XCTAssertFalse(String(describing: failure).contains("private-test-credential"))
+        }
+        let invocationCount = await spy.invocations().count
+        XCTAssertEqual(invocationCount, 1)
+    }
+
+    func testHTTP401VariantIsAlsoClassifiedAsCredentialRejected() async throws {
+        let fixture = try TranscriptionFixture()
+        defer { fixture.remove() }
+        let spy = SpeechTranscriberSpy(behavior: .providerStatus(401))
+        let adapter = fixture.adapter(spy: spy)
+
+        do {
+            _ = try await adapter.transcribe(
+                fixture.request(kind: .initial),
+                credential: "private-test-credential"
+            )
+            XCTFail("Expected a credential rejection")
+        } catch let failure as SegmentTranscriptionAdapterFailure {
+            XCTAssertEqual(failure.reason, .credentialRejected)
+            XCTAssertEqual(failure.providerCode, .unauthorized)
+        }
+    }
+
+    func testMissingAudioFailsBeforeProviderInvocation() async throws {
+        let fixture = try TranscriptionFixture(createAudio: false)
+        defer { fixture.remove() }
+        let spy = SpeechTranscriberSpy(
+            behavior: .result(Self.result(text: "must not be returned"))
+        )
+        let adapter = fixture.adapter(spy: spy)
+
+        do {
+            _ = try await adapter.transcribe(
+                fixture.request(kind: .initial),
+                credential: "public-test-key"
+            )
+            XCTFail("Expected invalid audio")
+        } catch let failure as SegmentTranscriptionAdapterFailure {
+            XCTAssertEqual(failure.reason, .invalidAudio)
+        }
+        let invocations = await spy.invocations()
+        XCTAssertEqual(invocations, [])
+    }
+
+    func testFirstUseCleanupRemovesOnlyStalePrivateScratch() async throws {
+        let fixture = try TranscriptionFixture()
+        defer { fixture.remove() }
+        let now = Date(timeIntervalSince1970: 2_000_000)
+        let paths = LiveVoicePaths(applicationSupportRoot: fixture.root)
+        let stale = try paths.transcriptionScratchDirectory(
+            sessionID: fixture.sessionID,
+            attemptID: TranscriptionAttemptID("stale-attempt")
+        )
+        let fresh = try paths.transcriptionScratchDirectory(
+            sessionID: fixture.sessionID,
+            attemptID: TranscriptionAttemptID("fresh-attempt")
+        )
+        try Data(repeating: 2, count: 128).write(
+            to: stale.appendingPathComponent("provider-chunk.m4a")
+        )
+        try Data(repeating: 3, count: 128).write(
+            to: fresh.appendingPathComponent("provider-chunk.m4a")
+        )
+        try FileManager.default.setAttributes(
+            [.modificationDate: now.addingTimeInterval(-7_200)],
+            ofItemAtPath: stale.path
+        )
+        try FileManager.default.setAttributes(
+            [.modificationDate: now],
+            ofItemAtPath: fresh.path
+        )
+
+        let outside = fixture.root.deletingLastPathComponent().appendingPathComponent(
+            "provider-scratch-outside-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        defer { try? FileManager.default.removeItem(at: outside) }
+        try FileManager.default.createDirectory(
+            at: outside,
+            withIntermediateDirectories: false
+        )
+        let outsideEvidence = outside.appendingPathComponent("must-remain.m4a")
+        try Data(repeating: 4, count: 128).write(to: outsideEvidence)
+        let linkedAttempt = try paths.transcriptionScratchDirectory(
+            sessionID: fixture.sessionID,
+            attemptID: TranscriptionAttemptID("linked-attempt")
+        )
+        try FileManager.default.removeItem(at: linkedAttempt)
+        try FileManager.default.createSymbolicLink(
+            at: linkedAttempt,
+            withDestinationURL: outside
+        )
+
+        let sourceAudio = try paths.audioURL(
+            sessionID: fixture.sessionID,
+            identity: fixture.audioIdentity,
+            createParentDirectory: false
+        )
+        let spy = SpeechTranscriberSpy(
+            behavior: .result(Self.result(text: "Preserved transcript"))
+        )
+        let adapter = fixture.adapter(
+            spy: spy,
+            scratchCleanupPolicy: ProviderScratchCleanupPolicy(
+                staleAge: 3_600,
+                maximumSessionDirectories: 8,
+                maximumAttemptDirectories: 32,
+                maximumDeletions: 8
+            ),
+            now: { now }
+        )
+
+        _ = try await adapter.transcribe(
+            fixture.request(kind: .initial),
+            credential: "public-test-key"
+        )
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: stale.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: fresh.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: linkedAttempt.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: outsideEvidence.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: sourceAudio.path))
+    }
+
+    func testScratchCleanupDeletionCountIsBounded() throws {
+        let fixture = try TranscriptionFixture()
+        defer { fixture.remove() }
+        let now = Date(timeIntervalSince1970: 2_000_000)
+        let paths = LiveVoicePaths(applicationSupportRoot: fixture.root)
+        var staleDirectories: [URL] = []
+        for index in 0..<3 {
+            let directory = try paths.transcriptionScratchDirectory(
+                sessionID: fixture.sessionID,
+                attemptID: TranscriptionAttemptID("bounded-attempt-\(index)")
+            )
+            try Data(repeating: UInt8(index), count: 128).write(
+                to: directory.appendingPathComponent("provider-chunk.m4a")
+            )
+            try FileManager.default.setAttributes(
+                [.modificationDate: now.addingTimeInterval(-7_200)],
+                ofItemAtPath: directory.path
+            )
+            staleDirectories.append(directory)
+        }
+
+        let removed = try paths.cleanupStaleTranscriptionScratch(
+            now: now,
+            policy: ProviderScratchCleanupPolicy(
+                staleAge: 3_600,
+                maximumSessionDirectories: 8,
+                maximumAttemptDirectories: 32,
+                maximumDeletions: 1
+            )
+        )
+
+        XCTAssertEqual(removed, 1)
+        XCTAssertEqual(
+            staleDirectories.filter {
+                FileManager.default.fileExists(atPath: $0.path)
+            }.count,
+            2
+        )
+    }
+
+    private static func result(text: String) -> TranscriptionResult {
+        TranscriptionResult(
+            text: text,
+            words: [],
+            durationSeconds: 1,
+            chunkCount: 1,
+            engine: "test",
+            model: "test"
+        )
+    }
+}
+
+private enum TranscriberInvocation: Equatable, Sendable {
+    case initial
+    case coverageRecovery
+}
+
+private actor SpeechTranscriberSpy: SpeechTranscribing {
+    enum Behavior: Sendable {
+        case result(TranscriptionResult)
+        case invalidCredential
+        case providerStatus(Int)
+    }
+
+    nonisolated let diagnosticEngine = "test"
+    nonisolated let diagnosticModel: String? = "test"
+    private let behavior: Behavior
+    private var recordedInvocations: [TranscriberInvocation] = []
+
+    init(behavior: Behavior) {
+        self.behavior = behavior
+    }
+
+    func transcribe(
+        fileURL: URL,
+        prompt: String,
+        temporaryDirectory: URL
+    ) async throws -> TranscriptionResult {
+        recordedInvocations.append(.initial)
+        return try response()
+    }
+
+    func transcribeCoverageRecovery(
+        fileURL: URL,
+        temporaryDirectory: URL
+    ) async throws -> TranscriptionResult {
+        recordedInvocations.append(.coverageRecovery)
+        return try response()
+    }
+
+    func invocations() -> [TranscriberInvocation] {
+        recordedInvocations
+    }
+
+    private func response() throws -> TranscriptionResult {
+        switch behavior {
+        case .result(let result):
+            result
+        case .invalidCredential:
+            throw VoiceBridgeError.invalidProviderCredential
+        case .providerStatus(let status):
+            throw VoiceBridgeError.providerResponseFailure(status, nil)
+        }
+    }
+}
+
+private struct TranscriptionFixture {
+    let root: URL
+    let sessionID = SessionID("public-test-session")
+    let audioIdentity: SegmentAudioIdentity
+
+    init(createAudio: Bool = true) throws {
+        root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "interview-arc-live-transcriber-tests-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        audioIdentity = try SegmentAudioIdentity(validating: "segment.m4a")
+        if createAudio {
+            let paths = LiveVoicePaths(applicationSupportRoot: root)
+            let url = try paths.audioURL(
+                sessionID: sessionID,
+                identity: audioIdentity,
+                createParentDirectory: true
+            )
+            try Data(repeating: 1, count: 2_048).write(to: url, options: .atomic)
+        }
+    }
+
+    func request(kind: SegmentTranscriptionKind) -> SegmentTranscriptionRequest {
+        SegmentTranscriptionRequest(
+            sessionID: sessionID,
+            segmentID: SegmentID("segment-test"),
+            attemptID: TranscriptionAttemptID("attempt-\(kind.rawValue)"),
+            kind: kind,
+            audioIdentity: audioIdentity
+        )
+    }
+
+    func adapter(
+        spy: SpeechTranscriberSpy,
+        evaluateIntegrity: @escaping VoiceCoreIntegrityEvaluator = {
+            audioURL,
+            prompt,
+            transcription in
+            TranscriptionIntegrityEvaluator.evaluate(
+                TranscriptionIntegrityEvidence(
+                    audioDurationSeconds: transcription.durationSeconds,
+                    providerDurationSeconds: transcription.durationSeconds,
+                    expectedChunkCount: transcription.chunkCount,
+                    returnedChunkCount: transcription.chunkCount,
+                    transcript: transcription.text,
+                    prompt: prompt
+                )
+            )
+        },
+        scratchCleanupPolicy: ProviderScratchCleanupPolicy = .production,
+        now: @escaping @Sendable () -> Date = Date.init
+    ) -> VoiceCoreSegmentTranscriber {
+        VoiceCoreSegmentTranscriber(
+            applicationSupportRoot: root,
+            makeTranscriber: { _ in spy },
+            evaluateIntegrity: evaluateIntegrity,
+            scratchCleanupPolicy: scratchCleanupPolicy,
+            now: now
+        )
+    }
+
+    func remove() {
+        try? FileManager.default.removeItem(at: root)
+    }
+}

--- a/docs/adr/0004-durable-segmented-speech.md
+++ b/docs/adr/0004-durable-segmented-speech.md
@@ -1,0 +1,46 @@
+# ADR 0004: Durable segmented candidate speech
+
+- Status: Accepted
+- Date: 2026-08-09
+- Issue: #5
+
+## Context
+
+A Candidate Turn may include several spoken intervals separated by thinking,
+coding, or drawing. Microphone and provider calls are fallible side effects;
+neither may be allowed to erase a playable recording, duplicate a request, or
+commit an answer merely because one audio interval ended.
+
+## Decision
+
+`InterviewRoomSession` owns ordered Segment and Transcription Attempt state in
+the canonical Session Manifest. It durably accepts each reservation or
+provider authorization before the corresponding side effect. Replaying the
+same command ID returns its prior receipt; only a fresh explicit retry ID may
+authorize another provider request.
+
+Each Segment keeps one private Source Recording under Live's session root and
+stores only a validated relative M4A identity in the Manifest. The URL returned
+by the recorder after finalization is authoritative because microphone recovery
+may replace the initially reserved file. Provider chunks are disposable.
+
+Every nonempty Groq result is persisted verbatim. Selection is deterministic:
+`verified`, then `best_available`, then `possible_contamination`; word and
+character count break ties, followed by the earlier Attempt. Empty results keep
+the Source Recording retryable and never invent text. Explicit Hand off joins
+the selected Segment transcripts in order into one Candidate Turn.
+
+The VoiceCore dependency is pinned at one merged revision and isolated behind
+the `InterviewArcLiveVoiceAdapter` target. Live never imports Voice delivery,
+dictation, planner, storage-root, or credential behavior.
+
+## Consequences
+
+- Relaunch can show the exact last durable Segment state and requires explicit
+  authorization before replaying an interrupted provider request.
+- SwiftUI observes immutable state and cannot call the microphone, filesystem,
+  or Groq directly.
+- Live pays the build cost of VoiceCore's current transitive dependencies until
+  a narrower shared audio package has demonstrated leverage.
+- Automatic silence segmentation, semantic handoff, D1/R2 delivery, and
+  cross-app microphone leases remain separate decisions.

--- a/scripts/install-app.sh
+++ b/scripts/install-app.sh
@@ -1,0 +1,124 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+bundle_identifier="app.interviewarc.live"
+destination="/Applications/Interview Arc Live.app"
+allow_adhoc_install="${INTERVIEW_ARC_LIVE_ALLOW_ADHOC_INSTALL:-0}"
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 '/path/to/Interview Arc Live.app'" >&2
+  exit 64
+fi
+
+source_app="${1:A}"
+source_info="$source_app/Contents/Info.plist"
+
+if [[ ! -d "$source_app" || ! -f "$source_info" ]]; then
+  echo "Expected a packaged Interview Arc Live application bundle." >&2
+  exit 66
+fi
+
+actual_identifier="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$source_info")"
+executable_name="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$source_info")"
+source_executable="$source_app/Contents/MacOS/$executable_name"
+
+if [[ "$actual_identifier" != "$bundle_identifier" || ! -x "$source_executable" ]]; then
+  echo "Refusing an application that is not Interview Arc Live." >&2
+  exit 65
+fi
+
+/usr/bin/codesign --verify --deep --strict --verbose=2 "$source_app"
+signature_details="$(/usr/bin/codesign -dvvv "$source_app" 2>&1)"
+if [[ "$signature_details" == *"Signature=adhoc"* && "$allow_adhoc_install" != "1" ]]; then
+  echo "Refusing an ad-hoc signature for installation." >&2
+  echo "Repackage with INTERVIEW_ARC_LIVE_SIGNING_IDENTITY set to a stable code-signing identity." >&2
+  echo "For an explicit development smoke only, set INTERVIEW_ARC_LIVE_ALLOW_ADHOC_INSTALL=1." >&2
+  exit 65
+fi
+if [[ "$signature_details" == *"Signature=adhoc"* ]]; then
+  echo "WARNING: installing an ad-hoc development build." >&2
+  echo "macOS may treat a future rebuild as a new identity and ask for microphone permission again." >&2
+fi
+
+source_cdhash="$(print -r -- "$signature_details" | /usr/bin/awk -F= '/^CDHash=/{print $2; exit}')"
+if [[ -z "$source_cdhash" ]]; then
+  echo "The packaged application has no verifiable code-directory hash." >&2
+  exit 65
+fi
+
+staging="/Applications/.Interview Arc Live.install-$$.app"
+backup="/Applications/.Interview Arc Live.backup-$$.app"
+
+cleanup() {
+  if [[ -d "$staging" ]]; then
+    rm -rf "$staging"
+  fi
+}
+trap cleanup EXIT
+
+# Refuse to displace an unrelated bundle even if it occupies the expected
+# application path.
+if [[ -e "$destination" ]]; then
+  installed_identifier="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$destination/Contents/Info.plist" 2>/dev/null || true)"
+  if [[ "$installed_identifier" != "$bundle_identifier" ]]; then
+    echo "Refusing to replace an unexpected application at $destination." >&2
+    exit 65
+  fi
+fi
+
+# Stop only this executable if it is already running. Refuse a forced quit so
+# an in-flight local session cannot be discarded by packaging automation.
+if /usr/bin/pgrep -x "$executable_name" >/dev/null; then
+  /usr/bin/osascript -e 'tell application id "app.interviewarc.live" to quit' >/dev/null 2>&1 || true
+  for _ in {1..50}; do
+    if ! /usr/bin/pgrep -x "$executable_name" >/dev/null; then
+      break
+    fi
+    sleep 0.1
+  done
+  if /usr/bin/pgrep -x "$executable_name" >/dev/null; then
+    echo "Interview Arc Live is still running; installation did not start." >&2
+    exit 75
+  fi
+fi
+
+/usr/bin/ditto "$source_app" "$staging"
+/usr/bin/codesign --verify --deep --strict --verbose=2 "$staging"
+
+if [[ -e "$destination" ]]; then
+  mv "$destination" "$backup"
+fi
+
+if ! mv "$staging" "$destination"; then
+  if [[ -d "$backup" ]]; then
+    mv "$backup" "$destination"
+  fi
+  echo "Installation failed; the previous application was restored." >&2
+  exit 1
+fi
+
+installed_details=""
+if ! /usr/bin/codesign --verify --deep --strict --verbose=2 "$destination"; then
+  installed_cdhash=""
+else
+  installed_details="$(/usr/bin/codesign -dvvv "$destination" 2>&1)"
+  installed_cdhash="$(print -r -- "$installed_details" | /usr/bin/awk -F= '/^CDHash=/{print $2; exit}')"
+fi
+
+if [[ -z "$installed_cdhash" || "$installed_cdhash" != "$source_cdhash" ]]; then
+  rm -rf "$destination"
+  if [[ -d "$backup" ]]; then
+    mv "$backup" "$destination"
+  fi
+  echo "Installed bytes did not match the packaged application; the previous application was restored." >&2
+  exit 1
+fi
+
+if [[ -d "$backup" ]]; then
+  rm -rf "$backup"
+fi
+
+/usr/bin/open "$destination"
+echo "Installed and launched exact package: $destination"
+echo "Code-directory hash: $installed_cdhash"

--- a/scripts/package-app.sh
+++ b/scripts/package-app.sh
@@ -1,0 +1,114 @@
+#!/bin/zsh
+
+set -euo pipefail
+setopt NULL_GLOB
+
+repo_root="${0:A:h:h}"
+configuration="${1:-release}"
+app_name="Interview Arc Live.app"
+app_dir="$repo_root/dist/$app_name"
+contents_dir="$app_dir/Contents"
+executable_name="InterviewArcLive"
+info_plist="$repo_root/Resources/Info.plist"
+signing_identity="${INTERVIEW_ARC_LIVE_SIGNING_IDENTITY:--}"
+manifest_path="$repo_root/dist/InterviewArcLive.package-manifest.txt"
+allow_dirty="${INTERVIEW_ARC_LIVE_ALLOW_DIRTY:-0}"
+
+if [[ "$configuration" != "debug" && "$configuration" != "release" ]]; then
+  echo "Usage: $0 [debug|release]" >&2
+  exit 64
+fi
+
+if [[ ! -f "$info_plist" ]]; then
+  echo "Missing application metadata: Resources/Info.plist" >&2
+  exit 66
+fi
+
+cd "$repo_root"
+source_commit="$(git rev-parse HEAD)"
+source_tree_clean="true"
+if [[ -n "$(git status --porcelain --untracked-files=all)" ]]; then
+  source_tree_clean="false"
+  if [[ "$allow_dirty" != "1" ]]; then
+    echo "Refusing to package a dirty source tree." >&2
+    echo "Set INTERVIEW_ARC_LIVE_ALLOW_DIRTY=1 only for an explicit development build." >&2
+    exit 65
+  fi
+fi
+
+swift build -c "$configuration" --product "$executable_name"
+bin_dir="$(swift build -c "$configuration" --show-bin-path)"
+executable="$bin_dir/$executable_name"
+
+if [[ -n "$(git status --porcelain --untracked-files=all)" ]]; then
+  source_tree_clean="false"
+  if [[ "$allow_dirty" != "1" ]]; then
+    echo "The build changed tracked or untracked source state; packaging stopped." >&2
+    exit 65
+  fi
+fi
+
+if [[ ! -x "$executable" ]]; then
+  echo "Built executable is missing: $executable" >&2
+  exit 66
+fi
+
+# The target is deliberately fixed beneath this repository. Packaging never
+# discovers or replaces an installed application.
+if [[ "$app_dir" != "$repo_root/dist/$app_name" ]]; then
+  echo "Refusing an unexpected package destination." >&2
+  exit 65
+fi
+
+rm -rf "$app_dir"
+mkdir -p "$contents_dir/MacOS" "$contents_dir/Resources"
+cp "$info_plist" "$contents_dir/Info.plist"
+cp "$executable" "$contents_dir/MacOS/$executable_name"
+chmod 0755 "$contents_dir/MacOS/$executable_name"
+
+for resource_bundle in "$bin_dir"/*.bundle; do
+  if [[ -d "$resource_bundle" ]]; then
+    cp -R "$resource_bundle" "$contents_dir/Resources/"
+  fi
+done
+
+/usr/bin/codesign \
+  --force \
+  --sign "$signing_identity" \
+  --timestamp=none \
+  "$app_dir"
+
+/usr/bin/codesign --verify --deep --strict --verbose=2 "$app_dir"
+/usr/bin/plutil -lint "$contents_dir/Info.plist"
+
+actual_identifier="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$contents_dir/Info.plist")"
+actual_executable="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$contents_dir/Info.plist")"
+if [[ "$actual_identifier" != "app.interviewarc.live" || "$actual_executable" != "$executable_name" ]]; then
+  echo "Packaged application metadata does not match Interview Arc Live." >&2
+  exit 65
+fi
+
+executable_sha256="$(/usr/bin/shasum -a 256 "$contents_dir/MacOS/$executable_name" | /usr/bin/awk '{print $1}')"
+info_plist_sha256="$(/usr/bin/shasum -a 256 "$contents_dir/Info.plist" | /usr/bin/awk '{print $1}')"
+code_directory_hash="$(/usr/bin/codesign -dvvv "$app_dir" 2>&1 | /usr/bin/awk -F= '/^CDHash=/{print $2; exit}')"
+resource_bundle_count="$(/usr/bin/find "$contents_dir/Resources" -mindepth 1 -maxdepth 1 -type d -name '*.bundle' | /usr/bin/wc -l | /usr/bin/tr -d ' ')"
+signature_mode="certificate"
+if [[ "$signing_identity" == "-" ]]; then
+  signature_mode="ad-hoc"
+fi
+
+{
+  print -r -- "bundle_identifier=$actual_identifier"
+  print -r -- "configuration=$configuration"
+  print -r -- "source_commit=$source_commit"
+  print -r -- "source_tree_clean=$source_tree_clean"
+  print -r -- "signature_mode=$signature_mode"
+  print -r -- "code_directory_hash=$code_directory_hash"
+  print -r -- "executable_sha256=$executable_sha256"
+  print -r -- "info_plist_sha256=$info_plist_sha256"
+  print -r -- "resource_bundle_count=$resource_bundle_count"
+} > "$manifest_path"
+chmod 0600 "$manifest_path"
+
+echo "$app_dir"
+echo "$manifest_path"


### PR DESCRIPTION
## **User description**
Refs #5

## Summary

- add a durable segmented-speech domain and coordinator with stable identities, crash reconciliation, idempotent capture/transcription authorizations, deterministic best-candidate selection, and ordered multi-segment Hand off
- pin the exact merged Interview Arc VoiceCore revision behind an isolated platform-adapter target for microphone capture, private M4A recovery/playback, Groq Whisper transcription, and a Live-only Keychain service
- replace the fixture transcript UI with real Record/Stop, Transcribe/Retry, Play, Exclude, and Hand off controls plus truthful recovery and transcript-quality states
- harden local manifests/audio/scratch storage, add bounded crash-residue cleanup, and package a regular standalone macOS application

## Reliability invariants

- source audio is persisted before Groq is contacted and is never deleted by transcript failure
- unexpected termination and relaunch recovery preserve audio without silently contacting Groq
- a persisted in-flight provider authorization becomes an interrupted attempt and requires a fresh explicit retry
- duplicate command IDs never repeat capture, provider, or interviewer side effects
- every nonempty provider candidate remains exact and visible; empty results never fabricate text
- directories are private 0700, evidence files are 0600, and credentials remain in the Live-specific macOS Keychain service

## Verification

- all Swift sources parse
- InterviewArcLiveCore semantic typecheck passes with warnings-as-errors against macOS 15.4
- app semantic typecheck passes against emitted Core and exact Voice-adapter public signatures
- recorder, transcriber, Keychain, manifest, crash-recovery, idempotency, and ordered-assembly tests added
- shell syntax, plist lint, public-safety scan, and git diff check pass
- full package/XCTest execution delegated to macOS CI because the local Command Line Tools installation pairs a Swift 6.3.3 compiler with a Swift 6.3.2 PackageDescription SDK

The first PR run intentionally exports the CI-generated Package.resolved so the exact lockfile can be committed before merge.


___

## **CodeAnt-AI Description**
Add durable segmented speech capture and recovery to Interview Arc Live

### What Changed
- Record multiple candidate speech segments, review each transcript, play preserved audio, retry transcription, exclude segments, and combine selected segments in order during Hand off.
- Save recordings before transcription and recover partial or interrupted recordings after relaunch without automatically sending them to Groq.
- Require explicit transcription attempts, prevent duplicate provider requests, preserve nonempty results with clear quality states, and block Hand off until every unresolved segment is handled.
- Add secure Groq API-key setup through macOS Keychain with clear credential and transcription failure messages.
- Store manifests and source recordings in private local directories, clean up bounded stale provider files, and package the macOS application with verification checks.

### Impact
`✅ Recoverable candidate recordings after interruption`
`✅ Fewer duplicate or unintended Groq requests`
`✅ Ordered multi-segment answers`
`✅ Clearer transcript quality and recovery states`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
