### PR TITLE
Keep development builds credential-ready

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -21,6 +21,8 @@ jobs:
         run: swift package resolve
       - name: Test package
         run: swift test
+      - name: Test installer safety
+        run: Tests/ScriptTests/install-app-tests.zsh
       - name: Package merged application
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: scripts/package-app.sh release

--- a/Sources/InterviewArcLive/GroqCredentialSetupView.swift
+++ b/Sources/InterviewArcLive/GroqCredentialSetupView.swift
@@ -5,9 +5,16 @@ struct GroqCredentialSetupView: View {
 
     let isSaving: Bool
     let errorMessage: String?
-    let onSave: (String) async -> Bool
+    let onSaveToKeychain: (String) async -> Bool
+    let onUseUntilQuit: (String) async -> Bool
 
     @State private var key = ""
+    @State private var activeSubmission: CredentialSubmission?
+
+    private enum CredentialSubmission {
+        case keychain
+        case untilQuit
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
@@ -20,7 +27,7 @@ struct GroqCredentialSetupView: View {
                 VStack(alignment: .leading, spacing: 6) {
                     Text("Connect Groq transcription")
                         .font(.system(.title2, design: .rounded, weight: .semibold))
-                    Text("Your key is read back from this app’s macOS Keychain after saving and is never shown again.")
+                    Text("Choose whether this app remembers the key in macOS Keychain or keeps it only until you quit.")
                         .font(.system(.body, design: .rounded))
                         .foregroundStyle(LivePalette.muted)
                         .fixedSize(horizontal: false, vertical: true)
@@ -33,8 +40,9 @@ struct GroqCredentialSetupView: View {
 
             SecureField("Groq API key", text: $key)
                 .textFieldStyle(.roundedBorder)
-                .disabled(isSaving)
-                .onSubmit { save() }
+                .disabled(isSubmissionInFlight)
+                .privacySensitive()
+                .onSubmit { saveToKeychain() }
 
             if let errorMessage {
                 Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
@@ -43,39 +51,120 @@ struct GroqCredentialSetupView: View {
                     .accessibilityLabel("Credential setup error: \(errorMessage)")
             }
 
+            VStack(alignment: .leading, spacing: 14) {
+                credentialChoice(
+                    title: "Save to Keychain",
+                    detail: "Persists for future launches on this Mac. The saved value is never displayed after verification.",
+                    submission: .keychain,
+                    action: saveToKeychain
+                )
+                credentialChoice(
+                    title: "Use until quit",
+                    detail: "Keeps the key only in this app’s memory. You must enter it again after quitting or relaunching.",
+                    submission: .untilQuit,
+                    action: useUntilQuit
+                )
+            }
+
             HStack {
-                Text("Existing recordings remain private and recoverable if setup fails.")
+                Text("If setup fails, existing source recordings remain local and recoverable.")
                     .font(.system(.caption, design: .rounded))
                     .foregroundStyle(LivePalette.muted)
 
                 Spacer()
 
                 Button("Not now") { dismiss() }
-                    .disabled(isSaving)
-
-                Button(action: save) {
-                    if isSaving {
-                        ProgressView()
-                            .controlSize(.small)
-                    } else {
-                        Text("Save key")
-                    }
-                }
-                .buttonStyle(.borderedProminent)
-                .tint(LivePalette.candidate)
-                .disabled(isSaving || key.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-                .keyboardShortcut(.defaultAction)
+                    .disabled(isSubmissionInFlight)
+                    .keyboardShortcut(.cancelAction)
             }
         }
         .padding(26)
-        .frame(width: 500)
+        .frame(width: 540)
         .background(LivePalette.paper)
     }
 
-    private func save() {
+    @ViewBuilder
+    private func credentialChoice(
+        title: String,
+        detail: String,
+        submission: CredentialSubmission,
+        action: @escaping () -> Void
+    ) -> some View {
+        HStack(alignment: .center, spacing: 16) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title)
+                    .font(.system(.body, design: .rounded, weight: .semibold))
+                Text(detail)
+                    .font(.system(.caption, design: .rounded))
+                    .foregroundStyle(LivePalette.muted)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 18)
+            if submission == .keychain {
+                Button(action: action) {
+                    actionLabel(title: title, submission: submission)
+                }
+                .buttonStyle(.borderedProminent)
+                .keyboardShortcut(.defaultAction)
+                .tint(LivePalette.candidate)
+                .disabled(isActionDisabled)
+                .accessibilityHint(detail)
+            } else {
+                Button(action: action) {
+                    actionLabel(title: title, submission: submission)
+                }
+                .buttonStyle(.bordered)
+                .tint(LivePalette.candidate)
+                .disabled(isActionDisabled)
+                .accessibilityHint(detail)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func actionLabel(
+        title: String,
+        submission: CredentialSubmission
+    ) -> some View {
+        if activeSubmission == submission {
+            HStack(spacing: 7) {
+                ProgressView().controlSize(.small)
+                Text(submission == .keychain ? "Saving…" : "Using…")
+            }
+        } else {
+            Text(title)
+        }
+    }
+
+    private var isActionDisabled: Bool {
+        isSubmissionInFlight
+            || key.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private var isSubmissionInFlight: Bool {
+        isSaving || activeSubmission != nil
+    }
+
+    private func saveToKeychain() {
         let submittedKey = key
-        Task {
-            if await onSave(submittedKey) {
+        activeSubmission = .keychain
+        Task { @MainActor in
+            let didSave = await onSaveToKeychain(submittedKey)
+            activeSubmission = nil
+            if didSave {
+                key = ""
+                dismiss()
+            }
+        }
+    }
+
+    private func useUntilQuit() {
+        let submittedKey = key
+        activeSubmission = .untilQuit
+        Task { @MainActor in
+            let didUse = await onUseUntilQuit(submittedKey)
+            activeSubmission = nil
+            if didUse {
                 key = ""
                 dismiss()
             }

--- a/Sources/InterviewArcLive/SystemDesignRoomModel.swift
+++ b/Sources/InterviewArcLive/SystemDesignRoomModel.swift
@@ -20,7 +20,8 @@ final class SystemDesignRoomModel: ObservableObject {
     private enum CredentialState {
         case checking
         case missing
-        case ready
+        case readyFromKeychain
+        case readyUntilQuit
         case unusable
     }
 
@@ -36,6 +37,11 @@ final class SystemDesignRoomModel: ObservableObject {
 
     var needsGroqCredential: Bool {
         credentialState == .missing || credentialState == .unusable
+    }
+
+    private var hasUsableGroqCredential: Bool {
+        credentialState == .readyFromKeychain
+            || credentialState == .readyUntilQuit
     }
 
     var canStopRecording: Bool {
@@ -60,7 +66,7 @@ final class SystemDesignRoomModel: ObservableObject {
 
     var canRecordSegment: Bool {
         guard !isWorking,
-              credentialState == .ready,
+              hasUsableGroqCredential,
               snapshot?.phase == .candidateFloor else {
             return false
         }
@@ -165,7 +171,7 @@ final class SystemDesignRoomModel: ObservableObject {
 
     func recordSegment() async {
         guard let coordinator else { return }
-        guard credentialState == .ready else {
+        guard hasUsableGroqCredential else {
             presentCredentialSetup()
             return
         }
@@ -228,8 +234,8 @@ final class SystemDesignRoomModel: ObservableObject {
 
     func transcribeSegment(id: String) async {
         guard let coordinator, !isWorking else { return }
-        guard credentialState == .ready else {
-            credentialErrorMessage = "Save a Groq API key before retrying this transcript."
+        guard hasUsableGroqCredential else {
+            credentialErrorMessage = "Add a Groq API key before retrying this transcript."
             presentCredentialSetup()
             return
         }
@@ -360,9 +366,9 @@ final class SystemDesignRoomModel: ObservableObject {
 
         do {
             try await credentialStore.saveAndVerify(value)
-            credentialState = .ready
+            credentialState = .readyFromKeychain
             statusMessage = segments.contains(where: { $0.transcriptionAction != nil })
-                ? "Groq key saved · transcribe the affected segment"
+                ? "Groq key saved to Keychain · transcribe the affected segment"
                 : status(for: snapshot)
             return true
         } catch let error as LiveGroqCredentialStoreError {
@@ -372,6 +378,28 @@ final class SystemDesignRoomModel: ObservableObject {
         } catch {
             credentialState = .unusable
             credentialErrorMessage = "macOS Keychain could not save the Groq API key."
+            return false
+        }
+    }
+
+    func useGroqCredentialUntilQuit(_ value: String) async -> Bool {
+        guard !isSavingCredential else { return false }
+        isSavingCredential = true
+        credentialErrorMessage = nil
+        defer { isSavingCredential = false }
+
+        do {
+            try await credentialStore.useUntilQuit(value)
+            credentialState = .readyUntilQuit
+            statusMessage = segments.contains(where: { $0.transcriptionAction != nil })
+                ? "Groq key available until quit · transcribe the affected segment"
+                : status(for: snapshot)
+            return true
+        } catch let error as LiveGroqCredentialStoreError {
+            credentialErrorMessage = error.localizedDescription
+            return false
+        } catch {
+            credentialErrorMessage = "The Groq API key could not be used for this app session."
             return false
         }
     }
@@ -403,9 +431,17 @@ final class SystemDesignRoomModel: ObservableObject {
         do {
             switch try await credentialStore.readiness() {
             case .ready:
-                credentialState = .ready
+                credentialState = .readyFromKeychain
+            case .readyUntilQuit:
+                credentialState = .readyUntilQuit
             case .missing:
                 credentialState = .missing
+                if presentWhenMissing {
+                    isCredentialSetupPresented = true
+                }
+            case .keychainUnavailable:
+                credentialState = .unusable
+                credentialErrorMessage = "macOS Keychain is unavailable. Use the key until quit to record in this app session."
                 if presentWhenMissing {
                     isCredentialSetupPresented = true
                 }
@@ -438,7 +474,7 @@ final class SystemDesignRoomModel: ObservableObject {
 
         switch snapshot.phase {
         case .candidateFloor:
-            if credentialState != .ready {
+            if !hasUsableGroqCredential {
                 return "Groq key required"
             }
             if draft.contains(where: {
@@ -454,9 +490,12 @@ final class SystemDesignRoomModel: ObservableObject {
             let selectedCount = draft.filter {
                 $0.lifecycle != .excluded && $0.selectedCandidate != nil
             }.count
-            return selectedCount == 0
-                ? "Ready to record"
-                : "\(selectedCount) segment\(selectedCount == 1 ? "" : "s") ready"
+            if selectedCount == 0 {
+                return credentialState == .readyUntilQuit
+                    ? "Ready to record · key available until quit"
+                    : "Ready to record"
+            }
+            return "\(selectedCount) segment\(selectedCount == 1 ? "" : "s") ready"
         case .interviewerProcessing:
             return "Answer saved · interviewer retry available"
         case .interviewerTurn:

--- a/Sources/InterviewArcLive/SystemDesignRoomView.swift
+++ b/Sources/InterviewArcLive/SystemDesignRoomView.swift
@@ -28,7 +28,8 @@ struct SystemDesignRoomView: View {
             GroqCredentialSetupView(
                 isSaving: model.isSavingCredential,
                 errorMessage: model.credentialErrorMessage,
-                onSave: model.saveGroqCredential
+                onSaveToKeychain: model.saveGroqCredential,
+                onUseUntilQuit: model.useGroqCredentialUntilQuit
             )
         }
     }

--- a/Sources/InterviewArcLiveVoiceAdapter/LiveGroqCredentialStore.swift
+++ b/Sources/InterviewArcLiveVoiceAdapter/LiveGroqCredentialStore.swift
@@ -17,6 +17,7 @@ public enum LiveGroqCredentialStoreError: Error, Equatable, LocalizedError, Send
     case missingCredential
     case keychainUnavailable
     case verificationFailed
+    case rollbackFailed
 
     public var errorDescription: String? {
         switch self {
@@ -28,6 +29,8 @@ public enum LiveGroqCredentialStoreError: Error, Equatable, LocalizedError, Send
             "macOS Keychain is unavailable. Use a key until quit or try again."
         case .verificationFailed:
             "Interview Arc Live could not verify the saved Groq API key."
+        case .rollbackFailed:
+            "Keychain may still contain the submitted Groq API key. Remove or replace it before retrying."
         }
     }
 }
@@ -80,17 +83,26 @@ public actor LiveGroqCredentialStore: GroqCredentialReading {
             throw LiveGroqCredentialStoreError.emptyCredential
         }
 
+        let previousValue: String?
+        do {
+            previousValue = try backend.read()
+        } catch {
+            throw LiveGroqCredentialStoreError.keychainUnavailable
+        }
+
         let retrieved: String?
         do {
             try backend.save(normalized)
             retrieved = try backend.read()
         } catch {
+            try restoreKeychain(previousValue)
             throw LiveGroqCredentialStoreError.keychainUnavailable
         }
         guard verificationPolicy.isVerified(
             submittedValue: normalized,
             retrievedValue: retrieved
         ) else {
+            try restoreKeychain(previousValue)
             throw LiveGroqCredentialStoreError.verificationFailed
         }
         credentialUntilQuit = nil
@@ -132,6 +144,30 @@ public actor LiveGroqCredentialStore: GroqCredentialReading {
         guard let value else { return nil }
         let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return normalized.isEmpty ? nil : normalized
+    }
+
+    private func restoreKeychain(_ previousValue: String?) throws {
+        do {
+            if let previousValue {
+                try backend.save(previousValue)
+                guard verificationPolicy.isVerified(
+                    submittedValue: previousValue,
+                    retrievedValue: try backend.read(),
+                    permitsEmpty: true
+                ) else {
+                    throw LiveGroqCredentialStoreError.rollbackFailed
+                }
+            } else {
+                try backend.remove()
+                guard normalized(try backend.read()) == nil else {
+                    throw LiveGroqCredentialStoreError.rollbackFailed
+                }
+            }
+        } catch let error as LiveGroqCredentialStoreError {
+            throw error
+        } catch {
+            throw LiveGroqCredentialStoreError.rollbackFailed
+        }
     }
 }
 

--- a/Sources/InterviewArcLiveVoiceAdapter/LiveGroqCredentialStore.swift
+++ b/Sources/InterviewArcLiveVoiceAdapter/LiveGroqCredentialStore.swift
@@ -3,13 +3,19 @@ import InterviewArcLiveCore
 import InterviewArcVoiceCore
 
 public enum LiveGroqCredentialReadiness: Equatable, Sendable {
+    /// A durable Keychain credential is available.
     case ready
+    /// The explicit process-memory credential is active and will disappear
+    /// when this app process exits.
+    case readyUntilQuit
     case missing
+    case keychainUnavailable
 }
 
 public enum LiveGroqCredentialStoreError: Error, Equatable, LocalizedError, Sendable {
     case emptyCredential
     case missingCredential
+    case keychainUnavailable
     case verificationFailed
 
     public var errorDescription: String? {
@@ -17,7 +23,9 @@ public enum LiveGroqCredentialStoreError: Error, Equatable, LocalizedError, Send
         case .emptyCredential:
             "Enter a Groq API key before saving."
         case .missingCredential:
-            "Interview Arc Live does not have a Groq API key in Keychain."
+            "Interview Arc Live does not have a Groq API key."
+        case .keychainUnavailable:
+            "macOS Keychain is unavailable. Use a key until quit or try again."
         case .verificationFailed:
             "Interview Arc Live could not verify the saved Groq API key."
         }
@@ -29,6 +37,9 @@ public actor LiveGroqCredentialStore: GroqCredentialReading {
 
     private let backend: LiveGroqCredentialBackend
     private let verificationPolicy = CredentialSaveVerificationPolicy()
+    /// Intentionally actor-local and non-Codable. This value has no Adapter
+    /// capable of writing it to disk, diagnostics, manifests, or preferences.
+    private var credentialUntilQuit: String?
 
     public init() {
         let keychain = KeychainStore(service: Self.keychainService)
@@ -44,7 +55,17 @@ public actor LiveGroqCredentialStore: GroqCredentialReading {
     }
 
     public func read() throws -> String? {
-        try backend.read()
+        if let credentialUntilQuit {
+            return credentialUntilQuit
+        }
+        do {
+            if let keychainCredential = normalized(try backend.read()) {
+                return keychainCredential
+            }
+            return nil
+        } catch {
+            throw LiveGroqCredentialStoreError.keychainUnavailable
+        }
     }
 
     public func readGroqCredential() throws -> String {
@@ -55,30 +76,62 @@ public actor LiveGroqCredentialStore: GroqCredentialReading {
     }
 
     public func saveAndVerify(_ value: String) throws {
-        let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !normalized.isEmpty else {
+        guard let normalized = normalized(value) else {
             throw LiveGroqCredentialStoreError.emptyCredential
         }
 
-        try backend.save(normalized)
+        let retrieved: String?
+        do {
+            try backend.save(normalized)
+            retrieved = try backend.read()
+        } catch {
+            throw LiveGroqCredentialStoreError.keychainUnavailable
+        }
         guard verificationPolicy.isVerified(
             submittedValue: normalized,
-            retrievedValue: try backend.read()
+            retrievedValue: retrieved
         ) else {
             throw LiveGroqCredentialStoreError.verificationFailed
         }
+        credentialUntilQuit = nil
+    }
+
+    /// Uses a credential only in this actor's process memory. It never calls
+    /// the Keychain backend or any serialization/logging Adapter.
+    public func useUntilQuit(_ value: String) throws {
+        guard let normalized = normalized(value) else {
+            throw LiveGroqCredentialStoreError.emptyCredential
+        }
+        credentialUntilQuit = normalized
     }
 
     public func remove() throws {
-        try backend.remove()
+        credentialUntilQuit = nil
+        do {
+            try backend.remove()
+        } catch {
+            throw LiveGroqCredentialStoreError.keychainUnavailable
+        }
     }
 
     public func readiness() throws -> LiveGroqCredentialReadiness {
-        guard let value = try read(),
-              !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            return .missing
+        if credentialUntilQuit != nil {
+            return .readyUntilQuit
         }
-        return .ready
+        do {
+            if normalized(try backend.read()) != nil {
+                return .ready
+            }
+            return .missing
+        } catch {
+            return .keychainUnavailable
+        }
+    }
+
+    private func normalized(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return normalized.isEmpty ? nil : normalized
     }
 }
 

--- a/Tests/InterviewArcLiveVoiceAdapterTests/LiveGroqCredentialStoreTests.swift
+++ b/Tests/InterviewArcLiveVoiceAdapterTests/LiveGroqCredentialStoreTests.swift
@@ -134,6 +134,78 @@ final class LiveGroqCredentialStoreTests: XCTestCase {
         }
     }
 
+    func testThrownReadbackRestoresPreviousKeychainValue() async throws {
+        let fixture = TransactionCredentialFixture(
+            value: "previous-test-key",
+            failingReadCalls: [2]
+        )
+        let store = LiveGroqCredentialStore(backend: fixture.backend)
+
+        do {
+            try await store.saveAndVerify("submitted-test-key")
+            XCTFail("Expected verification readback to fail")
+        } catch let error as LiveGroqCredentialStoreError {
+            XCTAssertEqual(error, .keychainUnavailable)
+        }
+
+        XCTAssertEqual(fixture.value, "previous-test-key")
+        XCTAssertEqual(fixture.saveCount, 2)
+    }
+
+    func testMismatchedReadbackRestoresPreviousKeychainValue() async throws {
+        let fixture = TransactionCredentialFixture(
+            value: "previous-test-key",
+            mismatchedReadCalls: [2: "different-test-key"]
+        )
+        let store = LiveGroqCredentialStore(backend: fixture.backend)
+
+        do {
+            try await store.saveAndVerify("submitted-test-key")
+            XCTFail("Expected verification mismatch")
+        } catch let error as LiveGroqCredentialStoreError {
+            XCTAssertEqual(error, .verificationFailed)
+        }
+
+        XCTAssertEqual(fixture.value, "previous-test-key")
+        XCTAssertEqual(fixture.saveCount, 2)
+    }
+
+    func testMismatchedReadbackRemovesNewlyInsertedKeychainValue() async throws {
+        let fixture = TransactionCredentialFixture(
+            value: nil,
+            mismatchedReadCalls: [2: "different-test-key"]
+        )
+        let store = LiveGroqCredentialStore(backend: fixture.backend)
+
+        do {
+            try await store.saveAndVerify("submitted-test-key")
+            XCTFail("Expected verification mismatch")
+        } catch let error as LiveGroqCredentialStoreError {
+            XCTAssertEqual(error, .verificationFailed)
+        }
+
+        XCTAssertNil(fixture.value)
+    }
+
+    func testFailedRollbackReportsSafePossibleSubmittedValue() async throws {
+        let fixture = TransactionCredentialFixture(
+            value: nil,
+            failingReadCalls: [2],
+            removeFails: true
+        )
+        let store = LiveGroqCredentialStore(backend: fixture.backend)
+
+        do {
+            try await store.saveAndVerify("submitted-test-key")
+            XCTFail("Expected rollback failure")
+        } catch let error as LiveGroqCredentialStoreError {
+            XCTAssertEqual(error, .rollbackFailed)
+            XCTAssertTrue(error.localizedDescription.contains("may still contain"))
+            XCTAssertFalse(error.localizedDescription.contains("submitted-test-key"))
+        }
+        XCTAssertEqual(fixture.value, "submitted-test-key")
+    }
+
     func testKeychainWriteFailureReturnsSafeUnavailableError() async throws {
         let fixture = CredentialMemoryFixture(keychainAvailable: false)
         let store = LiveGroqCredentialStore(backend: fixture.backend)
@@ -211,4 +283,62 @@ private final class CredentialMemoryFixture: @unchecked Sendable {
 
 private enum CredentialFixtureError: Error {
     case unavailable
+}
+
+private final class TransactionCredentialFixture: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedValue: String?
+    private var reads = 0
+    private var saves = 0
+    private let failingReadCalls: Set<Int>
+    private let mismatchedReadCalls: [Int: String]
+    private let removeFails: Bool
+
+    init(
+        value: String?,
+        failingReadCalls: Set<Int> = [],
+        mismatchedReadCalls: [Int: String] = [:],
+        removeFails: Bool = false
+    ) {
+        storedValue = value
+        self.failingReadCalls = failingReadCalls
+        self.mismatchedReadCalls = mismatchedReadCalls
+        self.removeFails = removeFails
+    }
+
+    var value: String? {
+        lock.withLock { storedValue }
+    }
+
+    var saveCount: Int {
+        lock.withLock { saves }
+    }
+
+    var backend: LiveGroqCredentialBackend {
+        LiveGroqCredentialBackend(
+            read: { [self] in
+                try lock.withLock {
+                    reads += 1
+                    if failingReadCalls.contains(reads) {
+                        throw CredentialFixtureError.unavailable
+                    }
+                    return mismatchedReadCalls[reads] ?? storedValue
+                }
+            },
+            save: { [self] value in
+                lock.withLock {
+                    saves += 1
+                    storedValue = value
+                }
+            },
+            remove: { [self] in
+                try lock.withLock {
+                    if removeFails {
+                        throw CredentialFixtureError.unavailable
+                    }
+                    storedValue = nil
+                }
+            }
+        )
+    }
 }

--- a/Tests/InterviewArcLiveVoiceAdapterTests/LiveGroqCredentialStoreTests.swift
+++ b/Tests/InterviewArcLiveVoiceAdapterTests/LiveGroqCredentialStoreTests.swift
@@ -32,6 +32,74 @@ final class LiveGroqCredentialStoreTests: XCTestCase {
         XCTAssertEqual(readiness, .ready)
     }
 
+    func testExplicitUntilQuitCredentialOverridesKeychainForThisStore() async throws {
+        let fixture = CredentialMemoryFixture(value: "durable-test-key")
+        let store = LiveGroqCredentialStore(backend: fixture.backend)
+
+        try await store.useUntilQuit("ephemeral-test-key")
+
+        let active = try await store.readGroqCredential()
+        let readiness = try await store.readiness()
+        XCTAssertEqual(active, "ephemeral-test-key")
+        XCTAssertEqual(readiness, .readyUntilQuit)
+        XCTAssertEqual(fixture.saveCount, 0)
+
+        try await store.saveAndVerify("replacement-durable-key")
+        let savedCredential = try await store.readGroqCredential()
+        let savedReadiness = try await store.readiness()
+        XCTAssertEqual(savedCredential, "replacement-durable-key")
+        XCTAssertEqual(savedReadiness, .ready)
+    }
+
+    func testUnavailableKeychainCanUseProcessMemoryWithoutWritingSecret() async throws {
+        let fixture = CredentialMemoryFixture(keychainAvailable: false)
+        let store = LiveGroqCredentialStore(backend: fixture.backend)
+
+        let unavailable = try await store.readiness()
+        XCTAssertEqual(unavailable, .keychainUnavailable)
+        do {
+            _ = try await store.readGroqCredential()
+            XCTFail("Expected unavailable Keychain to be distinguishable")
+        } catch let error as LiveGroqCredentialStoreError {
+            XCTAssertEqual(error, .keychainUnavailable)
+        }
+
+        try await store.useUntilQuit("  ephemeral-test-key  ")
+
+        let readiness = try await store.readiness()
+        let active = try await store.readGroqCredential()
+        XCTAssertEqual(readiness, .readyUntilQuit)
+        XCTAssertEqual(active, "ephemeral-test-key")
+        XCTAssertEqual(fixture.saveCount, 0)
+        XCTAssertNil(fixture.value)
+        XCTAssertFalse(String(describing: readiness).contains("ephemeral-test-key"))
+        XCTAssertFalse(
+            LiveGroqCredentialStoreError.keychainUnavailable.localizedDescription
+                .contains("ephemeral-test-key")
+        )
+
+        let relaunchedStore = LiveGroqCredentialStore(backend: fixture.backend)
+        let relaunchedReadiness = try await relaunchedStore.readiness()
+        XCTAssertEqual(relaunchedReadiness, .keychainUnavailable)
+        do {
+            _ = try await relaunchedStore.readGroqCredential()
+            XCTFail("A new process store must not inherit the until-quit credential")
+        } catch let error as LiveGroqCredentialStoreError {
+            XCTAssertEqual(error, .keychainUnavailable)
+        }
+    }
+
+    func testMissingKeychainAndUntilQuitCredentialHaveDistinctReadiness() async throws {
+        let fixture = CredentialMemoryFixture()
+        let store = LiveGroqCredentialStore(backend: fixture.backend)
+
+        let missing = try await store.readiness()
+        XCTAssertEqual(missing, .missing)
+        try await store.useUntilQuit("ephemeral-test-key")
+        let untilQuit = try await store.readiness()
+        XCTAssertEqual(untilQuit, .readyUntilQuit)
+    }
+
     func testEmptyCredentialIsRejectedWithoutWriting() async throws {
         let fixture = CredentialMemoryFixture()
         let store = LiveGroqCredentialStore(backend: fixture.backend)
@@ -44,6 +112,14 @@ final class LiveGroqCredentialStoreTests: XCTestCase {
         }
 
         XCTAssertNil(fixture.value)
+
+        do {
+            try await store.useUntilQuit("  \n")
+            XCTFail("Expected an empty process credential to fail")
+        } catch let error as LiveGroqCredentialStoreError {
+            XCTAssertEqual(error, .emptyCredential)
+        }
+        XCTAssertEqual(fixture.saveCount, 0)
     }
 
     func testFailedReadbackDoesNotClaimCredentialWasSaved() async throws {
@@ -55,6 +131,19 @@ final class LiveGroqCredentialStoreTests: XCTestCase {
             XCTFail("Expected verification to fail")
         } catch let error as LiveGroqCredentialStoreError {
             XCTAssertEqual(error, .verificationFailed)
+        }
+    }
+
+    func testKeychainWriteFailureReturnsSafeUnavailableError() async throws {
+        let fixture = CredentialMemoryFixture(keychainAvailable: false)
+        let store = LiveGroqCredentialStore(backend: fixture.backend)
+
+        do {
+            try await store.saveAndVerify("public-test-key")
+            XCTFail("Expected unavailable Keychain save to fail")
+        } catch let error as LiveGroqCredentialStoreError {
+            XCTAssertEqual(error, .keychainUnavailable)
+            XCTAssertFalse(error.localizedDescription.contains("public-test-key"))
         }
     }
 
@@ -74,25 +163,52 @@ private final class CredentialMemoryFixture: @unchecked Sendable {
     private let lock = NSLock()
     private var storedValue: String?
     private let persistsWrites: Bool
+    private let keychainAvailable: Bool
+    private var saves = 0
 
-    init(value: String? = nil, persistsWrites: Bool = true) {
+    init(
+        value: String? = nil,
+        persistsWrites: Bool = true,
+        keychainAvailable: Bool = true
+    ) {
         storedValue = value
         self.persistsWrites = persistsWrites
+        self.keychainAvailable = keychainAvailable
     }
 
     var value: String? {
         lock.withLock { storedValue }
     }
 
+    var saveCount: Int {
+        lock.withLock { saves }
+    }
+
     var backend: LiveGroqCredentialBackend {
         LiveGroqCredentialBackend(
-            read: { [self] in lock.withLock { storedValue } },
+            read: { [self] in
+                try lock.withLock {
+                    guard keychainAvailable else { throw CredentialFixtureError.unavailable }
+                    return storedValue
+                }
+            },
             save: { [self] value in
-                lock.withLock {
+                try lock.withLock {
+                    guard keychainAvailable else { throw CredentialFixtureError.unavailable }
+                    saves += 1
                     if persistsWrites { storedValue = value }
                 }
             },
-            remove: { [self] in lock.withLock { storedValue = nil } }
+            remove: { [self] in
+                try lock.withLock {
+                    guard keychainAvailable else { throw CredentialFixtureError.unavailable }
+                    storedValue = nil
+                }
+            }
         )
     }
+}
+
+private enum CredentialFixtureError: Error {
+    case unavailable
 }

--- a/Tests/ScriptTests/install-app-tests.zsh
+++ b/Tests/ScriptTests/install-app-tests.zsh
@@ -1,0 +1,124 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+repo_root="${0:A:h:h:h}"
+installer="$repo_root/scripts/install-app.sh"
+test_root="$(/usr/bin/mktemp -d "${TMPDIR:-/tmp}/interview-arc-live-installer.XXXXXX")"
+
+cleanup() {
+  rm -rf "$test_root"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+assert_equal() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+  [[ "$actual" == "$expected" ]] || fail "$label: expected '$expected', got '$actual'"
+}
+
+make_signed_bundle() {
+  local bundle="$1"
+  local identifier="$2"
+  local marker="$3"
+  local executable="InterviewArcLive"
+
+  mkdir -p "$bundle/Contents/MacOS"
+  /usr/bin/plutil -create xml1 "$bundle/Contents/Info.plist"
+  /usr/libexec/PlistBuddy -c "Add :CFBundleIdentifier string $identifier" "$bundle/Contents/Info.plist"
+  /usr/libexec/PlistBuddy -c "Add :CFBundleExecutable string $executable" "$bundle/Contents/Info.plist"
+  /usr/libexec/PlistBuddy -c "Add :CFBundlePackageType string APPL" "$bundle/Contents/Info.plist"
+  print -r -- "#!/bin/zsh\nprint -r -- '$marker'" > "$bundle/Contents/MacOS/$executable"
+  chmod 0755 "$bundle/Contents/MacOS/$executable"
+  /usr/bin/codesign --force --sign - --timestamp=none "$bundle" >/dev/null
+}
+
+cd "$repo_root"
+export INTERVIEW_ARC_LIVE_INSTALLER_SOURCE_ONLY=1
+source "$installer"
+unset INTERVIEW_ARC_LIVE_INSTALLER_SOURCE_ONLY
+
+system_directory="$test_root/system-applications"
+user_directory="$test_root/current-user-home/Applications"
+mkdir -p "$system_directory" "$user_directory"
+
+selected="$(select_install_destination "$system_directory" "$user_directory")"
+assert_equal "$system_directory/Interview Arc Live.app" "$selected" \
+  "writable system Applications selection"
+
+selected="$(select_install_destination "$test_root/missing-system-applications" "$user_directory")"
+assert_equal "$user_directory/Interview Arc Live.app" "$selected" \
+  "current-user Applications fallback"
+
+explicit="$test_root/explicit/Interview Arc Live.app"
+mkdir -p "${explicit:h}"
+selected="$(select_install_destination "$system_directory" "$user_directory" "$explicit")"
+assert_equal "${explicit:A}" "$selected" "explicit test destination"
+
+if select_install_destination \
+  "$system_directory" \
+  "$user_directory" \
+  "$test_root/explicit/Another App.app" >/dev/null 2>&1; then
+  fail "unexpected explicit bundle name was accepted"
+fi
+
+rollback_directory="$test_root/rollback"
+rollback_destination="$rollback_directory/Interview Arc Live.app"
+rollback_backup="$rollback_directory/.Interview Arc Live.backup-test.app"
+mkdir -p "$rollback_destination" "$rollback_backup"
+print -r -- "new" > "$rollback_destination/new-marker"
+print -r -- "previous" > "$rollback_backup/previous-marker"
+restore_previous_install "$rollback_destination" "$rollback_backup"
+[[ -f "$rollback_destination/previous-marker" ]] || fail "rollback did not restore the previous app"
+[[ ! -e "$rollback_destination/new-marker" ]] || fail "rollback retained failed installed bytes"
+[[ ! -e "$rollback_backup" ]] || fail "rollback left the backup behind"
+
+source_bundle="$test_root/source/Interview Arc Live.app"
+install_directory="$test_root/install"
+installed_bundle="$install_directory/Interview Arc Live.app"
+mkdir -p "$install_directory"
+make_signed_bundle "$source_bundle" "app.interviewarc.live" "first-build"
+
+INTERVIEW_ARC_LIVE_ALLOW_ADHOC_INSTALL=1 \
+INTERVIEW_ARC_LIVE_SKIP_LAUNCH=1 \
+  "$installer" "$source_bundle" "$installed_bundle" >/dev/null
+
+source_cdhash="$(/usr/bin/codesign -dvvv "$source_bundle" 2>&1 | /usr/bin/awk -F= '/^CDHash=/{print $2; exit}')"
+installed_cdhash="$(/usr/bin/codesign -dvvv "$installed_bundle" 2>&1 | /usr/bin/awk -F= '/^CDHash=/{print $2; exit}')"
+assert_equal "$source_cdhash" "$installed_cdhash" "installed code-directory hash"
+[[ -x "$installed_bundle/Contents/MacOS/InterviewArcLive" ]] || fail "installed executable is missing"
+
+replacement_bundle="$test_root/replacement/Interview Arc Live.app"
+make_signed_bundle "$replacement_bundle" "app.interviewarc.live" "replacement-build"
+INTERVIEW_ARC_LIVE_ALLOW_ADHOC_INSTALL=1 \
+INTERVIEW_ARC_LIVE_SKIP_LAUNCH=1 \
+  "$installer" "$replacement_bundle" "$installed_bundle" >/dev/null
+replacement_cdhash="$(/usr/bin/codesign -dvvv "$replacement_bundle" 2>&1 | /usr/bin/awk -F= '/^CDHash=/{print $2; exit}')"
+installed_cdhash="$(/usr/bin/codesign -dvvv "$installed_bundle" 2>&1 | /usr/bin/awk -F= '/^CDHash=/{print $2; exit}')"
+assert_equal "$replacement_cdhash" "$installed_cdhash" "replacement code-directory hash"
+if find "$install_directory" -maxdepth 1 -name '.Interview Arc Live.backup-*.app' | grep -q .; then
+  fail "successful replacement left a rollback bundle behind"
+fi
+
+unrelated_directory="$test_root/unrelated"
+unrelated_destination="$unrelated_directory/Interview Arc Live.app"
+mkdir -p "$unrelated_destination/Contents"
+/usr/bin/plutil -create xml1 "$unrelated_destination/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c 'Add :CFBundleIdentifier string example.unrelated' \
+  "$unrelated_destination/Contents/Info.plist"
+if INTERVIEW_ARC_LIVE_ALLOW_ADHOC_INSTALL=1 \
+  INTERVIEW_ARC_LIVE_SKIP_LAUNCH=1 \
+  "$installer" "$source_bundle" "$unrelated_destination" >/dev/null 2>&1; then
+  fail "installer replaced an unrelated bundle"
+fi
+actual_identifier="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' \
+  "$unrelated_destination/Contents/Info.plist")"
+assert_equal "example.unrelated" "$actual_identifier" "unrelated bundle preservation"
+
+echo "Installer destination, exact-bundle, CDHash, replacement, and rollback tests passed."

--- a/Tests/ScriptTests/install-app-tests.zsh
+++ b/Tests/ScriptTests/install-app-tests.zsh
@@ -23,6 +23,15 @@ assert_equal() {
   [[ "$actual" == "$expected" ]] || fail "$label: expected '$expected', got '$actual'"
 }
 
+assert_no_transaction_residue() {
+  local directory="$1"
+  if find "$directory" -maxdepth 1 \
+    \( -name '.Interview Arc Live.backup-*.app' -o -name '.Interview Arc Live.install-*.app' \) \
+    | grep -q .; then
+    fail "installer transaction residue remained in $directory"
+  fi
+}
+
 make_signed_bundle() {
   local bundle="$1"
   local identifier="$2"
@@ -102,9 +111,43 @@ INTERVIEW_ARC_LIVE_SKIP_LAUNCH=1 \
 replacement_cdhash="$(/usr/bin/codesign -dvvv "$replacement_bundle" 2>&1 | /usr/bin/awk -F= '/^CDHash=/{print $2; exit}')"
 installed_cdhash="$(/usr/bin/codesign -dvvv "$installed_bundle" 2>&1 | /usr/bin/awk -F= '/^CDHash=/{print $2; exit}')"
 assert_equal "$replacement_cdhash" "$installed_cdhash" "replacement code-directory hash"
-if find "$install_directory" -maxdepth 1 -name '.Interview Arc Live.backup-*.app' | grep -q .; then
-  fail "successful replacement left a rollback bundle behind"
+assert_no_transaction_residue "$install_directory"
+
+failed_replacement="$test_root/failed-replacement/Interview Arc Live.app"
+make_signed_bundle "$failed_replacement" "app.interviewarc.live" "must-not-install"
+if INTERVIEW_ARC_LIVE_ALLOW_ADHOC_INSTALL=1 \
+  INTERVIEW_ARC_LIVE_SKIP_LAUNCH=1 \
+  INTERVIEW_ARC_LIVE_TEST_AFTER_BACKUP_ACTION=fail \
+  "$installer" "$failed_replacement" "$installed_bundle" >/dev/null 2>&1; then
+  fail "injected post-backup failure unexpectedly succeeded"
 fi
+installed_cdhash="$(/usr/bin/codesign -dvvv "$installed_bundle" 2>&1 | /usr/bin/awk -F= '/^CDHash=/{print $2; exit}')"
+assert_equal "$replacement_cdhash" "$installed_cdhash" "set-e rollback after backup"
+assert_no_transaction_residue "$install_directory"
+
+interrupted_replacement="$test_root/interrupted-replacement/Interview Arc Live.app"
+make_signed_bundle "$interrupted_replacement" "app.interviewarc.live" "must-not-survive-signal"
+if INTERVIEW_ARC_LIVE_ALLOW_ADHOC_INSTALL=1 \
+  INTERVIEW_ARC_LIVE_SKIP_LAUNCH=1 \
+  INTERVIEW_ARC_LIVE_TEST_AFTER_BACKUP_ACTION=terminate \
+  "$installer" "$interrupted_replacement" "$installed_bundle" >/dev/null 2>&1; then
+  fail "injected post-backup termination unexpectedly succeeded"
+fi
+installed_cdhash="$(/usr/bin/codesign -dvvv "$installed_bundle" 2>&1 | /usr/bin/awk -F= '/^CDHash=/{print $2; exit}')"
+assert_equal "$replacement_cdhash" "$installed_cdhash" "signal rollback after backup"
+assert_no_transaction_residue "$install_directory"
+
+first_install_directory="$test_root/unverified-first-install"
+first_install_destination="$first_install_directory/Interview Arc Live.app"
+mkdir -p "$first_install_directory"
+if INTERVIEW_ARC_LIVE_ALLOW_ADHOC_INSTALL=1 \
+  INTERVIEW_ARC_LIVE_SKIP_LAUNCH=1 \
+  INTERVIEW_ARC_LIVE_TEST_FAIL_AFTER_INSTALL_MOVE=1 \
+  "$installer" "$source_bundle" "$first_install_destination" >/dev/null 2>&1; then
+  fail "injected unverified first install unexpectedly succeeded"
+fi
+[[ ! -e "$first_install_destination" ]] || fail "unverified first install was not removed"
+assert_no_transaction_residue "$first_install_directory"
 
 unrelated_directory="$test_root/unrelated"
 unrelated_destination="$unrelated_directory/Interview Arc Live.app"
@@ -121,4 +164,4 @@ actual_identifier="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' \
   "$unrelated_destination/Contents/Info.plist")"
 assert_equal "example.unrelated" "$actual_identifier" "unrelated bundle preservation"
 
-echo "Installer destination, exact-bundle, CDHash, replacement, and rollback tests passed."
+echo "Installer destination, exact-bundle, CDHash, replacement, interruption, and rollback tests passed."

--- a/scripts/install-app.sh
+++ b/scripts/install-app.sh
@@ -3,16 +3,67 @@
 set -euo pipefail
 
 bundle_identifier="app.interviewarc.live"
-destination="/Applications/Interview Arc Live.app"
+app_name="Interview Arc Live.app"
+system_applications_directory="/Applications"
 allow_adhoc_install="${INTERVIEW_ARC_LIVE_ALLOW_ADHOC_INSTALL:-0}"
 
-if [[ $# -ne 1 ]]; then
-  echo "Usage: $0 '/path/to/Interview Arc Live.app'" >&2
+select_install_destination() {
+  local system_directory="$1"
+  local user_directory="$2"
+  local explicit_destination="${3:-}"
+
+  if [[ -n "$explicit_destination" ]]; then
+    local resolved_destination="${explicit_destination:A}"
+    if [[ "${resolved_destination:t}" != "$app_name" ]]; then
+      echo "An explicit destination must end with '$app_name'." >&2
+      return 65
+    fi
+    print -r -- "$resolved_destination"
+    return
+  fi
+
+  if [[ -d "$system_directory" && -w "$system_directory" ]]; then
+    print -r -- "$system_directory/$app_name"
+  else
+    print -r -- "$user_directory/$app_name"
+  fi
+}
+
+restore_previous_install() {
+  local failed_destination="$1"
+  local previous_backup="$2"
+
+  if [[ "${failed_destination:t}" != "$app_name" ]]; then
+    echo "Refusing rollback for an unexpected destination." >&2
+    return 65
+  fi
+  if [[ -e "$failed_destination" ]]; then
+    rm -rf "$failed_destination"
+  fi
+  if [[ -d "$previous_backup" ]]; then
+    mv "$previous_backup" "$failed_destination"
+  fi
+}
+
+# Focused shell tests source these two path/rollback functions without running
+# installation side effects. This switch cannot weaken a real installation.
+if [[ "${INTERVIEW_ARC_LIVE_INSTALLER_SOURCE_ONLY:-0}" == "1" ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "Usage: $0 '/path/to/Interview Arc Live.app' ['/install/path/Interview Arc Live.app']" >&2
   exit 64
 fi
 
 source_app="${1:A}"
 source_info="$source_app/Contents/Info.plist"
+current_user_applications_directory="${HOME:?Current user home directory is unavailable.}/Applications"
+destination="$(select_install_destination \
+  "$system_applications_directory" \
+  "$current_user_applications_directory" \
+  "${2:-}")"
+destination_directory="${destination:h}"
 
 if [[ ! -d "$source_app" || ! -f "$source_info" ]]; then
   echo "Expected a packaged Interview Arc Live application bundle." >&2
@@ -47,8 +98,22 @@ if [[ -z "$source_cdhash" ]]; then
   exit 65
 fi
 
-staging="/Applications/.Interview Arc Live.install-$$.app"
-backup="/Applications/.Interview Arc Live.backup-$$.app"
+# Validate the package before creating a missing per-user Applications
+# directory. An invalid source must not mutate the destination filesystem.
+if [[ ! -e "$destination_directory" ]]; then
+  if [[ "$destination_directory" != "$current_user_applications_directory" ]]; then
+    echo "The explicit installation directory does not exist: $destination_directory" >&2
+    exit 73
+  fi
+  mkdir -p "$destination_directory"
+fi
+if [[ ! -d "$destination_directory" || ! -w "$destination_directory" ]]; then
+  echo "The installation directory is not writable: $destination_directory" >&2
+  exit 73
+fi
+
+staging="$destination_directory/.Interview Arc Live.install-$$.app"
+backup="$destination_directory/.Interview Arc Live.backup-$$.app"
 
 cleanup() {
   if [[ -d "$staging" ]]; then
@@ -91,9 +156,7 @@ if [[ -e "$destination" ]]; then
 fi
 
 if ! mv "$staging" "$destination"; then
-  if [[ -d "$backup" ]]; then
-    mv "$backup" "$destination"
-  fi
+  restore_previous_install "$destination" "$backup"
   echo "Installation failed; the previous application was restored." >&2
   exit 1
 fi
@@ -107,10 +170,7 @@ else
 fi
 
 if [[ -z "$installed_cdhash" || "$installed_cdhash" != "$source_cdhash" ]]; then
-  rm -rf "$destination"
-  if [[ -d "$backup" ]]; then
-    mv "$backup" "$destination"
-  fi
+  restore_previous_install "$destination" "$backup"
   echo "Installed bytes did not match the packaged application; the previous application was restored." >&2
   exit 1
 fi
@@ -119,6 +179,10 @@ if [[ -d "$backup" ]]; then
   rm -rf "$backup"
 fi
 
-/usr/bin/open "$destination"
-echo "Installed and launched exact package: $destination"
+if [[ "${INTERVIEW_ARC_LIVE_SKIP_LAUNCH:-0}" != "1" ]]; then
+  /usr/bin/open "$destination"
+  echo "Installed and launched exact package: $destination"
+else
+  echo "Installed exact package: $destination"
+fi
 echo "Code-directory hash: $installed_cdhash"

--- a/scripts/install-app.sh
+++ b/scripts/install-app.sh
@@ -37,11 +37,29 @@ restore_previous_install() {
     echo "Refusing rollback for an unexpected destination." >&2
     return 65
   fi
+  if [[ "${previous_backup:h}" != "${failed_destination:h}"
+      || "${previous_backup:t}" != .Interview\ Arc\ Live.backup-*.app ]]; then
+    echo "Refusing rollback from an unexpected backup." >&2
+    return 65
+  fi
+  if [[ ! -d "$previous_backup" ]]; then
+    echo "The previous application backup is unavailable." >&2
+    return 66
+  fi
   if [[ -e "$failed_destination" ]]; then
     rm -rf "$failed_destination"
   fi
-  if [[ -d "$previous_backup" ]]; then
-    mv "$previous_backup" "$failed_destination"
+  mv "$previous_backup" "$failed_destination"
+}
+
+remove_unverified_install() {
+  local failed_destination="$1"
+  if [[ "${failed_destination:t}" != "$app_name" ]]; then
+    echo "Refusing cleanup for an unexpected destination." >&2
+    return 65
+  fi
+  if [[ -e "$failed_destination" ]]; then
+    rm -rf "$failed_destination"
   fi
 }
 
@@ -114,13 +132,40 @@ fi
 
 staging="$destination_directory/.Interview Arc Live.install-$$.app"
 backup="$destination_directory/.Interview Arc Live.backup-$$.app"
+install_transaction_active=0
+had_previous_install=0
+installation_verified=0
 
 cleanup() {
-  if [[ -d "$staging" ]]; then
-    rm -rf "$staging"
+  local prior_status="${1:-$?}"
+  trap - EXIT HUP INT TERM
+
+  # Restore user data before best-effort staging cleanup. Errexit must never
+  # skip rollback merely because removal of a temporary copy failed.
+  if (( install_transaction_active && ! installation_verified )); then
+    if (( had_previous_install )); then
+      if [[ -d "$backup" ]]; then
+        if ! restore_previous_install "$destination" "$backup"; then
+          echo "Installation interrupted and automatic rollback failed; backup remains at $backup." >&2
+        fi
+      elif [[ ! -e "$destination" ]]; then
+        echo "Installation interrupted after the previous application moved, but its backup is unavailable." >&2
+      fi
+    elif ! remove_unverified_install "$destination"; then
+      echo "Installation interrupted and unverified bytes could not be removed." >&2
+    fi
   fi
+
+  if [[ -d "$staging" ]] && ! rm -rf "$staging"; then
+    echo "Installation rollback completed, but staging cleanup failed at $staging." >&2
+  fi
+
+  return "$prior_status"
 }
-trap cleanup EXIT
+trap 'cleanup $?' EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 # Refuse to displace an unrelated bundle even if it occupies the expected
 # application path.
@@ -130,6 +175,13 @@ if [[ -e "$destination" ]]; then
     echo "Refusing to replace an unexpected application at $destination." >&2
     exit 65
   fi
+fi
+
+if [[ $# -ne 2
+    && ( -n "${INTERVIEW_ARC_LIVE_TEST_AFTER_BACKUP_ACTION:-}"
+      || "${INTERVIEW_ARC_LIVE_TEST_FAIL_AFTER_INSTALL_MOVE:-0}" != "0" ) ]]; then
+  echo "Installer failure injection requires an explicit test destination." >&2
+  exit 64
 fi
 
 # Stop only this executable if it is already running. Refuse a forced quit so
@@ -151,14 +203,35 @@ fi
 /usr/bin/ditto "$source_app" "$staging"
 /usr/bin/codesign --verify --deep --strict --verbose=2 "$staging"
 
+install_transaction_active=1
 if [[ -e "$destination" ]]; then
+  had_previous_install=1
   mv "$destination" "$backup"
 fi
 
+case "${INTERVIEW_ARC_LIVE_TEST_AFTER_BACKUP_ACTION:-}" in
+  "") ;;
+  fail) false ;;
+  terminate) kill -TERM $$ ;;
+  *)
+    echo "Unknown installer test action." >&2
+    exit 64
+    ;;
+esac
+
 if ! mv "$staging" "$destination"; then
-  restore_previous_install "$destination" "$backup"
+  if (( had_previous_install )); then
+    restore_previous_install "$destination" "$backup"
+  else
+    remove_unverified_install "$destination"
+  fi
+  install_transaction_active=0
   echo "Installation failed; the previous application was restored." >&2
   exit 1
+fi
+
+if [[ "${INTERVIEW_ARC_LIVE_TEST_FAIL_AFTER_INSTALL_MOVE:-0}" == "1" ]]; then
+  false
 fi
 
 installed_details=""
@@ -170,14 +243,21 @@ else
 fi
 
 if [[ -z "$installed_cdhash" || "$installed_cdhash" != "$source_cdhash" ]]; then
-  restore_previous_install "$destination" "$backup"
+  if (( had_previous_install )); then
+    restore_previous_install "$destination" "$backup"
+  else
+    remove_unverified_install "$destination"
+  fi
+  install_transaction_active=0
   echo "Installed bytes did not match the packaged application; the previous application was restored." >&2
   exit 1
 fi
 
+installation_verified=1
 if [[ -d "$backup" ]]; then
   rm -rf "$backup"
 fi
+install_transaction_active=0
 
 if [[ "${INTERVIEW_ARC_LIVE_SKIP_LAUNCH:-0}" != "1" ]]; then
   /usr/bin/open "$destination"


### PR DESCRIPTION
## **User description**
Refs #7
Refs #5

## Summary
- keep Keychain as the only persistent Groq credential store while exposing an explicit process-memory Use until quit path for ad-hoc development builds
- distinguish credential lifetime in the setup UI and enable recording only after one source is ready
- install into system Applications when writable or the current user Applications directory otherwise, preserving exact bundle/CDHash/rollback checks
- run focused installer safety tests in CI

## Verification
- credential Adapter and focused tests typechecked against macOS 15.4
- app UI typechecked against the exact updated Adapter surface
- all Swift sources parsed
- Impeccable detector returned no findings
- installer shell syntax passed
- signed temp-bundle destination, replacement, rollback, bundle-ID, and CDHash tests passed
- full SwiftPM suite delegated to hosted macOS CI because the local compiler/SDK pair is mismatched


___

## **CodeAnt-AI Description**
Keep development credentials available for the session while protecting saved credentials and app installs

### What Changed
- Users can save a Groq API key in macOS Keychain or use it only until quitting the app.
- Recording and transcription remain available with a temporary key, including when Keychain is unavailable; the key is discarded after relaunch.
- Credential setup now explains each option, shows the active action, and reports Keychain failures without exposing the key.
- Failed credential saves restore the previous Keychain value, or clearly warn when rollback cannot be confirmed.
- App installation now uses writable system Applications or falls back to the user Applications folder, verifies the installed package, and restores the previous app after failed or interrupted updates.
- Added automated checks for temporary credentials, safe credential rollback, installer destinations, bundle identity, code signatures, replacement, and interruption recovery.

### Impact
`✅ Unsaved Groq credentials for development sessions`
`✅ Recording available when Keychain is unavailable`
`✅ Previous app preserved after failed installation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
