### PR TITLE
Add durable Groq endpoint shadow mode

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -23,10 +23,14 @@ jobs:
         run: swift test
       - name: Build opt-in Codex smoke helper
         run: swift build --product InterviewArcLiveCodexSmoke
+      - name: Build opt-in endpoint smoke helper
+        run: swift build --product InterviewArcLiveEndpointSmoke
       - name: Test installer safety
         run: Tests/ScriptTests/install-app-tests.zsh
       - name: Test installed Codex smoke safety
         run: Tests/ScriptTests/codex-smoke-tests.zsh
+      - name: Test installed endpoint smoke safety
+        run: Tests/ScriptTests/endpoint-smoke-tests.zsh
       - name: Package merged application
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: scripts/package-app.sh release

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -79,6 +79,13 @@ A non-authoritative semantic result—`likely_continue`, `likely_end`, or
 It may start a cancellable grace period but does not itself mutate durable
 conversation state.
 
+### Endpoint Evaluation
+
+One durably authorized semantic-classifier request at a specific selected
+Segment-evidence boundary. It retains stable evidence identities and a context
+fingerprint, not duplicated transcript or prompt text. An interrupted
+Evaluation is recorded without automatically replaying the provider request.
+
 ### Session Manifest
 
 The canonical, monotonically revisioned recovery record for an Interview Room

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -81,10 +81,12 @@ conversation state.
 
 ### Endpoint Evaluation
 
-One durably authorized semantic-classifier request at a specific selected
-Segment-evidence boundary. It retains stable evidence identities and a context
-fingerprint, not duplicated transcript or prompt text. An interrupted
-Evaluation is recorded without automatically replaying the provider request.
+One durably authorized semantic-classifier request triggered by one concrete
+Segment. It records that triggering Segment plus the ordered IDs of every
+selected transcript candidate in the accumulated answer. It retains those
+stable evidence identities and a context fingerprint, not duplicated
+transcript or prompt text. An interrupted Evaluation is recorded without
+automatically replaying the provider request.
 
 ### Session Manifest
 

--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,10 @@ let package = Package(
             name: "InterviewArcLiveCodexSmoke",
             targets: ["InterviewArcLiveCodexSmoke"]
         ),
+        .executable(
+            name: "InterviewArcLiveEndpointSmoke",
+            targets: ["InterviewArcLiveEndpointSmoke"]
+        ),
     ],
     dependencies: [
         .package(
@@ -47,6 +51,13 @@ let package = Package(
             dependencies: [
                 "InterviewArcLiveCore",
                 "InterviewArcLiveCodexAdapter",
+            ]
+        ),
+        .executableTarget(
+            name: "InterviewArcLiveEndpointSmoke",
+            dependencies: [
+                "InterviewArcLiveCore",
+                "InterviewArcLiveVoiceAdapter",
             ]
         ),
         .testTarget(

--- a/Sources/InterviewArcLive/EndpointShadowPresentation.swift
+++ b/Sources/InterviewArcLive/EndpointShadowPresentation.swift
@@ -1,0 +1,182 @@
+import InterviewArcLiveCore
+
+/// Pure presentation policy for the observational endpointing slice. The app
+/// model supplies canonical evidence identities; this Module decides whether
+/// the latest durable Evaluation is current and maps only bounded state to UI
+/// copy.
+struct EndpointShadowPresentation: Equatable {
+    enum Tone: Equatable {
+        case neutral
+        case working
+        case advisory
+        case warning
+    }
+
+    let title: String
+    let detail: String
+    let systemImage: String
+    let tone: Tone
+
+    static func currentEvaluation(
+        in evaluations: [EndpointEvaluation],
+        selectedCandidateIDs: [TranscriptCandidateID],
+        questionTurnID: TurnID?,
+        hasUnresolvedDraft: Bool
+    ) -> EndpointEvaluation? {
+        guard !hasUnresolvedDraft,
+              let latestEvaluation = evaluations.last,
+              latestEvaluation.selectedCandidateIDs == selectedCandidateIDs,
+              latestEvaluation.questionTurnID == questionTurnID else {
+            return nil
+        }
+        return latestEvaluation
+    }
+
+    static func make(
+        turnMode: TurnMode,
+        phase: InterviewRoomPhase?,
+        currentEvaluation: EndpointEvaluation?,
+        hasSelectedDraft: Bool,
+        hasUnresolvedDraft: Bool,
+        hasStaleEvaluation: Bool
+    ) -> EndpointShadowPresentation {
+        guard turnMode == .patientAuto else {
+            return EndpointShadowPresentation(
+                title: "Manual turn-taking",
+                detail: "Semantic endpoint calls are off. Hand off remains explicit.",
+                systemImage: "hand.raised.fill",
+                tone: .neutral
+            )
+        }
+        guard phase == .candidateFloor else {
+            return EndpointShadowPresentation(
+                title: "Shadow waits for your floor",
+                detail: "It observes completed Segments only. Hand off remains explicit.",
+                systemImage: "eye",
+                tone: .neutral
+            )
+        }
+        if hasUnresolvedDraft {
+            return EndpointShadowPresentation(
+                title: "Shadow waiting for complete transcripts",
+                detail: "Resolve or exclude every draft Segment before another advisory check.",
+                systemImage: "ellipsis.bubble",
+                tone: .neutral
+            )
+        }
+        if hasStaleEvaluation {
+            return EndpointShadowPresentation(
+                title: "Evidence changed · Shadow waiting",
+                detail: "The prior result is no longer current. A new Segment can start another check.",
+                systemImage: "arrow.triangle.2.circlepath",
+                tone: .neutral
+            )
+        }
+        guard let currentEvaluation else {
+            return EndpointShadowPresentation(
+                title: hasSelectedDraft
+                    ? "Shadow waits for the next Segment"
+                    : "Shadow waiting for a transcript",
+                detail: hasSelectedDraft
+                    ? "Existing evidence is not sent retroactively. Hand off remains explicit."
+                    : "It checks only after a new selected transcript is saved.",
+                systemImage: "eye",
+                tone: .neutral
+            )
+        }
+
+        switch currentEvaluation.lifecycle {
+        case .authorized:
+            return EndpointShadowPresentation(
+                title: "Shadow checking this answer",
+                detail: "Authorization is saved. This check cannot Hand off your answer.",
+                systemImage: "hourglass",
+                tone: .working
+            )
+        case .proposalStored:
+            guard let proposal = currentEvaluation.proposal else {
+                return invalidStatus
+            }
+            switch proposal.decision {
+            case .likelyContinue:
+                return EndpointShadowPresentation(
+                    title: "Shadow: keep going",
+                    detail: "The answer may be unfinished. Advisory only; Hand off remains explicit.",
+                    systemImage: "arrow.forward.circle",
+                    tone: .advisory
+                )
+            case .likelyEnd:
+                return EndpointShadowPresentation(
+                    title: "Shadow: likely complete",
+                    detail: "This is advisory only. Nothing happens until you choose Hand off.",
+                    systemImage: "checkmark.circle",
+                    tone: .advisory
+                )
+            case .ambiguous:
+                return EndpointShadowPresentation(
+                    title: "Shadow: unclear",
+                    detail: "Keep answering or Hand off when you decide the answer is complete.",
+                    systemImage: "questionmark.circle",
+                    tone: .neutral
+                )
+            }
+        case .failed:
+            guard let failure = currentEvaluation.failure else {
+                return invalidStatus
+            }
+            switch failure.reason {
+            case .missingCredential:
+                return EndpointShadowPresentation(
+                    title: "Shadow needs a Groq key",
+                    detail: "The transcript is saved. Add a key before a later Segment check.",
+                    systemImage: "key.fill",
+                    tone: .warning
+                )
+            case .contextRejected:
+                return EndpointShadowPresentation(
+                    title: "Shadow skipped this answer",
+                    detail: "The complete draft exceeds its context limit. Hand off remains explicit.",
+                    systemImage: "doc.badge.ellipsis",
+                    tone: .warning
+                )
+            case .transportFailure:
+                return EndpointShadowPresentation(
+                    title: "Shadow unavailable",
+                    detail: "The transcript is saved. A later Segment can start a new check.",
+                    systemImage: "network.slash",
+                    tone: .warning
+                )
+            case .providerRejected:
+                return EndpointShadowPresentation(
+                    title: "Shadow request rejected",
+                    detail: "The transcript is saved. Check Groq access before the next Segment.",
+                    systemImage: "exclamationmark.shield.fill",
+                    tone: .warning
+                )
+            case .invalidResponse:
+                return EndpointShadowPresentation(
+                    title: "Shadow response unavailable",
+                    detail: "No advisory result was saved. Hand off remains explicit.",
+                    systemImage: "exclamationmark.bubble.fill",
+                    tone: .warning
+                )
+            case .interrupted:
+                return EndpointShadowPresentation(
+                    title: "Shadow check interrupted",
+                    detail: "It will not replay automatically. A later Segment can start a new check.",
+                    systemImage: "pause.circle.fill",
+                    tone: .warning
+                )
+            }
+        }
+    }
+
+    private static var invalidStatus: EndpointShadowPresentation {
+        EndpointShadowPresentation(
+            title: "Shadow status unavailable",
+            detail: "The transcript is saved. Hand off remains explicit.",
+            systemImage: "exclamationmark.circle.fill",
+            tone: .warning
+        )
+    }
+}

--- a/Sources/InterviewArcLive/EndpointShadowPresentation.swift
+++ b/Sources/InterviewArcLive/EndpointShadowPresentation.swift
@@ -85,7 +85,13 @@ struct EndpointShadowPresentation: Equatable {
             )
         }
 
-        switch currentEvaluation.lifecycle {
+        return lifecyclePresentation(for: currentEvaluation)
+    }
+
+    private static func lifecyclePresentation(
+        for evaluation: EndpointEvaluation
+    ) -> EndpointShadowPresentation {
+        switch evaluation.lifecycle {
         case .authorized:
             return EndpointShadowPresentation(
                 title: "Shadow checking this answer",
@@ -94,80 +100,92 @@ struct EndpointShadowPresentation: Equatable {
                 tone: .working
             )
         case .proposalStored:
-            guard let proposal = currentEvaluation.proposal else {
+            guard let proposal = evaluation.proposal else {
                 return invalidStatus
             }
-            switch proposal.decision {
-            case .likelyContinue:
-                return EndpointShadowPresentation(
-                    title: "Shadow: keep going",
-                    detail: "The answer may be unfinished. Advisory only; Hand off remains explicit.",
-                    systemImage: "arrow.forward.circle",
-                    tone: .advisory
-                )
-            case .likelyEnd:
-                return EndpointShadowPresentation(
-                    title: "Shadow: likely complete",
-                    detail: "This is advisory only. Nothing happens until you choose Hand off.",
-                    systemImage: "checkmark.circle",
-                    tone: .advisory
-                )
-            case .ambiguous:
-                return EndpointShadowPresentation(
-                    title: "Shadow: unclear",
-                    detail: "Keep answering or Hand off when you decide the answer is complete.",
-                    systemImage: "questionmark.circle",
-                    tone: .neutral
-                )
-            }
+            return proposalPresentation(for: proposal)
         case .failed:
-            guard let failure = currentEvaluation.failure else {
+            guard let failure = evaluation.failure else {
                 return invalidStatus
             }
-            switch failure.reason {
-            case .missingCredential:
-                return EndpointShadowPresentation(
-                    title: "Shadow needs a Groq key",
-                    detail: "The transcript is saved. Add a key before a later Segment check.",
-                    systemImage: "key.fill",
-                    tone: .warning
-                )
-            case .contextRejected:
-                return EndpointShadowPresentation(
-                    title: "Shadow skipped this answer",
-                    detail: "The complete draft exceeds its context limit. Hand off remains explicit.",
-                    systemImage: "doc.badge.ellipsis",
-                    tone: .warning
-                )
-            case .transportFailure:
-                return EndpointShadowPresentation(
-                    title: "Shadow unavailable",
-                    detail: "The transcript is saved. A later Segment can start a new check.",
-                    systemImage: "network.slash",
-                    tone: .warning
-                )
-            case .providerRejected:
-                return EndpointShadowPresentation(
-                    title: "Shadow request rejected",
-                    detail: "The transcript is saved. Check Groq access before the next Segment.",
-                    systemImage: "exclamationmark.shield.fill",
-                    tone: .warning
-                )
-            case .invalidResponse:
-                return EndpointShadowPresentation(
-                    title: "Shadow response unavailable",
-                    detail: "No advisory result was saved. Hand off remains explicit.",
-                    systemImage: "exclamationmark.bubble.fill",
-                    tone: .warning
-                )
-            case .interrupted:
-                return EndpointShadowPresentation(
-                    title: "Shadow check interrupted",
-                    detail: "It will not replay automatically. A later Segment can start a new check.",
-                    systemImage: "pause.circle.fill",
-                    tone: .warning
-                )
-            }
+            return failurePresentation(for: failure)
+        }
+    }
+
+    private static func proposalPresentation(
+        for proposal: SemanticEndpointProposal
+    ) -> EndpointShadowPresentation {
+        switch proposal.decision {
+        case .likelyContinue:
+            return EndpointShadowPresentation(
+                title: "Shadow: keep going",
+                detail: "The answer may be unfinished. Advisory only; Hand off remains explicit.",
+                systemImage: "arrow.forward.circle",
+                tone: .advisory
+            )
+        case .likelyEnd:
+            return EndpointShadowPresentation(
+                title: "Shadow: likely complete",
+                detail: "This is advisory only. Nothing happens until you choose Hand off.",
+                systemImage: "checkmark.circle",
+                tone: .advisory
+            )
+        case .ambiguous:
+            return EndpointShadowPresentation(
+                title: "Shadow: unclear",
+                detail: "Keep answering or Hand off when you decide the answer is complete.",
+                systemImage: "questionmark.circle",
+                tone: .neutral
+            )
+        }
+    }
+
+    private static func failurePresentation(
+        for failure: EndpointEvaluationFailure
+    ) -> EndpointShadowPresentation {
+        switch failure.reason {
+        case .missingCredential:
+            return EndpointShadowPresentation(
+                title: "Shadow needs a Groq key",
+                detail: "The transcript is saved. Add a key before a later Segment check.",
+                systemImage: "key.fill",
+                tone: .warning
+            )
+        case .contextRejected:
+            return EndpointShadowPresentation(
+                title: "Shadow skipped this answer",
+                detail: "The complete draft exceeds its context limit. Hand off remains explicit.",
+                systemImage: "doc.badge.ellipsis",
+                tone: .warning
+            )
+        case .transportFailure:
+            return EndpointShadowPresentation(
+                title: "Shadow unavailable",
+                detail: "The transcript is saved. A later Segment can start a new check.",
+                systemImage: "network.slash",
+                tone: .warning
+            )
+        case .providerRejected:
+            return EndpointShadowPresentation(
+                title: "Shadow request rejected",
+                detail: "The transcript is saved. Check Groq access before the next Segment.",
+                systemImage: "exclamationmark.shield.fill",
+                tone: .warning
+            )
+        case .invalidResponse:
+            return EndpointShadowPresentation(
+                title: "Shadow response unavailable",
+                detail: "No advisory result was saved. Hand off remains explicit.",
+                systemImage: "exclamationmark.bubble.fill",
+                tone: .warning
+            )
+        case .interrupted:
+            return EndpointShadowPresentation(
+                title: "Shadow check interrupted",
+                detail: "It will not replay automatically. A later Segment can start a new check.",
+                systemImage: "pause.circle.fill",
+                tone: .warning
+            )
         }
     }
 

--- a/Sources/InterviewArcLive/SystemDesignRoomModel.swift
+++ b/Sources/InterviewArcLive/SystemDesignRoomModel.swift
@@ -196,7 +196,6 @@ final class SystemDesignRoomModel: ObservableObject {
             hasUnresolvedDraft: hasUnresolvedDraft,
             hasStaleEvaluation: latestEvaluation != nil
                 && currentEvaluation == nil
-                && !selectedCandidateIDs.isEmpty
         )
     }
 

--- a/Sources/InterviewArcLive/SystemDesignRoomModel.swift
+++ b/Sources/InterviewArcLive/SystemDesignRoomModel.swift
@@ -128,6 +128,78 @@ final class SystemDesignRoomModel: ObservableObject {
         credentialState == .missing || credentialState == .unusable
     }
 
+    var availableTurnModes: [TurnMode] {
+        [.manual, .patientAuto]
+    }
+
+    var turnMode: TurnMode {
+        snapshot?.turnMode ?? .manual
+    }
+
+    var canSelectTurnMode: Bool {
+        guard !isWorking, let snapshot else { return false }
+        return snapshot.phase != .completed
+    }
+
+    func turnModeTitle(_ mode: TurnMode) -> String {
+        switch mode {
+        case .manual:
+            return "Manual"
+        case .patientAuto:
+            return "Patient Auto · Shadow"
+        case .cueOnly:
+            return "Cue Only"
+        }
+    }
+
+    var endpointShadowPresentation: EndpointShadowPresentation {
+        guard let snapshot else {
+            return EndpointShadowPresentation.make(
+                turnMode: .manual,
+                phase: nil,
+                currentEvaluation: nil,
+                hasSelectedDraft: false,
+                hasUnresolvedDraft: false,
+                hasStaleEvaluation: false
+            )
+        }
+
+        let draftSegments = snapshot.segments.filter { $0.committedTurnID == nil }
+        let includedDrafts = draftSegments
+            .filter { $0.lifecycle != .excluded }
+            .sorted { $0.ordinal < $1.ordinal }
+        let hasUnresolvedDraft = includedDrafts.contains {
+            $0.lifecycle == .captureAuthorized
+                || $0.lifecycle == .recording
+                || $0.lifecycle == .finalizationAuthorized
+                || $0.lifecycle == .transcribing
+                || $0.selectedCandidateID == nil
+        }
+        let selectedCandidateIDs = includedDrafts.compactMap(\.selectedCandidateID)
+        let questionTurnID: TurnID? = snapshot.turns.reversed().lazy.compactMap { turn in
+            guard case .interviewer(let interviewer) = turn else { return nil }
+            return interviewer.id
+        }.first
+        let latestEvaluation = snapshot.endpointEvaluations.last
+        let currentEvaluation = EndpointShadowPresentation.currentEvaluation(
+            in: snapshot.endpointEvaluations,
+            selectedCandidateIDs: selectedCandidateIDs,
+            questionTurnID: questionTurnID,
+            hasUnresolvedDraft: hasUnresolvedDraft
+        )
+
+        return EndpointShadowPresentation.make(
+            turnMode: snapshot.turnMode,
+            phase: snapshot.phase,
+            currentEvaluation: currentEvaluation,
+            hasSelectedDraft: !selectedCandidateIDs.isEmpty,
+            hasUnresolvedDraft: hasUnresolvedDraft,
+            hasStaleEvaluation: latestEvaluation != nil
+                && currentEvaluation == nil
+                && !selectedCandidateIDs.isEmpty
+        )
+    }
+
     private var hasUsableGroqCredential: Bool {
         credentialState == .readyFromKeychain
             || credentialState == .readyUntilQuit
@@ -228,7 +300,10 @@ final class SystemDesignRoomModel: ObservableObject {
                 interviewerRuntime: codexRuntime,
                 recording: VoiceCoreSegmentRecorder(),
                 transcriber: VoiceCoreSegmentTranscriber(),
-                credentialReader: credentialStore
+                credentialReader: credentialStore,
+                semanticEndpointClassifier: GroqEndpointClassifier(
+                    credentialReader: credentialStore
+                )
             )
             coordinator = opened
             opened.setSnapshotHandler { [weak self, weak opened] nextSnapshot in
@@ -268,6 +343,31 @@ final class SystemDesignRoomModel: ObservableObject {
         defer { isCheckingCodex = false }
 
         applyCodexReadiness(await codexRuntime.preflight())
+    }
+
+    func selectTurnMode(_ mode: TurnMode) async {
+        guard mode == .manual || mode == .patientAuto,
+              mode != turnMode,
+              canSelectTurnMode,
+              let coordinator else {
+            return
+        }
+
+        isWorking = true
+        errorMessage = nil
+        statusMessage = "Saving turn-taking mode…"
+        defer { isWorking = false }
+
+        do {
+            let updated = try await coordinator.setTurnMode(
+                mode,
+                commandID: commandID("set-turn-mode")
+            )
+            publish(updated)
+        } catch {
+            publish(coordinator.snapshot)
+            errorMessage = safeMessage(for: error)
+        }
     }
 
     func recordSegment() async {

--- a/Sources/InterviewArcLive/SystemDesignRoomView.swift
+++ b/Sources/InterviewArcLive/SystemDesignRoomView.swift
@@ -122,6 +122,7 @@ struct SystemDesignRoomView: View {
 
     private var turnModeBar: some View {
         let presentation = model.endpointShadowPresentation
+        let statusColor = endpointShadowStatusColor(for: presentation.tone)
 
         return HStack(spacing: 14) {
             Text("Turn-taking")
@@ -146,12 +147,12 @@ struct SystemDesignRoomView: View {
                 .frame(width: 1, height: 28)
 
             Image(systemName: presentation.systemImage)
-                .foregroundStyle(endpointShadowStatusColor)
+                .foregroundStyle(statusColor)
                 .accessibilityHidden(true)
             VStack(alignment: .leading, spacing: 2) {
                 Text(presentation.title)
                     .font(.system(.callout, design: .rounded, weight: .semibold))
-                    .foregroundStyle(endpointShadowStatusColor)
+                    .foregroundStyle(statusColor)
                 Text(presentation.detail)
                     .font(.system(.caption, design: .rounded))
                     .foregroundStyle(LivePalette.muted)
@@ -182,8 +183,10 @@ struct SystemDesignRoomView: View {
         )
     }
 
-    private var endpointShadowStatusColor: Color {
-        switch model.endpointShadowPresentation.tone {
+    private func endpointShadowStatusColor(
+        for tone: EndpointShadowPresentation.Tone
+    ) -> Color {
+        switch tone {
         case .neutral:
             return LivePalette.muted
         case .working:

--- a/Sources/InterviewArcLive/SystemDesignRoomView.swift
+++ b/Sources/InterviewArcLive/SystemDesignRoomView.swift
@@ -14,6 +14,7 @@ struct SystemDesignRoomView: View {
             if let codexMessage = model.codexAttentionMessage {
                 codexReadinessBanner(codexMessage)
             }
+            turnModeBar
 
             HSplitView {
                 transcript
@@ -116,6 +117,81 @@ struct SystemDesignRoomView: View {
         .background(LivePalette.paper)
         .overlay(alignment: .bottom) {
             Rectangle().fill(LivePalette.line).frame(height: 1)
+        }
+    }
+
+    private var turnModeBar: some View {
+        let presentation = model.endpointShadowPresentation
+
+        return HStack(spacing: 14) {
+            Text("Turn-taking")
+                .font(.system(.subheadline, design: .rounded, weight: .semibold))
+
+            Picker("Turn-taking mode", selection: turnModeRawSelection) {
+                ForEach(model.availableTurnModes, id: \.rawValue) { mode in
+                    Text(model.turnModeTitle(mode)).tag(mode.rawValue)
+                }
+            }
+            .labelsHidden()
+            .pickerStyle(.segmented)
+            .frame(width: 310)
+            .disabled(!model.canSelectTurnMode)
+            .accessibilityLabel("Turn-taking mode")
+            .accessibilityHint(
+                "Patient Auto observes completed Segment transcripts, but Hand off remains manual"
+            )
+
+            Rectangle()
+                .fill(LivePalette.line)
+                .frame(width: 1, height: 28)
+
+            Image(systemName: presentation.systemImage)
+                .foregroundStyle(endpointShadowStatusColor)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(presentation.title)
+                    .font(.system(.callout, design: .rounded, weight: .semibold))
+                    .foregroundStyle(endpointShadowStatusColor)
+                Text(presentation.detail)
+                    .font(.system(.caption, design: .rounded))
+                    .foregroundStyle(LivePalette.muted)
+                    .lineLimit(2)
+            }
+            Spacer(minLength: 8)
+        }
+        .padding(.horizontal, 24)
+        .padding(.vertical, 9)
+        .background(LivePalette.paper)
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(LivePalette.line).frame(height: 1)
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    private var turnModeRawSelection: Binding<String> {
+        Binding(
+            get: { model.turnMode.rawValue },
+            set: { rawValue in
+                guard let mode = model.availableTurnModes.first(where: {
+                    $0.rawValue == rawValue
+                }) else {
+                    return
+                }
+                Task { await model.selectTurnMode(mode) }
+            }
+        )
+    }
+
+    private var endpointShadowStatusColor: Color {
+        switch model.endpointShadowPresentation.tone {
+        case .neutral:
+            return LivePalette.muted
+        case .working:
+            return LivePalette.interviewer
+        case .advisory:
+            return LivePalette.candidate
+        case .warning:
+            return LivePalette.warning
         }
     }
 

--- a/Sources/InterviewArcLiveCore/GroqEndpointClassifier.swift
+++ b/Sources/InterviewArcLiveCore/GroqEndpointClassifier.swift
@@ -71,26 +71,32 @@ public struct GroqEndpointClassifier: SemanticEndpointClassifying {
   private static let maximumSilenceMilliseconds = 10 * 60 * 1_000
   private static let maximumResponseBytes = 64 * 1_024
 
-  private let apiKey: String
+  private let credentialReader: any GroqCredentialReading
   private let transport: any GroqEndpointTransport
 
   public init(
-    apiKey: String,
+    credentialReader: any GroqCredentialReading,
     transport: any GroqEndpointTransport = URLSessionGroqEndpointTransport()
   ) {
-    self.apiKey = apiKey
+    self.credentialReader = credentialReader
     self.transport = transport
   }
 
   public func classify(_ context: SemanticEndpointContext) async throws -> SemanticEndpointProposal
   {
+    let apiKey: String
+    do {
+      apiKey = try await credentialReader.readGroqCredential()
+    } catch {
+      throw GroqEndpointClassifierError.missingCredential
+    }
     guard !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
       throw GroqEndpointClassifierError.missingCredential
     }
 
     let request: URLRequest
     do {
-      request = try makeRequest(context)
+      request = try makeRequest(context, apiKey: apiKey)
     } catch let error as GroqEndpointClassifierError {
       throw error
     } catch {
@@ -117,7 +123,10 @@ public struct GroqEndpointClassifier: SemanticEndpointClassifying {
     return try decodeProposal(from: data)
   }
 
-  private func makeRequest(_ context: SemanticEndpointContext) throws -> URLRequest {
+  private func makeRequest(
+    _ context: SemanticEndpointContext,
+    apiKey: String
+  ) throws -> URLRequest {
     try validate(context)
 
     let endpointContext = EndpointContextPayload(

--- a/Sources/InterviewArcLiveCore/InterviewRoomSession.swift
+++ b/Sources/InterviewArcLiveCore/InterviewRoomSession.swift
@@ -508,8 +508,27 @@ public actor InterviewRoomSession {
                 )
             }
             try Self.validateEndpointEvaluationOutcome(outcome)
+            let recordedOutcome: EndpointEvaluationOutcome
+            if case .proposal = outcome,
+               !Self.isCurrentEndpointEvaluation(
+                   endpointEvaluations[index],
+                   phase: phase,
+                   mode: mode,
+                   turns: manifest.turns,
+                   segments: segments
+               ) {
+                // The classifier completed, but its authorization no longer
+                // describes the current Candidate Floor. Consume this result
+                // atomically as interrupted so it can never surface as a
+                // proposal for stale evidence or strand the authorization.
+                recordedOutcome = .failed(
+                    EndpointEvaluationFailure(reason: .interrupted)
+                )
+            } else {
+                recordedOutcome = outcome
+            }
             endpointEvaluations[index] = Self.recordingEndpointOutcome(
-                outcome,
+                recordedOutcome,
                 for: endpointEvaluations[index]
             )
 
@@ -960,6 +979,35 @@ public actor InterviewRoomSession {
             }
         }
         return nil
+    }
+
+    /// Revalidates the durable authorization against the exact current draft
+    /// immediately before a classifier proposal becomes canonical Shadow
+    /// state. This check stays in the Session Module so phase, evidence, and
+    /// question identity are observed atomically with outcome persistence.
+    private static func isCurrentEndpointEvaluation(
+        _ evaluation: EndpointEvaluation,
+        phase: InterviewRoomPhase,
+        mode: TurnMode,
+        turns: [InterviewTurn],
+        segments: [CandidateSegment]
+    ) -> Bool {
+        guard phase == .candidateFloor,
+              mode == .patientAuto,
+              (try? validateEndpointContextFingerprint(evaluation.contextFingerprint)) != nil,
+              latestInterviewerTurnID(in: turns) == evaluation.questionTurnID,
+              let currentCandidateIDs = try? currentEndpointCandidateIDs(in: segments),
+              currentCandidateIDs == evaluation.selectedCandidateIDs,
+              let triggerSegment = segments.first(where: {
+                  $0.id == evaluation.triggerSegmentID
+              }),
+              triggerSegment.committedTurnID == nil,
+              triggerSegment.lifecycle != .excluded,
+              let triggerCandidateID = triggerSegment.selectedCandidateID,
+              evaluation.selectedCandidateIDs.contains(triggerCandidateID) else {
+            return false
+        }
+        return true
     }
 
     private static func recordingEndpointOutcome(
@@ -1435,9 +1483,19 @@ public actor InterviewRoomSession {
         let evaluationFingerprints = manifest.endpointEvaluations.map(
             \.contextFingerprint
         )
-        let allCandidateIDs = Set(
-            manifest.segments.flatMap { $0.transcriptCandidates.map(\.id) }
-        )
+        var candidateOrdinalByID: [TranscriptCandidateID: Int] = [:]
+        var hasDuplicateCandidateIdentity = false
+        for segment in manifest.segments {
+            for candidate in segment.transcriptCandidates {
+                if candidateOrdinalByID.updateValue(
+                    segment.ordinal,
+                    forKey: candidate.id
+                ) != nil {
+                    hasDuplicateCandidateIdentity = true
+                }
+            }
+        }
+        let allCandidateIDs = Set(candidateOrdinalByID.keys)
         let interviewerTurnIDs: Set<TurnID> = Set(manifest.turns.compactMap { turn in
             guard case .interviewer(let interviewer) = turn else { return nil }
             return interviewer.id
@@ -1445,6 +1503,7 @@ public actor InterviewRoomSession {
         guard Set(evaluationIDs).count == evaluationIDs.count,
               Set(evaluationAuthorizationIDs).count == evaluationAuthorizationIDs.count,
               Set(evaluationFingerprints).count == evaluationFingerprints.count,
+              !hasDuplicateCandidateIdentity,
               manifest.endpointEvaluations.filter({ $0.lifecycle == .authorized }).count <= 1
         else {
             throw InterviewRoomSessionError.invalidManifest(
@@ -1483,14 +1542,12 @@ public actor InterviewRoomSession {
 
             let evidenceOrdinals = try evaluation.selectedCandidateIDs.map {
                 candidateID -> Int in
-                guard let segment = manifest.segments.first(where: { segment in
-                    segment.transcriptCandidates.contains(where: { $0.id == candidateID })
-                }) else {
+                guard let ordinal = candidateOrdinalByID[candidateID] else {
                     throw InterviewRoomSessionError.invalidManifest(
                         reason: "endpoint evaluation candidate is missing"
                     )
                 }
-                return segment.ordinal
+                return ordinal
             }
             guard evidenceOrdinals == evidenceOrdinals.sorted(),
                   Set(evidenceOrdinals).count == evidenceOrdinals.count else {

--- a/Sources/InterviewArcLiveCore/InterviewRoomSession.swift
+++ b/Sources/InterviewArcLiveCore/InterviewRoomSession.swift
@@ -23,6 +23,22 @@ public enum InterviewRoomCommand: Codable, Sendable, Equatable {
         attemptID: TranscriptionAttemptID,
         outcome: SegmentTranscriptionOutcome
     )
+    case authorizeEndpointEvaluation(
+        commandID: CommandID,
+        triggerSegmentID: SegmentID,
+        selectedCandidateIDs: [TranscriptCandidateID],
+        questionTurnID: TurnID?,
+        contextFingerprint: String
+    )
+    case recordEndpointEvaluationOutcome(
+        commandID: CommandID,
+        evaluationID: EndpointEvaluationID,
+        outcome: EndpointEvaluationOutcome
+    )
+    case reconcileInterruptedEndpointEvaluation(
+        commandID: CommandID,
+        evaluationID: EndpointEvaluationID
+    )
     case excludeSegment(
         commandID: CommandID,
         segmentID: SegmentID,
@@ -42,6 +58,9 @@ public enum InterviewRoomCommand: Codable, Sendable, Equatable {
              .recordSegmentCaptureOutcome(let commandID, _, _),
              .authorizeSegmentTranscription(let commandID, _, _, _),
              .recordSegmentTranscriptionOutcome(let commandID, _, _, _),
+             .authorizeEndpointEvaluation(let commandID, _, _, _, _),
+             .recordEndpointEvaluationOutcome(let commandID, _, _),
+             .reconcileInterruptedEndpointEvaluation(let commandID, _),
              .excludeSegment(let commandID, _, _),
              .handOffSegments(let commandID),
              .handOff(let commandID, _),
@@ -50,6 +69,13 @@ public enum InterviewRoomCommand: Codable, Sendable, Equatable {
             commandID
         }
     }
+}
+
+private struct EndpointContextFingerprintEnvelope: Encodable {
+    let context: SemanticEndpointContext
+    let triggerSegmentID: SegmentID
+    let selectedCandidateIDs: [TranscriptCandidateID]
+    let questionTurnID: TurnID?
 }
 
 public enum InterviewRoomCommandDisposition: Sendable, Equatable {
@@ -82,6 +108,7 @@ public enum InterviewRoomSessionError: Error, Sendable, Equatable {
     case commandIDReused(CommandID)
     case commandInProgress
     case commandEncodingFailed
+    case endpointContextEncodingFailed
     case segmentAlreadyActive(SegmentID)
     case segmentNotFound(SegmentID)
     case invalidSegmentTransition(segmentID: SegmentID, lifecycle: CandidateSegmentLifecycle)
@@ -93,6 +120,16 @@ public enum InterviewRoomSessionError: Error, Sendable, Equatable {
     case rejectedCredentialUnchanged
     case segmentHasInsufficientSignal(SegmentID)
     case invalidTranscriptionOutcome
+    case endpointEvaluationNotFound(EndpointEvaluationID)
+    case endpointEvaluationAlreadyInProgress(EndpointEvaluationID)
+    case endpointEvidenceMismatch
+    case invalidEndpointContextFingerprint
+    case endpointContextFingerprintReused
+    case invalidEndpointEvaluationOutcome
+    case invalidEndpointEvaluationTransition(
+        evaluationID: EndpointEvaluationID,
+        lifecycle: EndpointEvaluationLifecycle
+    )
     case noTranscribedSegments
     case unresolvedSegmentsPreventHandOff([SegmentID])
     case uncommittedSegmentsRequireSegmentHandOff
@@ -211,6 +248,37 @@ public actor InterviewRoomSession {
             )
         }
 
+        if case .authorizeEndpointEvaluation(
+            _,
+            let triggerSegmentID,
+            let selectedCandidateIDs,
+            let questionTurnID,
+            let contextFingerprint
+        ) = command,
+           let existing = manifest.endpointEvaluations.first(where: {
+               $0.contextFingerprint == contextFingerprint
+           }) {
+            guard existing.triggerSegmentID == triggerSegmentID,
+                  existing.selectedCandidateIDs == selectedCandidateIDs,
+                  existing.questionTurnID == questionTurnID else {
+                throw InterviewRoomSessionError.endpointContextFingerprintReused
+            }
+            let deduplicated = appendingReceipt(
+                command: command,
+                fingerprint: fingerprint,
+                phase: manifest.phase,
+                turnMode: manifest.turnMode,
+                turns: manifest.turns,
+                segments: manifest.segments,
+                endpointEvaluations: manifest.endpointEvaluations
+            )
+            try await persist(deduplicated)
+            return InterviewRoomCommandApplication(
+                snapshot: InterviewRoomSnapshot(manifest: deduplicated),
+                disposition: .alreadyApplied
+            )
+        }
+
         let snapshot: InterviewRoomSnapshot
         switch command {
         case .handOff(let commandID, let transcript):
@@ -252,6 +320,7 @@ public actor InterviewRoomSession {
         var phase = manifest.phase
         var mode = manifest.turnMode
         var segments = manifest.segments
+        var endpointEvaluations = manifest.endpointEvaluations
 
         switch command {
         case .giveCandidateFloor:
@@ -378,6 +447,88 @@ public actor InterviewRoomSession {
                 to: &segments[index]
             )
 
+        case .authorizeEndpointEvaluation(
+            let commandID,
+            let triggerSegmentID,
+            let selectedCandidateIDs,
+            let questionTurnID,
+            let contextFingerprint
+        ):
+            guard phase == .candidateFloor, mode == .patientAuto else {
+                throw invalidTransition("authorizeEndpointEvaluation")
+            }
+            try Self.validateEndpointContextFingerprint(contextFingerprint)
+            if let activeEvaluation = endpointEvaluations.first(where: {
+                $0.lifecycle == .authorized
+            }) {
+                throw InterviewRoomSessionError.endpointEvaluationAlreadyInProgress(
+                    activeEvaluation.id
+                )
+            }
+            let expectedCandidateIDs = try Self.currentEndpointCandidateIDs(
+                in: segments
+            )
+            guard selectedCandidateIDs == expectedCandidateIDs,
+                  Set(selectedCandidateIDs).count == selectedCandidateIDs.count,
+                  let triggerSegment = segments.first(where: {
+                      $0.id == triggerSegmentID
+                  }),
+                  triggerSegment.committedTurnID == nil,
+                  triggerSegment.lifecycle != .excluded,
+                  let triggerCandidateID = triggerSegment.selectedCandidateID,
+                  selectedCandidateIDs.contains(triggerCandidateID),
+                  questionTurnID == Self.latestInterviewerTurnID(in: manifest.turns) else {
+                throw InterviewRoomSessionError.endpointEvidenceMismatch
+            }
+
+            endpointEvaluations.append(
+                EndpointEvaluation(
+                    id: Self.endpointEvaluationID(
+                        sessionID: manifest.sessionID,
+                        commandID: commandID
+                    ),
+                    authorizationCommandID: commandID,
+                    triggerSegmentID: triggerSegmentID,
+                    selectedCandidateIDs: selectedCandidateIDs,
+                    questionTurnID: questionTurnID,
+                    contextFingerprint: contextFingerprint,
+                    lifecycle: .authorized
+                )
+            )
+
+        case .recordEndpointEvaluationOutcome(_, let evaluationID, let outcome):
+            let index = try endpointEvaluationIndex(
+                evaluationID,
+                in: endpointEvaluations
+            )
+            guard endpointEvaluations[index].lifecycle == .authorized else {
+                throw InterviewRoomSessionError.invalidEndpointEvaluationTransition(
+                    evaluationID: evaluationID,
+                    lifecycle: endpointEvaluations[index].lifecycle
+                )
+            }
+            try Self.validateEndpointEvaluationOutcome(outcome)
+            endpointEvaluations[index] = Self.recordingEndpointOutcome(
+                outcome,
+                for: endpointEvaluations[index]
+            )
+
+        case .reconcileInterruptedEndpointEvaluation(_, let evaluationID):
+            let index = try endpointEvaluationIndex(
+                evaluationID,
+                in: endpointEvaluations
+            )
+            guard endpointEvaluations[index].lifecycle == .authorized else {
+                throw InterviewRoomSessionError.invalidEndpointEvaluationTransition(
+                    evaluationID: evaluationID,
+                    lifecycle: endpointEvaluations[index].lifecycle
+                )
+            }
+            endpointEvaluations[index] = Self.recordingEndpointOutcome(
+                .failed(EndpointEvaluationFailure(reason: .interrupted)),
+                for: endpointEvaluations[index]
+            )
+
         case .excludeSegment(_, let segmentID, let reason):
             let index = try segmentIndex(segmentID, in: segments)
             guard segments[index].committedTurnID == nil,
@@ -407,7 +558,8 @@ public actor InterviewRoomSession {
             phase: phase,
             turnMode: mode,
             turns: manifest.turns,
-            segments: segments
+            segments: segments,
+            endpointEvaluations: endpointEvaluations
         )
     }
 
@@ -639,6 +791,7 @@ public actor InterviewRoomSession {
             turnMode: manifest.turnMode,
             turns: manifest.turns + [.candidate(candidate)],
             segments: segments,
+            endpointEvaluations: manifest.endpointEvaluations,
             revision: candidateRevision,
             appliedCommands: manifest.appliedCommands + [receipt]
         )
@@ -668,6 +821,7 @@ public actor InterviewRoomSession {
             turnMode: manifest.turnMode,
             turns: manifest.turns,
             segments: manifest.segments,
+            endpointEvaluations: manifest.endpointEvaluations,
             revision: manifest.revision + 1,
             appliedCommands: manifest.appliedCommands + [receipt]
         )
@@ -718,6 +872,7 @@ public actor InterviewRoomSession {
             turnMode: manifest.turnMode,
             turns: manifest.turns + [.interviewer(interviewer)],
             segments: manifest.segments,
+            endpointEvaluations: manifest.endpointEvaluations,
             revision: manifest.revision + 1,
             appliedCommands: manifest.appliedCommands
         )
@@ -731,7 +886,8 @@ public actor InterviewRoomSession {
         phase: InterviewRoomPhase,
         turnMode: TurnMode,
         turns: [InterviewTurn],
-        segments: [CandidateSegment]
+        segments: [CandidateSegment],
+        endpointEvaluations: [EndpointEvaluation]
     ) -> SessionManifest {
         let nextRevision = manifest.revision + 1
         let applied = AppliedCommandRecord(
@@ -747,6 +903,7 @@ public actor InterviewRoomSession {
             turnMode: turnMode,
             turns: turns,
             segments: segments,
+            endpointEvaluations: endpointEvaluations,
             revision: nextRevision,
             appliedCommands: manifest.appliedCommands + [applied]
         )
@@ -765,6 +922,102 @@ public actor InterviewRoomSession {
             throw InterviewRoomSessionError.segmentNotFound(segmentID)
         }
         return index
+    }
+
+    private func endpointEvaluationIndex(
+        _ evaluationID: EndpointEvaluationID,
+        in evaluations: [EndpointEvaluation]
+    ) throws -> Int {
+        guard let index = evaluations.firstIndex(where: { $0.id == evaluationID }) else {
+            throw InterviewRoomSessionError.endpointEvaluationNotFound(evaluationID)
+        }
+        return index
+    }
+
+    private static func currentEndpointCandidateIDs(
+        in segments: [CandidateSegment]
+    ) throws -> [TranscriptCandidateID] {
+        let draftSegments = segments
+            .filter { $0.committedTurnID == nil && $0.lifecycle != .excluded }
+            .sorted { $0.ordinal < $1.ordinal }
+        guard !draftSegments.isEmpty,
+              draftSegments.allSatisfy({
+                  !isActiveSegment($0)
+                      && $0.lifecycle != .transcribing
+                      && $0.selectedCandidateID != nil
+              }) else {
+            throw InterviewRoomSessionError.endpointEvidenceMismatch
+        }
+        return draftSegments.compactMap(\.selectedCandidateID)
+    }
+
+    private static func latestInterviewerTurnID(
+        in turns: [InterviewTurn]
+    ) -> TurnID? {
+        for turn in turns.reversed() {
+            if case .interviewer(let interviewer) = turn {
+                return interviewer.id
+            }
+        }
+        return nil
+    }
+
+    private static func recordingEndpointOutcome(
+        _ outcome: EndpointEvaluationOutcome,
+        for evaluation: EndpointEvaluation
+    ) -> EndpointEvaluation {
+        switch outcome {
+        case .proposal(let proposal):
+            return EndpointEvaluation(
+                id: evaluation.id,
+                authorizationCommandID: evaluation.authorizationCommandID,
+                triggerSegmentID: evaluation.triggerSegmentID,
+                selectedCandidateIDs: evaluation.selectedCandidateIDs,
+                questionTurnID: evaluation.questionTurnID,
+                contextFingerprint: evaluation.contextFingerprint,
+                lifecycle: .proposalStored,
+                proposal: proposal
+            )
+        case .failed(let failure):
+            return EndpointEvaluation(
+                id: evaluation.id,
+                authorizationCommandID: evaluation.authorizationCommandID,
+                triggerSegmentID: evaluation.triggerSegmentID,
+                selectedCandidateIDs: evaluation.selectedCandidateIDs,
+                questionTurnID: evaluation.questionTurnID,
+                contextFingerprint: evaluation.contextFingerprint,
+                lifecycle: .failed,
+                failure: failure
+            )
+        }
+    }
+
+    private static func validateEndpointEvaluationOutcome(
+        _ outcome: EndpointEvaluationOutcome
+    ) throws {
+        switch outcome {
+        case .proposal(let proposal):
+            let isConsistent: Bool
+            switch proposal.reasonCode {
+            case .explicitHandoffCue, .answerResolvesQuestion:
+                isConsistent = proposal.decision == .likelyEnd
+            case .unfinishedThought, .requestedPartUnanswered, .recentWorkspaceActivity:
+                isConsistent = proposal.decision == .likelyContinue
+            case .insufficientEvidence:
+                isConsistent = proposal.decision == .ambiguous
+            }
+            guard isConsistent else {
+                throw InterviewRoomSessionError.invalidEndpointEvaluationOutcome
+            }
+
+        case .failed(let failure):
+            if let statusCode = failure.providerStatusCode {
+                guard failure.reason == .providerRejected,
+                      (100...599).contains(statusCode) else {
+                    throw InterviewRoomSessionError.invalidEndpointEvaluationOutcome
+                }
+            }
+        }
     }
 
     private func invalidTransition(_ command: String) -> InterviewRoomSessionError {
@@ -878,6 +1131,34 @@ public actor InterviewRoomSession {
         return digest(versionedPayload, namespace: "command")
     }
 
+    /// Stable identity for the exact classifier request and its durable
+    /// evidence references. Candidate identity is deliberately part of the
+    /// envelope: a newly selected candidate may contain byte-identical text
+    /// while still representing a distinct authorized evaluation.
+    public static func endpointContextFingerprint(
+        _ context: SemanticEndpointContext,
+        triggerSegmentID: SegmentID,
+        selectedCandidateIDs: [TranscriptCandidateID],
+        questionTurnID: TurnID?
+    ) throws -> String {
+        let envelope = EndpointContextFingerprintEnvelope(
+            context: context,
+            triggerSegmentID: triggerSegmentID,
+            selectedCandidateIDs: selectedCandidateIDs,
+            questionTurnID: questionTurnID
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        do {
+            return digest(
+                try encoder.encode(envelope),
+                namespace: "semantic-endpoint-context"
+            )
+        } catch {
+            throw InterviewRoomSessionError.endpointContextEncodingFailed
+        }
+    }
+
     static func credentialFingerprint(_ credential: String) -> String {
         digest(Data(credential.utf8), namespace: "groq-credential")
     }
@@ -925,6 +1206,16 @@ public actor InterviewRoomSession {
         TranscriptCandidateID(stableIdentity(
             namespace: "transcript-candidate",
             fields: [attemptID.rawValue]
+        ))
+    }
+
+    private static func endpointEvaluationID(
+        sessionID: SessionID,
+        commandID: CommandID
+    ) -> EndpointEvaluationID {
+        EndpointEvaluationID(stableIdentity(
+            namespace: "endpoint-evaluation",
+            fields: [sessionID.rawValue, commandID.rawValue]
         ))
     }
 
@@ -985,6 +1276,16 @@ public actor InterviewRoomSession {
               suffix.count == 64,
               suffix.allSatisfy({ $0.isHexDigit }) else {
             throw InterviewRoomSessionError.invalidCredentialFingerprint
+        }
+    }
+
+    private static func validateEndpointContextFingerprint(_ value: String) throws {
+        let prefix = "sha256:v1:"
+        let suffix = value.dropFirst(prefix.count)
+        guard value.hasPrefix(prefix),
+              suffix.count == 64,
+              suffix.allSatisfy({ $0.isHexDigit }) else {
+            throw InterviewRoomSessionError.invalidEndpointContextFingerprint
         }
     }
 
@@ -1124,6 +1425,115 @@ public actor InterviewRoomSession {
                 throw InterviewRoomSessionError.invalidManifest(
                     reason: "uncommitted Segment is referenced by a Candidate Turn"
                 )
+            }
+        }
+
+        let evaluationIDs = manifest.endpointEvaluations.map(\.id)
+        let evaluationAuthorizationIDs = manifest.endpointEvaluations.map(
+            \.authorizationCommandID
+        )
+        let evaluationFingerprints = manifest.endpointEvaluations.map(
+            \.contextFingerprint
+        )
+        let allCandidateIDs = Set(
+            manifest.segments.flatMap { $0.transcriptCandidates.map(\.id) }
+        )
+        let interviewerTurnIDs: Set<TurnID> = Set(manifest.turns.compactMap { turn in
+            guard case .interviewer(let interviewer) = turn else { return nil }
+            return interviewer.id
+        })
+        guard Set(evaluationIDs).count == evaluationIDs.count,
+              Set(evaluationAuthorizationIDs).count == evaluationAuthorizationIDs.count,
+              Set(evaluationFingerprints).count == evaluationFingerprints.count,
+              manifest.endpointEvaluations.filter({ $0.lifecycle == .authorized }).count <= 1
+        else {
+            throw InterviewRoomSessionError.invalidManifest(
+                reason: "invalid endpoint evaluation history"
+            )
+        }
+
+        for evaluation in manifest.endpointEvaluations {
+            do {
+                try validateEndpointContextFingerprint(evaluation.contextFingerprint)
+            } catch {
+                throw InterviewRoomSessionError.invalidManifest(
+                    reason: "invalid endpoint context fingerprint"
+                )
+            }
+            guard evaluation.id == endpointEvaluationID(
+                sessionID: manifest.sessionID,
+                commandID: evaluation.authorizationCommandID
+            ),
+                  commandIDs.contains(evaluation.authorizationCommandID),
+                  !evaluation.selectedCandidateIDs.isEmpty,
+                  Set(evaluation.selectedCandidateIDs).count
+                    == evaluation.selectedCandidateIDs.count,
+                  evaluation.selectedCandidateIDs.allSatisfy(allCandidateIDs.contains),
+                  evaluation.questionTurnID.map({
+                      interviewerTurnIDs.contains($0)
+                  }) ?? true,
+                  let triggerSegment = segmentByID[evaluation.triggerSegmentID],
+                  triggerSegment.transcriptCandidates.contains(where: {
+                      evaluation.selectedCandidateIDs.contains($0.id)
+                  }) else {
+                throw InterviewRoomSessionError.invalidManifest(
+                    reason: "endpoint evaluation evidence is inconsistent"
+                )
+            }
+
+            let evidenceOrdinals = try evaluation.selectedCandidateIDs.map {
+                candidateID -> Int in
+                guard let segment = manifest.segments.first(where: { segment in
+                    segment.transcriptCandidates.contains(where: { $0.id == candidateID })
+                }) else {
+                    throw InterviewRoomSessionError.invalidManifest(
+                        reason: "endpoint evaluation candidate is missing"
+                    )
+                }
+                return segment.ordinal
+            }
+            guard evidenceOrdinals == evidenceOrdinals.sorted(),
+                  Set(evidenceOrdinals).count == evidenceOrdinals.count else {
+                throw InterviewRoomSessionError.invalidManifest(
+                    reason: "endpoint evaluation evidence is out of order"
+                )
+            }
+
+            switch evaluation.lifecycle {
+            case .authorized:
+                guard evaluation.proposal == nil, evaluation.failure == nil else {
+                    throw InterviewRoomSessionError.invalidManifest(
+                        reason: "authorized endpoint evaluation has an outcome"
+                    )
+                }
+            case .proposalStored:
+                guard let proposal = evaluation.proposal,
+                      evaluation.failure == nil else {
+                    throw InterviewRoomSessionError.invalidManifest(
+                        reason: "stored endpoint proposal is incomplete"
+                    )
+                }
+                do {
+                    try validateEndpointEvaluationOutcome(.proposal(proposal))
+                } catch {
+                    throw InterviewRoomSessionError.invalidManifest(
+                        reason: "stored endpoint proposal is invalid"
+                    )
+                }
+            case .failed:
+                guard let failure = evaluation.failure,
+                      evaluation.proposal == nil else {
+                    throw InterviewRoomSessionError.invalidManifest(
+                        reason: "failed endpoint evaluation is incomplete"
+                    )
+                }
+                do {
+                    try validateEndpointEvaluationOutcome(.failed(failure))
+                } catch {
+                    throw InterviewRoomSessionError.invalidManifest(
+                        reason: "stored endpoint failure is invalid"
+                    )
+                }
             }
         }
 

--- a/Sources/InterviewArcLiveCore/SegmentSpeechCoordinator.swift
+++ b/Sources/InterviewArcLiveCore/SegmentSpeechCoordinator.swift
@@ -596,7 +596,7 @@ public final class SegmentSpeechCoordinator {
               recordedSegment.selectedCandidateID != previouslySelectedCandidateID else {
             return recorded
         }
-        return try await evaluateEndpointIfNeeded(
+        return await evaluateEndpointIfNeeded(
             triggerSegmentID: segmentID,
             sourceCommandID: commandID
         )
@@ -608,7 +608,7 @@ public final class SegmentSpeechCoordinator {
     private func evaluateEndpointIfNeeded(
         triggerSegmentID: SegmentID,
         sourceCommandID: CommandID
-    ) async throws -> InterviewRoomSnapshot {
+    ) async -> InterviewRoomSnapshot {
         guard snapshot.phase == .candidateFloor,
               snapshot.turnMode == .patientAuto else {
             return snapshot
@@ -664,12 +664,19 @@ public final class SegmentSpeechCoordinator {
             explicitCue: false,
             workspaceActivity: []
         )
-        let contextFingerprint = try InterviewRoomSession.endpointContextFingerprint(
-            context,
-            triggerSegmentID: triggerSegmentID,
-            selectedCandidateIDs: selectedCandidateIDs,
-            questionTurnID: questionTurnID
-        )
+        let contextFingerprint: String
+        do {
+            contextFingerprint = try InterviewRoomSession.endpointContextFingerprint(
+                context,
+                triggerSegmentID: triggerSegmentID,
+                selectedCandidateIDs: selectedCandidateIDs,
+                questionTurnID: questionTurnID
+            )
+        } catch {
+            // Shadow work is advisory. The selected transcript is already
+            // durable and remains the successful result of this operation.
+            return snapshot
+        }
         let authorizationCommandID = InterviewRoomSession.derivedCommandID(
             source: sourceCommandID,
             operation: "endpoint-evaluation-authorization"
@@ -685,17 +692,11 @@ public final class SegmentSpeechCoordinator {
                     contextFingerprint: contextFingerprint
                 )
             )
-        } catch let sessionError as InterviewRoomSessionError {
-            switch sessionError {
-            case .endpointEvidenceMismatch,
-                 .endpointEvaluationAlreadyInProgress:
-                // Transcript persistence succeeded. Concurrent or unresolved
-                // evidence makes Shadow ineligible, never a transcription
-                // failure and never permission to call the classifier.
-                return snapshot
-            default:
-                throw sessionError
-            }
+        } catch {
+            // Authorization persistence and concurrent ineligibility never
+            // relabel a durably successful transcription as failed.
+            publish(await session.snapshot())
+            return snapshot
         }
         guard authorization.disposition == .accepted else {
             return authorization.snapshot
@@ -703,9 +704,7 @@ public final class SegmentSpeechCoordinator {
         guard let evaluation = authorization.snapshot.endpointEvaluations.first(where: {
             $0.authorizationCommandID == authorizationCommandID
         }) else {
-            throw InterviewRoomSessionError.invalidManifest(
-                reason: "endpoint evaluation authorization is missing"
-            )
+            return authorization.snapshot
         }
 
         let outcome: EndpointEvaluationOutcome
@@ -714,16 +713,47 @@ public final class SegmentSpeechCoordinator {
         } catch {
             outcome = .failed(Self.endpointFailure(for: error))
         }
-        return try await applyAndPublish(
-            .recordEndpointEvaluationOutcome(
-                commandID: InterviewRoomSession.derivedCommandID(
-                    source: authorizationCommandID,
-                    operation: "endpoint-evaluation-outcome"
-                ),
-                evaluationID: evaluation.id,
-                outcome: outcome
+        do {
+            return try await applyAndPublish(
+                .recordEndpointEvaluationOutcome(
+                    commandID: InterviewRoomSession.derivedCommandID(
+                        source: authorizationCommandID,
+                        operation: "endpoint-evaluation-outcome"
+                    ),
+                    evaluationID: evaluation.id,
+                    outcome: outcome
+                )
+            ).snapshot
+        } catch {
+            return await reconcileEndpointEvaluation(
+                evaluation,
+                authorizationCommandID: authorizationCommandID
             )
-        ).snapshot
+        }
+    }
+
+    /// Once provider work was durably authorized, an outcome-write failure is
+    /// reconciled independently from transcription. A persistent store outage
+    /// leaves the authorization recoverable by `resumePendingWork` rather than
+    /// reporting the already-stored transcript as failed.
+    private func reconcileEndpointEvaluation(
+        _ evaluation: EndpointEvaluation,
+        authorizationCommandID: CommandID
+    ) async -> InterviewRoomSnapshot {
+        do {
+            return try await applyAndPublish(
+                .reconcileInterruptedEndpointEvaluation(
+                    commandID: InterviewRoomSession.derivedCommandID(
+                        source: authorizationCommandID,
+                        operation: "endpoint-evaluation-outcome-recovery"
+                    ),
+                    evaluationID: evaluation.id
+                )
+            ).snapshot
+        } catch {
+            publish(await session.snapshot())
+            return snapshot
+        }
     }
 
     private static func endpointFailure(for error: Error) -> EndpointEvaluationFailure {

--- a/Sources/InterviewArcLiveCore/SegmentSpeechCoordinator.swift
+++ b/Sources/InterviewArcLiveCore/SegmentSpeechCoordinator.swift
@@ -20,6 +20,7 @@ public final class SegmentSpeechCoordinator {
     private let recording: any SegmentRecording
     private let transcriber: any SegmentTranscribing
     private let credentialReader: any GroqCredentialReading
+    private let semanticEndpointClassifier: any SemanticEndpointClassifying
     private var snapshotHandler: (@MainActor @Sendable (InterviewRoomSnapshot) -> Void)?
     private var isFinalizing = false
 
@@ -28,13 +29,21 @@ public final class SegmentSpeechCoordinator {
         initialSnapshot: InterviewRoomSnapshot,
         recording: any SegmentRecording,
         transcriber: any SegmentTranscribing,
-        credentialReader: any GroqCredentialReading
+        credentialReader: any GroqCredentialReading,
+        semanticEndpointClassifier: (any SemanticEndpointClassifying)?
     ) {
         self.session = session
         snapshot = initialSnapshot
         self.recording = recording
         self.transcriber = transcriber
         self.credentialReader = credentialReader
+        if let semanticEndpointClassifier {
+            self.semanticEndpointClassifier = semanticEndpointClassifier
+        } else {
+            self.semanticEndpointClassifier = GroqEndpointClassifier(
+                credentialReader: credentialReader
+            )
+        }
         installUnexpectedTerminationHandler()
     }
 
@@ -59,7 +68,8 @@ public final class SegmentSpeechCoordinator {
         interviewerRuntime: any InterviewerRuntime,
         recording: any SegmentRecording,
         transcriber: any SegmentTranscribing,
-        credentialReader: any GroqCredentialReading
+        credentialReader: any GroqCredentialReading,
+        semanticEndpointClassifier: (any SemanticEndpointClassifying)? = nil
     ) async throws -> SegmentSpeechCoordinator {
         let session: InterviewRoomSession
         if try await manifestStore.load(sessionID: sessionID) == nil {
@@ -84,7 +94,8 @@ public final class SegmentSpeechCoordinator {
             initialSnapshot: await session.snapshot(),
             recording: recording,
             transcriber: transcriber,
-            credentialReader: credentialReader
+            credentialReader: credentialReader,
+            semanticEndpointClassifier: semanticEndpointClassifier
         )
     }
 
@@ -98,7 +109,8 @@ public final class SegmentSpeechCoordinator {
         interviewerRuntime: any InterviewerRuntime,
         recording: any SegmentRecording,
         transcriber: any SegmentTranscribing,
-        credentialReader: any GroqCredentialReading
+        credentialReader: any GroqCredentialReading,
+        semanticEndpointClassifier: (any SemanticEndpointClassifying)? = nil
     ) async throws -> SegmentSpeechCoordinator {
         try await open(
             sessionID: sessionID,
@@ -109,7 +121,8 @@ public final class SegmentSpeechCoordinator {
             interviewerRuntime: interviewerRuntime,
             recording: recording,
             transcriber: transcriber,
-            credentialReader: credentialReader
+            credentialReader: credentialReader,
+            semanticEndpointClassifier: semanticEndpointClassifier
         )
     }
 
@@ -323,6 +336,21 @@ public final class SegmentSpeechCoordinator {
             )
         }
 
+        let interruptedEvaluations = snapshot.endpointEvaluations.filter {
+            $0.lifecycle == .authorized
+        }
+        for evaluation in interruptedEvaluations {
+            _ = try await applyAndPublish(
+                .reconcileInterruptedEndpointEvaluation(
+                    commandID: InterviewRoomSession.derivedCommandID(
+                        source: evaluation.authorizationCommandID,
+                        operation: "interrupted-endpoint-evaluation"
+                    ),
+                    evaluationID: evaluation.id
+                )
+            )
+        }
+
         let pending = snapshot.segments.filter {
             $0.lifecycle == .captureAuthorized
                 || $0.lifecycle == .recording
@@ -509,6 +537,7 @@ public final class SegmentSpeechCoordinator {
               }) else {
             throw SegmentSpeechCoordinatorError.segmentAudioUnavailable(segmentID)
         }
+        let previouslySelectedCandidateID = segment.selectedCandidateID
 
         let request = SegmentTranscriptionRequest(
             sessionID: authorization.snapshot.sessionID,
@@ -562,7 +591,160 @@ public final class SegmentSpeechCoordinator {
         if case .failed(let failure) = outcome {
             throw SegmentSpeechCoordinatorError.transcriptionFailed(failure.reason)
         }
-        return recorded
+        guard case .candidate = outcome,
+              let recordedSegment = recorded.segments.first(where: { $0.id == segmentID }),
+              recordedSegment.selectedCandidateID != previouslySelectedCandidateID else {
+            return recorded
+        }
+        return try await evaluateEndpointIfNeeded(
+            triggerSegmentID: segmentID,
+            sourceCommandID: commandID
+        )
+    }
+
+    /// Patient Auto is intentionally a Shadow policy in this slice. It stores
+    /// one proposal at an explicit transcript boundary but never commits a
+    /// Candidate Turn, starts grace, or invokes the interviewer runtime.
+    private func evaluateEndpointIfNeeded(
+        triggerSegmentID: SegmentID,
+        sourceCommandID: CommandID
+    ) async throws -> InterviewRoomSnapshot {
+        guard snapshot.phase == .candidateFloor,
+              snapshot.turnMode == .patientAuto else {
+            return snapshot
+        }
+
+        let draftSegments = snapshot.segments.filter { $0.committedTurnID == nil }
+        let unresolvedDraft = draftSegments.contains {
+            $0.lifecycle != .excluded
+                && ($0.lifecycle == .captureAuthorized
+                    || $0.lifecycle == .recording
+                    || $0.lifecycle == .finalizationAuthorized
+                    || $0.lifecycle == .transcribing
+                    || $0.selectedCandidate == nil)
+        }
+        guard !unresolvedDraft else { return snapshot }
+
+        let selectedSegments = draftSegments
+            .filter { $0.lifecycle != .excluded && $0.selectedCandidate != nil }
+            .sorted { $0.ordinal < $1.ordinal }
+        guard let triggerSegment = selectedSegments.first(where: { $0.id == triggerSegmentID }),
+              let triggerBody = triggerSegment.selectedCandidate?.body else {
+            return snapshot
+        }
+        let latestSegment = triggerBody.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let selectedCandidateIDs = selectedSegments.compactMap(\.selectedCandidateID)
+        let accumulatedBodies = selectedSegments.compactMap {
+            $0.selectedCandidate?.body.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        guard selectedCandidateIDs.count == selectedSegments.count,
+              accumulatedBodies.count == selectedSegments.count,
+              !latestSegment.isEmpty,
+              accumulatedBodies.allSatisfy({ !$0.isEmpty }) else {
+            return snapshot
+        }
+
+        let latestQuestionTurn: InterviewerTurn? = snapshot.turns.reversed().lazy.compactMap {
+            guard case .interviewer(let turn) = $0 else { return nil }
+            return turn
+        }.first
+        let questionTurnID = latestQuestionTurn?.id
+        let context = SemanticEndpointContext(
+            interviewerQuestion: latestQuestionTurn?.displayMarkdown
+                ?? snapshot.activityPrompt.question,
+            requestedParts: questionTurnID == nil
+                ? snapshot.activityPrompt.requestedParts
+                : [],
+            accumulatedAnswer: accumulatedBodies.joined(separator: "\n\n"),
+            latestSegment: latestSegment,
+            silenceDurationMilliseconds: 0,
+            specialty: snapshot.activityPrompt.specialty.rawValue,
+            stage: snapshot.activityPrompt.stage,
+            explicitCue: false,
+            workspaceActivity: []
+        )
+        let contextFingerprint = try InterviewRoomSession.endpointContextFingerprint(
+            context,
+            triggerSegmentID: triggerSegmentID,
+            selectedCandidateIDs: selectedCandidateIDs,
+            questionTurnID: questionTurnID
+        )
+        let authorizationCommandID = InterviewRoomSession.derivedCommandID(
+            source: sourceCommandID,
+            operation: "endpoint-evaluation-authorization"
+        )
+        let authorization: InterviewRoomCommandApplication
+        do {
+            authorization = try await applyAndPublish(
+                .authorizeEndpointEvaluation(
+                    commandID: authorizationCommandID,
+                    triggerSegmentID: triggerSegmentID,
+                    selectedCandidateIDs: selectedCandidateIDs,
+                    questionTurnID: questionTurnID,
+                    contextFingerprint: contextFingerprint
+                )
+            )
+        } catch let sessionError as InterviewRoomSessionError {
+            switch sessionError {
+            case .endpointEvidenceMismatch,
+                 .endpointEvaluationAlreadyInProgress:
+                // Transcript persistence succeeded. Concurrent or unresolved
+                // evidence makes Shadow ineligible, never a transcription
+                // failure and never permission to call the classifier.
+                return snapshot
+            default:
+                throw sessionError
+            }
+        }
+        guard authorization.disposition == .accepted else {
+            return authorization.snapshot
+        }
+        guard let evaluation = authorization.snapshot.endpointEvaluations.first(where: {
+            $0.authorizationCommandID == authorizationCommandID
+        }) else {
+            throw InterviewRoomSessionError.invalidManifest(
+                reason: "endpoint evaluation authorization is missing"
+            )
+        }
+
+        let outcome: EndpointEvaluationOutcome
+        do {
+            outcome = .proposal(try await semanticEndpointClassifier.classify(context))
+        } catch {
+            outcome = .failed(Self.endpointFailure(for: error))
+        }
+        return try await applyAndPublish(
+            .recordEndpointEvaluationOutcome(
+                commandID: InterviewRoomSession.derivedCommandID(
+                    source: authorizationCommandID,
+                    operation: "endpoint-evaluation-outcome"
+                ),
+                evaluationID: evaluation.id,
+                outcome: outcome
+            )
+        ).snapshot
+    }
+
+    private static func endpointFailure(for error: Error) -> EndpointEvaluationFailure {
+        guard let classifierError = error as? GroqEndpointClassifierError else {
+            return EndpointEvaluationFailure(reason: .transportFailure)
+        }
+        switch classifierError {
+        case .missingCredential:
+            return EndpointEvaluationFailure(reason: .missingCredential)
+        case .invalidContext, .contextLimitExceeded:
+            return EndpointEvaluationFailure(reason: .contextRejected)
+        case .transportFailure, .invalidHTTPResponse:
+            return EndpointEvaluationFailure(reason: .transportFailure)
+        case .rejected(let statusCode):
+            return EndpointEvaluationFailure(
+                reason: .providerRejected,
+                providerStatusCode: statusCode
+            )
+        case .malformedResponse, .invalidClassification:
+            return EndpointEvaluationFailure(reason: .invalidResponse)
+        }
     }
 
     private func recordUnavailableCredential(

--- a/Sources/InterviewArcLiveCore/SemanticEndpointClassifier.swift
+++ b/Sources/InterviewArcLiveCore/SemanticEndpointClassifier.swift
@@ -145,7 +145,7 @@ public struct EndpointEvaluation: Codable, Sendable, Equatable {
   public let proposal: SemanticEndpointProposal?
   public let failure: EndpointEvaluationFailure?
 
-  public init(
+  internal init(
     id: EndpointEvaluationID,
     authorizationCommandID: CommandID,
     triggerSegmentID: SegmentID,
@@ -165,6 +165,67 @@ public struct EndpointEvaluation: Codable, Sendable, Equatable {
     self.lifecycle = lifecycle
     self.proposal = proposal
     self.failure = failure
+  }
+
+  public static func authorized(
+    id: EndpointEvaluationID,
+    authorizationCommandID: CommandID,
+    triggerSegmentID: SegmentID,
+    selectedCandidateIDs: [TranscriptCandidateID],
+    questionTurnID: TurnID?,
+    contextFingerprint: String
+  ) -> EndpointEvaluation {
+    EndpointEvaluation(
+      id: id,
+      authorizationCommandID: authorizationCommandID,
+      triggerSegmentID: triggerSegmentID,
+      selectedCandidateIDs: selectedCandidateIDs,
+      questionTurnID: questionTurnID,
+      contextFingerprint: contextFingerprint,
+      lifecycle: .authorized
+    )
+  }
+
+  public static func proposalStored(
+    id: EndpointEvaluationID,
+    authorizationCommandID: CommandID,
+    triggerSegmentID: SegmentID,
+    selectedCandidateIDs: [TranscriptCandidateID],
+    questionTurnID: TurnID?,
+    contextFingerprint: String,
+    proposal: SemanticEndpointProposal
+  ) -> EndpointEvaluation {
+    EndpointEvaluation(
+      id: id,
+      authorizationCommandID: authorizationCommandID,
+      triggerSegmentID: triggerSegmentID,
+      selectedCandidateIDs: selectedCandidateIDs,
+      questionTurnID: questionTurnID,
+      contextFingerprint: contextFingerprint,
+      lifecycle: .proposalStored,
+      proposal: proposal
+    )
+  }
+
+  public static func failed(
+    id: EndpointEvaluationID,
+    authorizationCommandID: CommandID,
+    triggerSegmentID: SegmentID,
+    selectedCandidateIDs: [TranscriptCandidateID],
+    questionTurnID: TurnID?,
+    contextFingerprint: String,
+    failure: EndpointEvaluationFailure
+  ) -> EndpointEvaluation {
+    EndpointEvaluation(
+      id: id,
+      authorizationCommandID: authorizationCommandID,
+      triggerSegmentID: triggerSegmentID,
+      selectedCandidateIDs: selectedCandidateIDs,
+      questionTurnID: questionTurnID,
+      contextFingerprint: contextFingerprint,
+      lifecycle: .failed,
+      failure: failure
+    )
   }
 }
 

--- a/Sources/InterviewArcLiveCore/SemanticEndpointClassifier.swift
+++ b/Sources/InterviewArcLiveCore/SemanticEndpointClassifier.swift
@@ -8,7 +8,7 @@ public protocol SemanticEndpointClassifying: Sendable {
   func classify(_ context: SemanticEndpointContext) async throws -> SemanticEndpointProposal
 }
 
-public struct SemanticEndpointContext: Sendable, Equatable {
+public struct SemanticEndpointContext: Codable, Sendable, Equatable {
   public let interviewerQuestion: String
   public let requestedParts: [String]
   public let accumulatedAnswer: String
@@ -42,7 +42,7 @@ public struct SemanticEndpointContext: Sendable, Equatable {
   }
 }
 
-public struct SemanticEndpointWorkspaceActivity: Sendable, Equatable {
+public struct SemanticEndpointWorkspaceActivity: Codable, Sendable, Equatable {
   public let kind: String
   public let millisecondsAgo: Int
   public let summary: String
@@ -54,13 +54,13 @@ public struct SemanticEndpointWorkspaceActivity: Sendable, Equatable {
   }
 }
 
-public enum SemanticEndpointDecision: String, Sendable, Equatable, CaseIterable {
+public enum SemanticEndpointDecision: String, Codable, Sendable, Equatable, CaseIterable {
   case likelyContinue = "likely_continue"
   case likelyEnd = "likely_end"
   case ambiguous
 }
 
-public enum SemanticEndpointReasonCode: String, Sendable, Equatable, CaseIterable {
+public enum SemanticEndpointReasonCode: String, Codable, Sendable, Equatable, CaseIterable {
   case explicitHandoffCue = "explicit_handoff_cue"
   case answerResolvesQuestion = "answer_resolves_question"
   case unfinishedThought = "unfinished_thought"
@@ -69,13 +69,102 @@ public enum SemanticEndpointReasonCode: String, Sendable, Equatable, CaseIterabl
   case insufficientEvidence = "insufficient_evidence"
 }
 
-public struct SemanticEndpointProposal: Sendable, Equatable {
+public struct SemanticEndpointProposal: Codable, Sendable, Equatable {
   public let decision: SemanticEndpointDecision
   public let reasonCode: SemanticEndpointReasonCode
 
   public init(decision: SemanticEndpointDecision, reasonCode: SemanticEndpointReasonCode) {
     self.decision = decision
     self.reasonCode = reasonCode
+  }
+}
+
+public struct EndpointEvaluationID:
+  RawRepresentable, Codable, Hashable, Sendable, CustomStringConvertible
+{
+  public let rawValue: String
+
+  public init(rawValue: String) {
+    self.rawValue = rawValue
+  }
+
+  public init(_ rawValue: String) {
+    self.rawValue = rawValue
+  }
+
+  public var description: String { rawValue }
+}
+
+public enum EndpointEvaluationLifecycle: String, Codable, Sendable, Equatable {
+  case authorized
+  case proposalStored = "proposal_stored"
+  case failed
+}
+
+/// Bounded failure categories safe to persist and present. Provider response
+/// bodies, request context, credentials, and private paths never cross this
+/// Interface.
+public enum EndpointEvaluationFailureReason: String, Codable, Sendable, Equatable {
+  case missingCredential = "missing_credential"
+  case contextRejected = "context_rejected"
+  case transportFailure = "transport_failure"
+  case providerRejected = "provider_rejected"
+  case invalidResponse = "invalid_response"
+  case interrupted
+}
+
+public struct EndpointEvaluationFailure: Codable, Sendable, Equatable {
+  public let reason: EndpointEvaluationFailureReason
+  public let providerStatusCode: Int?
+
+  public init(
+    reason: EndpointEvaluationFailureReason,
+    providerStatusCode: Int? = nil
+  ) {
+    self.reason = reason
+    self.providerStatusCode = providerStatusCode
+  }
+}
+
+public enum EndpointEvaluationOutcome: Codable, Sendable, Equatable {
+  case proposal(SemanticEndpointProposal)
+  case failed(EndpointEvaluationFailure)
+}
+
+/// One durably authorized semantic-classifier request. It retains only stable
+/// evidence identities and a fingerprint; the prompt and transcript bodies
+/// remain canonical elsewhere in the Session Manifest.
+public struct EndpointEvaluation: Codable, Sendable, Equatable {
+  public let id: EndpointEvaluationID
+  public let authorizationCommandID: CommandID
+  public let triggerSegmentID: SegmentID
+  public let selectedCandidateIDs: [TranscriptCandidateID]
+  public let questionTurnID: TurnID?
+  public let contextFingerprint: String
+  public let lifecycle: EndpointEvaluationLifecycle
+  public let proposal: SemanticEndpointProposal?
+  public let failure: EndpointEvaluationFailure?
+
+  public init(
+    id: EndpointEvaluationID,
+    authorizationCommandID: CommandID,
+    triggerSegmentID: SegmentID,
+    selectedCandidateIDs: [TranscriptCandidateID],
+    questionTurnID: TurnID?,
+    contextFingerprint: String,
+    lifecycle: EndpointEvaluationLifecycle,
+    proposal: SemanticEndpointProposal? = nil,
+    failure: EndpointEvaluationFailure? = nil
+  ) {
+    self.id = id
+    self.authorizationCommandID = authorizationCommandID
+    self.triggerSegmentID = triggerSegmentID
+    self.selectedCandidateIDs = selectedCandidateIDs
+    self.questionTurnID = questionTurnID
+    self.contextFingerprint = contextFingerprint
+    self.lifecycle = lifecycle
+    self.proposal = proposal
+    self.failure = failure
   }
 }
 

--- a/Sources/InterviewArcLiveCore/SessionManifest.swift
+++ b/Sources/InterviewArcLiveCore/SessionManifest.swift
@@ -296,6 +296,7 @@ public struct SessionManifest: Codable, Sendable, Equatable {
     public let turnMode: TurnMode
     public let turns: [InterviewTurn]
     public let segments: [CandidateSegment]
+    public let endpointEvaluations: [EndpointEvaluation]
     public let revision: Int
 
     let appliedCommands: [AppliedCommandRecord]
@@ -308,6 +309,7 @@ public struct SessionManifest: Codable, Sendable, Equatable {
         turnMode: TurnMode,
         turns: [InterviewTurn],
         segments: [CandidateSegment] = [],
+        endpointEvaluations: [EndpointEvaluation] = [],
         revision: Int,
         appliedCommands: [AppliedCommandRecord]
     ) {
@@ -318,6 +320,7 @@ public struct SessionManifest: Codable, Sendable, Equatable {
         self.turnMode = turnMode
         self.turns = turns
         self.segments = segments
+        self.endpointEvaluations = endpointEvaluations
         self.revision = revision
         self.appliedCommands = appliedCommands
     }
@@ -330,6 +333,7 @@ public struct SessionManifest: Codable, Sendable, Equatable {
         case turnMode
         case turns
         case segments
+        case endpointEvaluations
         case revision
         case appliedCommands
     }
@@ -343,6 +347,10 @@ public struct SessionManifest: Codable, Sendable, Equatable {
         turnMode = try container.decode(TurnMode.self, forKey: .turnMode)
         turns = try container.decode([InterviewTurn].self, forKey: .turns)
         segments = try container.decodeIfPresent([CandidateSegment].self, forKey: .segments) ?? []
+        endpointEvaluations = try container.decodeIfPresent(
+            [EndpointEvaluation].self,
+            forKey: .endpointEvaluations
+        ) ?? []
         revision = try container.decode(Int.self, forKey: .revision)
         appliedCommands = try container.decode(
             [AppliedCommandRecord].self,
@@ -359,6 +367,7 @@ public struct SessionManifest: Codable, Sendable, Equatable {
         try container.encode(turnMode, forKey: .turnMode)
         try container.encode(turns, forKey: .turns)
         try container.encode(segments, forKey: .segments)
+        try container.encode(endpointEvaluations, forKey: .endpointEvaluations)
         try container.encode(revision, forKey: .revision)
         try container.encode(appliedCommands, forKey: .appliedCommands)
     }
@@ -373,6 +382,7 @@ public struct InterviewRoomSnapshot: Sendable, Equatable {
     public let turnMode: TurnMode
     public let turns: [InterviewTurn]
     public let segments: [CandidateSegment]
+    public let endpointEvaluations: [EndpointEvaluation]
     public let revision: Int
 
     init(manifest: SessionManifest) {
@@ -383,6 +393,7 @@ public struct InterviewRoomSnapshot: Sendable, Equatable {
         turnMode = manifest.turnMode
         turns = manifest.turns
         segments = manifest.segments
+        endpointEvaluations = manifest.endpointEvaluations
         revision = manifest.revision
     }
 }

--- a/Sources/InterviewArcLiveEndpointSmoke/main.swift
+++ b/Sources/InterviewArcLiveEndpointSmoke/main.swift
@@ -1,0 +1,288 @@
+import Darwin
+import Foundation
+import InterviewArcLiveCore
+import InterviewArcLiveVoiceAdapter
+
+@main
+struct InterviewArcLiveEndpointSmoke {
+  private static let optInEnvironmentKey =
+    "INTERVIEW_ARC_LIVE_RUN_ENDPOINT_SMOKE"
+  private static let transcript =
+    "I would make processing idempotent and retry transient failures with bounded backoff."
+
+  @MainActor
+  static func main() async {
+    guard ProcessInfo.processInfo.environment[optInEnvironmentKey] == "1" else {
+      fail(
+        "Endpoint smoke is opt-in. Set \(optInEnvironmentKey)=1 to run it.",
+        code: 64
+      )
+    }
+
+    let workingDirectory = URL(
+      fileURLWithPath: FileManager.default.currentDirectoryPath,
+      isDirectory: true
+    ).standardizedFileURL
+    guard !isInsideRepository(workingDirectory) else {
+      fail("Endpoint smoke requires a temporary non-repository working directory.", code: 65)
+    }
+
+    let stateRoot = workingDirectory.appendingPathComponent(
+      "shadow-state-\(UUID().uuidString)",
+      isDirectory: true
+    )
+    defer { try? FileManager.default.removeItem(at: stateRoot) }
+
+    let sessionID = SessionID("installed-endpoint-shadow")
+    let store = FileSessionManifestStore(directoryURL: stateRoot)
+    let credentialStore = LiveGroqCredentialStore()
+    let productionClassifier = GroqEndpointClassifier(
+      credentialReader: credentialStore
+    )
+    let expectedContext = SemanticEndpointContext(
+      interviewerQuestion: "Describe one way to make a queue consumer resilient.",
+      requestedParts: ["State the failure-handling mechanism."],
+      accumulatedAnswer: transcript,
+      latestSegment: transcript,
+      silenceDurationMilliseconds: 0,
+      specialty: "system_design",
+      stage: "Installed smoke",
+      explicitCue: false,
+      workspaceActivity: []
+    )
+    let classifier = DurableProductionClassifier(
+      classifier: productionClassifier,
+      manifestStore: store,
+      sessionID: sessionID,
+      expectedContext: expectedContext
+    )
+    let interviewer = CountingInterviewerRuntime()
+    let recorder: DeterministicSegmentRecorder
+    do {
+      recorder = try DeterministicSegmentRecorder()
+    } catch {
+      fail("Endpoint smoke failed to prepare deterministic source evidence.", code: 70)
+    }
+    let transcriber = DeterministicSegmentTranscriber(body: transcript)
+
+    do {
+      let prompt = try ActivityPrompt(
+        specialty: .systemDesign,
+        stage: "Installed smoke",
+        question: "Describe one way to make a queue consumer resilient.",
+        requestedParts: ["State the failure-handling mechanism."]
+      )
+      let coordinator = try await SegmentSpeechCoordinator.open(
+        sessionID: sessionID,
+        activityID: "installed-endpoint-shadow",
+        activityPrompt: prompt,
+        turnMode: .patientAuto,
+        manifestStore: store,
+        interviewerRuntime: interviewer,
+        recording: recorder,
+        transcriber: transcriber,
+        credentialReader: credentialStore,
+        semanticEndpointClassifier: classifier
+      )
+      _ = try await coordinator.giveCandidateFloor(
+        commandID: CommandID("installed-shadow-floor")
+      )
+      _ = try await coordinator.beginSegment(
+        commandID: CommandID("installed-shadow-begin")
+      )
+      let completed = try await coordinator.finishSegment(
+        commandID: CommandID("installed-shadow-finish"),
+        transcriptionCommandID: CommandID("installed-shadow-transcribe")
+      )
+
+      let persisted = try await store.load(sessionID: sessionID)
+      let classifierCalls = await classifier.invocationCount()
+      let durableAtEntry = await classifier.authorizationWasDurableAtEntry()
+      let transcriberCalls = await transcriber.invocationCount()
+      let interviewerCalls = await interviewer.invocationCount()
+      guard
+        completed.turnMode == .patientAuto,
+        completed.phase == .candidateFloor,
+        completed.turns.isEmpty,
+        completed.segments.count == 1,
+        completed.segments.first?.selectedCandidate?.body == transcript,
+        completed.endpointEvaluations.count == 1,
+        completed.endpointEvaluations.first?.lifecycle == .proposalStored,
+        completed.endpointEvaluations.first?.proposal != nil,
+        completed.endpointEvaluations.first?.failure == nil,
+        persisted?.endpointEvaluations == completed.endpointEvaluations,
+        persisted?.phase == .candidateFloor,
+        persisted?.turns.isEmpty == true,
+        classifierCalls == 1,
+        durableAtEntry,
+        recorder.beginCount == 1,
+        recorder.finishCount == 1,
+        transcriberCalls == 1,
+        interviewerCalls == 0
+      else {
+        if completed.endpointEvaluations.first?.failure?.reason == .missingCredential {
+          fail(
+            "Endpoint smoke failed: Interview Arc Live has no readable Groq credential.",
+            code: 70
+          )
+        }
+        fail("Endpoint smoke failed: the Shadow invariants were not satisfied.", code: 70)
+      }
+      print("Installed Patient Auto Groq endpoint shadow smoke passed.")
+    } catch SegmentSpeechCoordinatorError.credentialUnavailable {
+      fail(
+        "Endpoint smoke failed: Interview Arc Live has no readable Groq credential.",
+        code: 70
+      )
+    } catch {
+      fail("Endpoint smoke failed before durable Shadow verification completed.", code: 70)
+    }
+  }
+
+  private static func isInsideRepository(_ directory: URL) -> Bool {
+    var current = directory.resolvingSymlinksInPath().standardizedFileURL
+    while current.path != "/" {
+      if FileManager.default.fileExists(
+        atPath: current.appendingPathComponent(".git").path
+      ) {
+        return true
+      }
+      current.deleteLastPathComponent()
+    }
+    return false
+  }
+
+  private static func fail(_ message: String, code: Int32) -> Never {
+    if let data = "\(message)\n".data(using: .utf8) {
+      try? FileHandle.standardError.write(contentsOf: data)
+    }
+    Darwin.exit(code)
+  }
+}
+
+private actor DurableProductionClassifier: SemanticEndpointClassifying {
+  private let classifier: GroqEndpointClassifier
+  private let manifestStore: FileSessionManifestStore
+  private let sessionID: SessionID
+  private let expectedContext: SemanticEndpointContext
+  private var calls = 0
+  private var authorizationDurableAtEntry = false
+
+  init(
+    classifier: GroqEndpointClassifier,
+    manifestStore: FileSessionManifestStore,
+    sessionID: SessionID,
+    expectedContext: SemanticEndpointContext
+  ) {
+    self.classifier = classifier
+    self.manifestStore = manifestStore
+    self.sessionID = sessionID
+    self.expectedContext = expectedContext
+  }
+
+  func classify(
+    _ context: SemanticEndpointContext
+  ) async throws -> SemanticEndpointProposal {
+    calls += 1
+    let manifest = try await manifestStore.load(sessionID: sessionID)
+    authorizationDurableAtEntry =
+      manifest?.endpointEvaluations.last?.lifecycle == .authorized
+    guard authorizationDurableAtEntry, context == expectedContext else {
+      throw EndpointSmokeAssertionError.unexpectedClassifierEntry
+    }
+    return try await classifier.classify(context)
+  }
+
+  func invocationCount() -> Int { calls }
+  func authorizationWasDurableAtEntry() -> Bool { authorizationDurableAtEntry }
+}
+
+@MainActor
+private final class DeterministicSegmentRecorder: SegmentRecording {
+  private let capture: CapturedAudioSegment
+  private var unexpectedTerminationHandler: (@MainActor @Sendable () -> Void)?
+  private(set) var beginCount = 0
+  private(set) var finishCount = 0
+
+  init() throws {
+    capture = CapturedAudioSegment(
+      audioIdentity: try SegmentAudioIdentity(
+        validating: "installed-shadow-segment.m4a"
+      ),
+      startedAtMilliseconds: 1_000,
+      endedAtMilliseconds: 2_000,
+      durationMilliseconds: 1_000,
+      decodedDurationMilliseconds: 1_000,
+      byteCount: 4_096,
+      isPlayable: true,
+      isPartial: false
+    )
+  }
+
+  func setUnexpectedTerminationHandler(
+    _ handler: (@MainActor @Sendable () -> Void)?
+  ) {
+    unexpectedTerminationHandler = handler
+  }
+
+  func beginCapture(_ request: SegmentCaptureRequest) async throws {
+    beginCount += 1
+  }
+
+  func finishCapture() async throws -> CapturedAudioSegment {
+    finishCount += 1
+    return capture
+  }
+
+  func recoverCapture(
+    _ request: SegmentCaptureRequest
+  ) async throws -> CapturedAudioSegment? {
+    nil
+  }
+
+  func playbackURL(
+    sessionID: SessionID,
+    audioIdentity: SegmentAudioIdentity
+  ) async throws -> URL {
+    URL(fileURLWithPath: audioIdentity.fileName)
+  }
+}
+
+private actor DeterministicSegmentTranscriber: SegmentTranscribing {
+  private let body: String
+  private var calls = 0
+
+  init(body: String) {
+    self.body = body
+  }
+
+  func transcribe(
+    _ request: SegmentTranscriptionRequest,
+    credential: String
+  ) -> SegmentTranscriptionResult {
+    calls += 1
+    return SegmentTranscriptionResult(body: body, quality: .verified)
+  }
+
+  func invocationCount() -> Int { calls }
+}
+
+private actor CountingInterviewerRuntime: InterviewerRuntime {
+  private var calls = 0
+
+  func respond(
+    to request: InterviewerRequest
+  ) -> CanonicalInterviewerResponse {
+    calls += 1
+    return CanonicalInterviewerResponse(
+      displayMarkdown: "This response must remain unreachable.",
+      spokenText: "This response must remain unreachable."
+    )
+  }
+
+  func invocationCount() -> Int { calls }
+}
+
+private enum EndpointSmokeAssertionError: Error {
+  case unexpectedClassifierEntry
+}

--- a/Tests/InterviewArcLiveCoreTests/EndpointEvaluationSessionTests.swift
+++ b/Tests/InterviewArcLiveCoreTests/EndpointEvaluationSessionTests.swift
@@ -160,7 +160,7 @@ final class EndpointEvaluationSessionTests: XCTestCase {
 
         let replacement = try await restored.apply(
             .authorizeEndpointEvaluation(
-                commandID: CommandID("identity-replacement-authorize"),
+                commandID: CommandID("identity-replacement-endpoint-authorize"),
                 triggerSegmentID: initial.segmentID,
                 selectedCandidateIDs: [replacementCandidateID],
                 questionTurnID: nil,

--- a/Tests/InterviewArcLiveCoreTests/EndpointEvaluationSessionTests.swift
+++ b/Tests/InterviewArcLiveCoreTests/EndpointEvaluationSessionTests.swift
@@ -1,0 +1,452 @@
+import Foundation
+import XCTest
+@testable import InterviewArcLiveCore
+
+@MainActor
+final class EndpointEvaluationSessionTests: XCTestCase {
+    func testAuthorizationAndProposalAreDurableWithoutLeavingCandidateFloor() async throws {
+        let store = InMemorySessionManifestStore()
+        let session = try await makePatientAutoSession(store: store)
+        let evidence = try await makeTranscribedSegment(
+            session: session,
+            commandStem: "proposal",
+            body: "Use a durable queue and idempotent delivery workers.",
+            quality: .verified
+        )
+        let context = endpointContext(body: evidence.body)
+        let fingerprint = try InterviewRoomSession.endpointContextFingerprint(
+            context,
+            triggerSegmentID: evidence.segmentID,
+            selectedCandidateIDs: [evidence.candidateID],
+            questionTurnID: nil
+        )
+
+        let authorization = try await session.apply(
+            .authorizeEndpointEvaluation(
+                commandID: CommandID("endpoint-proposal-authorize"),
+                triggerSegmentID: evidence.segmentID,
+                selectedCandidateIDs: [evidence.candidateID],
+                questionTurnID: nil,
+                contextFingerprint: fingerprint
+            )
+        )
+
+        XCTAssertEqual(authorization.disposition, .accepted)
+        XCTAssertEqual(authorization.snapshot.phase, .candidateFloor)
+        XCTAssertTrue(authorization.snapshot.turns.isEmpty)
+        let authorized = try XCTUnwrap(authorization.snapshot.endpointEvaluations.first)
+        XCTAssertEqual(authorized.lifecycle, .authorized)
+        XCTAssertEqual(authorized.contextFingerprint, fingerprint)
+        XCTAssertNil(authorized.proposal)
+        XCTAssertNil(authorized.failure)
+
+        let proposal = SemanticEndpointProposal(
+            decision: .likelyEnd,
+            reasonCode: .answerResolvesQuestion
+        )
+        let completed = try await session.execute(
+            .recordEndpointEvaluationOutcome(
+                commandID: CommandID("endpoint-proposal-outcome"),
+                evaluationID: authorized.id,
+                outcome: .proposal(proposal)
+            )
+        )
+
+        XCTAssertEqual(completed.phase, .candidateFloor)
+        XCTAssertTrue(completed.turns.isEmpty)
+        XCTAssertEqual(completed.endpointEvaluations[0].lifecycle, .proposalStored)
+        XCTAssertEqual(completed.endpointEvaluations[0].proposal, proposal)
+        XCTAssertNil(completed.endpointEvaluations[0].failure)
+
+        let restored = try await InterviewRoomSession.restore(
+            sessionID: completed.sessionID,
+            manifestStore: store,
+            interviewerRuntime: fixtureRuntime()
+        )
+        let restoredSnapshot = await restored.snapshot()
+        XCTAssertEqual(restoredSnapshot, completed)
+    }
+
+    func testExactContextDedupesButNewEvidenceIdentityGetsANewFingerprint() async throws {
+        let store = InMemorySessionManifestStore()
+        let session = try await makePatientAutoSession(store: store)
+        let initial = try await makeTranscribedSegment(
+            session: session,
+            commandStem: "identity-initial",
+            body: "The same semantic answer.",
+            quality: .bestAvailable
+        )
+        let context = endpointContext(body: initial.body)
+        let initialFingerprint = try InterviewRoomSession.endpointContextFingerprint(
+            context,
+            triggerSegmentID: initial.segmentID,
+            selectedCandidateIDs: [initial.candidateID],
+            questionTurnID: nil
+        )
+        let firstAuthorization = InterviewRoomCommand.authorizeEndpointEvaluation(
+            commandID: CommandID("identity-first-authorize"),
+            triggerSegmentID: initial.segmentID,
+            selectedCandidateIDs: [initial.candidateID],
+            questionTurnID: nil,
+            contextFingerprint: initialFingerprint
+        )
+        let first = try await session.apply(firstAuthorization)
+        let firstEvaluation = try XCTUnwrap(first.snapshot.endpointEvaluations.first)
+        _ = try await session.execute(
+            .recordEndpointEvaluationOutcome(
+                commandID: CommandID("identity-first-outcome"),
+                evaluationID: firstEvaluation.id,
+                outcome: .proposal(
+                    SemanticEndpointProposal(
+                        decision: .ambiguous,
+                        reasonCode: .insufficientEvidence
+                    )
+                )
+            )
+        )
+        let beforeSemanticDuplicate = await session.snapshot()
+
+        let semanticDuplicateCommandID = CommandID("identity-duplicate-authorize")
+        let semanticDuplicate = try await session.apply(
+            .authorizeEndpointEvaluation(
+                commandID: semanticDuplicateCommandID,
+                triggerSegmentID: initial.segmentID,
+                selectedCandidateIDs: [initial.candidateID],
+                questionTurnID: nil,
+                contextFingerprint: initialFingerprint
+            )
+        )
+        XCTAssertEqual(semanticDuplicate.disposition, .alreadyApplied)
+        XCTAssertEqual(semanticDuplicate.snapshot.endpointEvaluations.count, 1)
+        XCTAssertEqual(
+            semanticDuplicate.snapshot.revision,
+            beforeSemanticDuplicate.revision + 1
+        )
+
+        let restored = try await InterviewRoomSession.restore(
+            sessionID: semanticDuplicate.snapshot.sessionID,
+            manifestStore: store,
+            interviewerRuntime: fixtureRuntime()
+        )
+        do {
+            _ = try await restored.execute(
+                .setTurnMode(
+                    commandID: semanticDuplicateCommandID,
+                    mode: .manual
+                )
+            )
+            XCTFail("Expected the consumed semantic-dedupe command ID to reject reuse")
+        } catch {
+            XCTAssertEqual(
+                error as? InterviewRoomSessionError,
+                .commandIDReused(semanticDuplicateCommandID)
+            )
+        }
+
+        let replacementCandidateID = try await recordRetryCandidate(
+            session: restored,
+            segmentID: initial.segmentID,
+            commandStem: "identity-replacement",
+            body: initial.body,
+            quality: .verified
+        )
+        let replacementFingerprint = try InterviewRoomSession.endpointContextFingerprint(
+            context,
+            triggerSegmentID: initial.segmentID,
+            selectedCandidateIDs: [replacementCandidateID],
+            questionTurnID: nil
+        )
+        XCTAssertNotEqual(replacementFingerprint, initialFingerprint)
+
+        let replacement = try await restored.apply(
+            .authorizeEndpointEvaluation(
+                commandID: CommandID("identity-replacement-authorize"),
+                triggerSegmentID: initial.segmentID,
+                selectedCandidateIDs: [replacementCandidateID],
+                questionTurnID: nil,
+                contextFingerprint: replacementFingerprint
+            )
+        )
+        XCTAssertEqual(replacement.disposition, .accepted)
+        XCTAssertEqual(replacement.snapshot.endpointEvaluations.count, 2)
+    }
+
+    func testInterruptedAuthorizationReconcilesWithoutCreatingAProposal() async throws {
+        let store = InMemorySessionManifestStore()
+        let session = try await makePatientAutoSession(store: store)
+        let evidence = try await makeTranscribedSegment(
+            session: session,
+            commandStem: "interrupted",
+            body: "Preserve the exact answer before provider work.",
+            quality: .verified
+        )
+        let context = endpointContext(body: evidence.body)
+        let fingerprint = try InterviewRoomSession.endpointContextFingerprint(
+            context,
+            triggerSegmentID: evidence.segmentID,
+            selectedCandidateIDs: [evidence.candidateID],
+            questionTurnID: nil
+        )
+        let authorized = try await session.execute(
+            .authorizeEndpointEvaluation(
+                commandID: CommandID("interrupted-authorize"),
+                triggerSegmentID: evidence.segmentID,
+                selectedCandidateIDs: [evidence.candidateID],
+                questionTurnID: nil,
+                contextFingerprint: fingerprint
+            )
+        )
+        let evaluationID = try XCTUnwrap(authorized.endpointEvaluations.first?.id)
+
+        let restored = try await InterviewRoomSession.restore(
+            sessionID: authorized.sessionID,
+            manifestStore: store,
+            interviewerRuntime: fixtureRuntime()
+        )
+        let beforeReconciliation = await restored.snapshot()
+        XCTAssertEqual(beforeReconciliation.endpointEvaluations[0].lifecycle, .authorized)
+
+        let reconciled = try await restored.execute(
+            .reconcileInterruptedEndpointEvaluation(
+                commandID: CommandID("interrupted-reconcile"),
+                evaluationID: evaluationID
+            )
+        )
+        XCTAssertEqual(reconciled.endpointEvaluations[0].lifecycle, .failed)
+        XCTAssertEqual(
+            reconciled.endpointEvaluations[0].failure,
+            EndpointEvaluationFailure(reason: .interrupted)
+        )
+        XCTAssertNil(reconciled.endpointEvaluations[0].proposal)
+
+        let duplicate = try await restored.apply(
+            .reconcileInterruptedEndpointEvaluation(
+                commandID: CommandID("interrupted-reconcile"),
+                evaluationID: evaluationID
+            )
+        )
+        XCTAssertEqual(duplicate.disposition, .alreadyApplied)
+        XCTAssertEqual(duplicate.snapshot.endpointEvaluations.count, 1)
+    }
+
+    func testInvalidProposalDoesNotChangeAuthorizedEvaluation() async throws {
+        let session = try await makePatientAutoSession(
+            store: InMemorySessionManifestStore()
+        )
+        let evidence = try await makeTranscribedSegment(
+            session: session,
+            commandStem: "invalid-outcome",
+            body: "An unfinished answer.",
+            quality: .verified
+        )
+        let context = endpointContext(body: evidence.body)
+        let fingerprint = try InterviewRoomSession.endpointContextFingerprint(
+            context,
+            triggerSegmentID: evidence.segmentID,
+            selectedCandidateIDs: [evidence.candidateID],
+            questionTurnID: nil
+        )
+        let authorized = try await session.execute(
+            .authorizeEndpointEvaluation(
+                commandID: CommandID("invalid-outcome-authorize"),
+                triggerSegmentID: evidence.segmentID,
+                selectedCandidateIDs: [evidence.candidateID],
+                questionTurnID: nil,
+                contextFingerprint: fingerprint
+            )
+        )
+        let evaluationID = try XCTUnwrap(authorized.endpointEvaluations.first?.id)
+
+        do {
+            _ = try await session.execute(
+                .recordEndpointEvaluationOutcome(
+                    commandID: CommandID("invalid-outcome-record"),
+                    evaluationID: evaluationID,
+                    outcome: .proposal(
+                        SemanticEndpointProposal(
+                            decision: .likelyEnd,
+                            reasonCode: .unfinishedThought
+                        )
+                    )
+                )
+            )
+            XCTFail("Expected inconsistent proposal to be rejected")
+        } catch {
+            XCTAssertEqual(
+                error as? InterviewRoomSessionError,
+                .invalidEndpointEvaluationOutcome
+            )
+        }
+
+        let unchanged = await session.snapshot()
+        XCTAssertEqual(unchanged, authorized)
+    }
+
+    private func makePatientAutoSession(
+        store: InMemorySessionManifestStore
+    ) async throws -> InterviewRoomSession {
+        let session = try await InterviewRoomSession.start(
+            sessionID: SessionID("endpoint-session-\(UUID().uuidString)"),
+            activityID: "endpoint-activity",
+            activityPrompt: try fixtureActivityPrompt(),
+            turnMode: .patientAuto,
+            manifestStore: store,
+            interviewerRuntime: fixtureRuntime()
+        )
+        _ = try await session.execute(
+            .giveCandidateFloor(commandID: CommandID("endpoint-floor-\(UUID().uuidString)"))
+        )
+        return session
+    }
+
+    private func makeTranscribedSegment(
+        session: InterviewRoomSession,
+        commandStem: String,
+        body: String,
+        quality: TranscriptQuality
+    ) async throws -> EndpointEvidenceFixture {
+        let begun = try await session.execute(
+            .beginSegment(commandID: CommandID("\(commandStem)-begin"))
+        )
+        let segmentID = try XCTUnwrap(begun.segments.last?.id)
+        _ = try await session.execute(
+            .recordSegmentCaptureOutcome(
+                commandID: CommandID("\(commandStem)-recording"),
+                segmentID: segmentID,
+                outcome: .recordingStarted
+            )
+        )
+        _ = try await session.execute(
+            .finalizeSegment(
+                commandID: CommandID("\(commandStem)-finalize"),
+                segmentID: segmentID
+            )
+        )
+        _ = try await session.execute(
+            .recordSegmentCaptureOutcome(
+                commandID: CommandID("\(commandStem)-capture"),
+                segmentID: segmentID,
+                outcome: .finalized(try capturedAudio("\(commandStem).m4a"))
+            )
+        )
+        let candidateID = try await recordCandidate(
+            session: session,
+            segmentID: segmentID,
+            commandStem: "\(commandStem)-transcription",
+            kind: .initial,
+            body: body,
+            quality: quality
+        )
+        return EndpointEvidenceFixture(
+            segmentID: segmentID,
+            candidateID: candidateID,
+            body: body
+        )
+    }
+
+    private func recordRetryCandidate(
+        session: InterviewRoomSession,
+        segmentID: SegmentID,
+        commandStem: String,
+        body: String,
+        quality: TranscriptQuality
+    ) async throws -> TranscriptCandidateID {
+        try await recordCandidate(
+            session: session,
+            segmentID: segmentID,
+            commandStem: commandStem,
+            kind: .retry,
+            body: body,
+            quality: quality
+        )
+    }
+
+    private func recordCandidate(
+        session: InterviewRoomSession,
+        segmentID: SegmentID,
+        commandStem: String,
+        kind: SegmentTranscriptionKind,
+        body: String,
+        quality: TranscriptQuality
+    ) async throws -> TranscriptCandidateID {
+        let authorized = try await session.execute(
+            .authorizeSegmentTranscription(
+                commandID: CommandID("\(commandStem)-authorize"),
+                segmentID: segmentID,
+                kind: kind,
+                credentialFingerprint: InterviewRoomSession.credentialFingerprint(
+                    "public-safe-fixture-key"
+                )
+            )
+        )
+        let segment = try XCTUnwrap(authorized.segments.first(where: {
+            $0.id == segmentID
+        }))
+        let attempt = try XCTUnwrap(segment.transcriptionAttempts.last)
+        let completed = try await session.execute(
+            .recordSegmentTranscriptionOutcome(
+                commandID: CommandID("\(commandStem)-outcome"),
+                segmentID: segmentID,
+                attemptID: attempt.id,
+                outcome: .candidate(
+                    SegmentTranscriptionResult(body: body, quality: quality)
+                )
+            )
+        )
+        let completedSegment = try XCTUnwrap(completed.segments.first(where: {
+            $0.id == segmentID
+        }))
+        return try XCTUnwrap(completedSegment.selectedCandidateID)
+    }
+
+    private func capturedAudio(_ fileName: String) throws -> CapturedAudioSegment {
+        CapturedAudioSegment(
+            audioIdentity: try SegmentAudioIdentity(validating: fileName),
+            startedAtMilliseconds: 100,
+            endedAtMilliseconds: 2_100,
+            durationMilliseconds: 2_000,
+            decodedDurationMilliseconds: 2_000,
+            byteCount: 8_192,
+            isPlayable: true,
+            isPartial: false
+        )
+    }
+
+    private func endpointContext(body: String) -> SemanticEndpointContext {
+        SemanticEndpointContext(
+            interviewerQuestion: "Design a global notification system.",
+            requestedParts: ["Explain reliability."],
+            accumulatedAnswer: body,
+            latestSegment: body,
+            silenceDurationMilliseconds: 0,
+            specialty: ActivitySpecialty.systemDesign.rawValue,
+            stage: "High-level design",
+            explicitCue: false,
+            workspaceActivity: []
+        )
+    }
+
+    private func fixtureActivityPrompt() throws -> ActivityPrompt {
+        try ActivityPrompt(
+            specialty: .systemDesign,
+            stage: "High-level design",
+            question: "Design a global notification system.",
+            requestedParts: ["Explain reliability."]
+        )
+    }
+
+    private func fixtureRuntime() -> DeterministicInterviewerRuntime {
+        DeterministicInterviewerRuntime(
+            response: CanonicalInterviewerResponse(
+                displayMarkdown: "What would you test next?",
+                spokenText: "What would you test next?"
+            )
+        )
+    }
+}
+
+private struct EndpointEvidenceFixture {
+    let segmentID: SegmentID
+    let candidateID: TranscriptCandidateID
+    let body: String
+}

--- a/Tests/InterviewArcLiveCoreTests/GroqEndpointClassifierTests.swift
+++ b/Tests/InterviewArcLiveCoreTests/GroqEndpointClassifierTests.swift
@@ -14,7 +14,10 @@ final class GroqEndpointClassifierTests: XCTestCase {
       statusCode: 200,
       body: responseBody(decision: "likely_continue", reason: "requested_part_unanswered")
     )
-    let classifier = GroqEndpointClassifier(apiKey: "private-test-key", transport: transport)
+    let classifier = GroqEndpointClassifier(
+      credentialReader: FixedEndpointCredentialReader("private-test-key"),
+      transport: transport
+    )
     let context = SemanticEndpointContext(
       interviewerQuestion: "How are you, and why did you choose BFS?",
       requestedParts: ["Describe how you are", "Explain the BFS choice"],
@@ -108,7 +111,10 @@ final class GroqEndpointClassifierTests: XCTestCase {
         statusCode: 200,
         body: responseBody(decision: decision, reason: reason)
       )
-      let classifier = GroqEndpointClassifier(apiKey: "test-key", transport: transport)
+      let classifier = GroqEndpointClassifier(
+        credentialReader: FixedEndpointCredentialReader("test-key"),
+        transport: transport
+      )
       let actual = try await classifier.classify(validContext)
       XCTAssertEqual(actual, expected)
     }
@@ -122,7 +128,10 @@ final class GroqEndpointClassifierTests: XCTestCase {
       statusCode: 200,
       body: chatResponse(content: content)
     )
-    let classifier = GroqEndpointClassifier(apiKey: "test-key", transport: transport)
+    let classifier = GroqEndpointClassifier(
+      credentialReader: FixedEndpointCredentialReader("test-key"),
+      transport: transport
+    )
 
     await assertClassifierError(.invalidClassification) {
       try await classifier.classify(validContext)
@@ -134,7 +143,10 @@ final class GroqEndpointClassifierTests: XCTestCase {
       statusCode: 200,
       body: responseBody(decision: "done", reason: "answer_resolves_question")
     )
-    let classifier = GroqEndpointClassifier(apiKey: "test-key", transport: transport)
+    let classifier = GroqEndpointClassifier(
+      credentialReader: FixedEndpointCredentialReader("test-key"),
+      transport: transport
+    )
 
     await assertClassifierError(.invalidClassification) {
       try await classifier.classify(validContext)
@@ -146,7 +158,10 @@ final class GroqEndpointClassifierTests: XCTestCase {
       statusCode: 200,
       body: responseBody(decision: "likely_end", reason: "unfinished_thought")
     )
-    let classifier = GroqEndpointClassifier(apiKey: "test-key", transport: transport)
+    let classifier = GroqEndpointClassifier(
+      credentialReader: FixedEndpointCredentialReader("test-key"),
+      transport: transport
+    )
 
     await assertClassifierError(.invalidClassification) {
       try await classifier.classify(validContext)
@@ -158,7 +173,10 @@ final class GroqEndpointClassifierTests: XCTestCase {
       statusCode: 200,
       body: responseBody(decision: "ambiguous", reason: "insufficient_evidence")
     )
-    let classifier = GroqEndpointClassifier(apiKey: "test-key", transport: transport)
+    let classifier = GroqEndpointClassifier(
+      credentialReader: FixedEndpointCredentialReader("test-key"),
+      transport: transport
+    )
     let context = SemanticEndpointContext(
       interviewerQuestion: String(repeating: "q", count: 16 * 1_024 + 1),
       requestedParts: [],
@@ -181,7 +199,7 @@ final class GroqEndpointClassifierTests: XCTestCase {
   func testTransportAndProviderErrorsExposeNoPayloadOrCredential() async throws {
     let failingTransport = RecordingGroqTransport(failure: true)
     let transportClassifier = GroqEndpointClassifier(
-      apiKey: "must-never-appear",
+      credentialReader: FixedEndpointCredentialReader("must-never-appear"),
       transport: failingTransport
     )
 
@@ -194,12 +212,65 @@ final class GroqEndpointClassifierTests: XCTestCase {
       body: Data("provider diagnostic containing request data".utf8)
     )
     let rejectedClassifier = GroqEndpointClassifier(
-      apiKey: "must-never-appear",
+      credentialReader: FixedEndpointCredentialReader("must-never-appear"),
       transport: rejectedTransport
     )
     await assertClassifierError(.rejected(statusCode: 429)) {
       try await rejectedClassifier.classify(validContext)
     }
+  }
+
+  func testReadsTheCurrentCredentialForEveryRequest() async throws {
+    let credentialReader = RotatingEndpointCredentialReader([
+      "first-private-key",
+      "second-private-key",
+    ])
+    let transport = RecordingGroqTransport(
+      statusCode: 200,
+      body: responseBody(decision: "ambiguous", reason: "insufficient_evidence")
+    )
+    let classifier = GroqEndpointClassifier(
+      credentialReader: credentialReader,
+      transport: transport
+    )
+
+    _ = try await classifier.classify(validContext)
+    _ = try await classifier.classify(validContext)
+
+    let requests = await transport.recordedRequests()
+    XCTAssertEqual(requests.count, 2)
+    XCTAssertEqual(
+      requests[0].value(forHTTPHeaderField: "Authorization"),
+      "Bearer first-private-key"
+    )
+    XCTAssertEqual(
+      requests[1].value(forHTTPHeaderField: "Authorization"),
+      "Bearer second-private-key"
+    )
+    let credentialReadCount = await credentialReader.readCount()
+    XCTAssertEqual(credentialReadCount, 2)
+  }
+
+  func testMissingOrUnreadableCurrentCredentialFailsBeforeTransport() async {
+    let transport = RecordingGroqTransport()
+    let missingClassifier = GroqEndpointClassifier(
+      credentialReader: FixedEndpointCredentialReader("  \n"),
+      transport: transport
+    )
+    await assertClassifierError(.missingCredential) {
+      try await missingClassifier.classify(validContext)
+    }
+
+    let unreadableClassifier = GroqEndpointClassifier(
+      credentialReader: FailingEndpointCredentialReader(),
+      transport: transport
+    )
+    await assertClassifierError(.missingCredential) {
+      try await unreadableClassifier.classify(validContext)
+    }
+
+    let requests = await transport.recordedRequests()
+    XCTAssertTrue(requests.isEmpty)
   }
 
   func testDeterministicAdapterUsesTheSameClassifierSeam() async throws {
@@ -264,7 +335,7 @@ private actor RecordingGroqTransport: GroqEndpointTransport {
   private let statusCode: Int
   private let body: Data
   private let failure: Bool
-  private var request: URLRequest?
+  private var requests: [URLRequest] = []
 
   init(statusCode: Int = 200, body: Data = Data(), failure: Bool = false) {
     self.statusCode = statusCode
@@ -273,7 +344,7 @@ private actor RecordingGroqTransport: GroqEndpointTransport {
   }
 
   func send(_ request: URLRequest) async throws -> (Data, HTTPURLResponse) {
-    self.request = request
+    requests.append(request)
     if failure {
       throw RecordingTransportError.failure
     }
@@ -287,8 +358,55 @@ private actor RecordingGroqTransport: GroqEndpointTransport {
   }
 
   func recordedRequest() -> URLRequest? {
-    request
+    requests.last
   }
+
+  func recordedRequests() -> [URLRequest] {
+    requests
+  }
+}
+
+private struct FixedEndpointCredentialReader: GroqCredentialReading {
+  private let value: String
+
+  init(_ value: String) {
+    self.value = value
+  }
+
+  func readGroqCredential() -> String {
+    value
+  }
+}
+
+private actor RotatingEndpointCredentialReader: GroqCredentialReading {
+  private let values: [String]
+  private var index = 0
+
+  init(_ values: [String]) {
+    self.values = values
+  }
+
+  func readGroqCredential() throws -> String {
+    guard index < values.count else {
+      throw EndpointCredentialReaderError.unavailable
+    }
+    defer { index += 1 }
+    return values[index]
+  }
+
+  func readCount() -> Int {
+    index
+  }
+}
+
+private struct FailingEndpointCredentialReader: GroqCredentialReading {
+  func readGroqCredential() throws -> String {
+    throw EndpointCredentialReaderError.unavailable
+  }
+}
+
+private enum EndpointCredentialReaderError: Error {
+  case unavailable
 }
 
 private enum RecordingTransportError: Error {

--- a/Tests/InterviewArcLiveCoreTests/SegmentLifecycleTests.swift
+++ b/Tests/InterviewArcLiveCoreTests/SegmentLifecycleTests.swift
@@ -1085,6 +1085,193 @@ final class SegmentLifecycleTests: XCTestCase {
         XCTAssertEqual(completed.phase, .candidateFloor)
     }
 
+    func testPatientAutoAuthorizationPersistenceFailureKeepsSuccessfulTranscript() async throws {
+        let store = EndpointWriteFailingSessionManifestStore(failurePoint: .authorization)
+        let classifier = RecordingSemanticEndpointClassifier(
+            results: [
+                .success(
+                    SemanticEndpointProposal(
+                        decision: .likelyEnd,
+                        reasonCode: .answerResolvesQuestion
+                    )
+                )
+            ]
+        )
+        let transcriber = SequencedSegmentTranscriber(
+            results: [
+                .success(
+                    SegmentTranscriptionResult(
+                        body: "The transcript remains the successful operation.",
+                        quality: .verified
+                    )
+                )
+            ]
+        )
+        let coordinator = try await SegmentSpeechCoordinator.open(
+            sessionID: SessionID("endpoint-authorization-write-failure"),
+            activityID: "endpoint-authorization-write-failure-activity",
+            activityPrompt: try fixtureActivityPrompt(),
+            turnMode: .patientAuto,
+            manifestStore: store,
+            interviewerRuntime: fixtureRuntime(),
+            recording: StubSegmentRecorder(
+                capture: try capturedAudio(fileName: "endpoint-authorization-write-failure.m4a")
+            ),
+            transcriber: transcriber,
+            credentialReader: FixedCredentialReader(value: "credential"),
+            semanticEndpointClassifier: classifier
+        )
+        _ = try await coordinator.giveCandidateFloor(
+            commandID: CommandID("endpoint-authorization-write-failure-floor")
+        )
+        _ = try await coordinator.beginSegment(
+            commandID: CommandID("endpoint-authorization-write-failure-begin")
+        )
+
+        let completed = try await coordinator.finishSegment(
+            commandID: CommandID("endpoint-authorization-write-failure-finish"),
+            transcriptionCommandID: CommandID("endpoint-authorization-write-failure-transcribe")
+        )
+
+        XCTAssertEqual(
+            completed.segments.first?.selectedCandidate?.body,
+            "The transcript remains the successful operation."
+        )
+        XCTAssertTrue(completed.endpointEvaluations.isEmpty)
+        let classifierCalls = await classifier.invocationCount()
+        let transcriptionCalls = await transcriber.invocationCount()
+        XCTAssertEqual(classifierCalls, 0)
+        XCTAssertEqual(transcriptionCalls, 1)
+        let durable = await store.load(sessionID: completed.sessionID)
+        XCTAssertEqual(durable?.revision, completed.revision)
+        XCTAssertEqual(durable?.segments, completed.segments)
+        XCTAssertEqual(durable?.endpointEvaluations, completed.endpointEvaluations)
+    }
+
+    func testPatientAutoOutcomePersistenceFailureReconcilesAuthorization() async throws {
+        let store = EndpointWriteFailingSessionManifestStore(failurePoint: .outcome)
+        let classifier = RecordingSemanticEndpointClassifier(
+            results: [
+                .success(
+                    SemanticEndpointProposal(
+                        decision: .likelyEnd,
+                        reasonCode: .answerResolvesQuestion
+                    )
+                )
+            ]
+        )
+        let transcriber = SequencedSegmentTranscriber(
+            results: [
+                .success(
+                    SegmentTranscriptionResult(
+                        body: "The transcript survives Shadow persistence recovery.",
+                        quality: .verified
+                    )
+                )
+            ]
+        )
+        let coordinator = try await SegmentSpeechCoordinator.open(
+            sessionID: SessionID("endpoint-outcome-write-failure"),
+            activityID: "endpoint-outcome-write-failure-activity",
+            activityPrompt: try fixtureActivityPrompt(),
+            turnMode: .patientAuto,
+            manifestStore: store,
+            interviewerRuntime: fixtureRuntime(),
+            recording: StubSegmentRecorder(
+                capture: try capturedAudio(fileName: "endpoint-outcome-write-failure.m4a")
+            ),
+            transcriber: transcriber,
+            credentialReader: FixedCredentialReader(value: "credential"),
+            semanticEndpointClassifier: classifier
+        )
+        _ = try await coordinator.giveCandidateFloor(
+            commandID: CommandID("endpoint-outcome-write-failure-floor")
+        )
+        _ = try await coordinator.beginSegment(
+            commandID: CommandID("endpoint-outcome-write-failure-begin")
+        )
+
+        let completed = try await coordinator.finishSegment(
+            commandID: CommandID("endpoint-outcome-write-failure-finish"),
+            transcriptionCommandID: CommandID("endpoint-outcome-write-failure-transcribe")
+        )
+
+        XCTAssertEqual(
+            completed.segments.first?.selectedCandidate?.body,
+            "The transcript survives Shadow persistence recovery."
+        )
+        let evaluation = try XCTUnwrap(completed.endpointEvaluations.first)
+        XCTAssertEqual(evaluation.lifecycle, .failed)
+        XCTAssertEqual(evaluation.failure?.reason, .interrupted)
+        XCTAssertNil(evaluation.proposal)
+        let classifierCalls = await classifier.invocationCount()
+        let transcriptionCalls = await transcriber.invocationCount()
+        XCTAssertEqual(classifierCalls, 1)
+        XCTAssertEqual(transcriptionCalls, 1)
+        let durable = await store.load(sessionID: completed.sessionID)
+        XCTAssertEqual(durable?.revision, completed.revision)
+        XCTAssertEqual(durable?.segments, completed.segments)
+        XCTAssertEqual(durable?.endpointEvaluations, completed.endpointEvaluations)
+    }
+
+    func testInFlightProposalBecomesInterruptedAfterConcurrentHandOff() async throws {
+        let classifier = SuspendedSemanticEndpointClassifier(
+            proposal: SemanticEndpointProposal(
+                decision: .likelyEnd,
+                reasonCode: .answerResolvesQuestion
+            )
+        )
+        let coordinator = try await SegmentSpeechCoordinator.open(
+            sessionID: SessionID("endpoint-concurrent-handoff"),
+            activityID: "endpoint-concurrent-handoff-activity",
+            activityPrompt: try fixtureActivityPrompt(),
+            turnMode: .patientAuto,
+            manifestStore: InMemorySessionManifestStore(),
+            interviewerRuntime: fixtureRuntime(),
+            recording: StubSegmentRecorder(
+                capture: try capturedAudio(fileName: "endpoint-concurrent-handoff.m4a")
+            ),
+            transcriber: SequencedSegmentTranscriber(
+                results: [
+                    .success(
+                        SegmentTranscriptionResult(
+                            body: "This answer is handed off while classification is pending.",
+                            quality: .verified
+                        )
+                    )
+                ]
+            ),
+            credentialReader: FixedCredentialReader(value: "credential"),
+            semanticEndpointClassifier: classifier
+        )
+        _ = try await coordinator.giveCandidateFloor(
+            commandID: CommandID("endpoint-concurrent-handoff-floor")
+        )
+        _ = try await coordinator.beginSegment(
+            commandID: CommandID("endpoint-concurrent-handoff-begin")
+        )
+
+        let finishing = Task { @MainActor in
+            try await coordinator.finishSegment(
+                commandID: CommandID("endpoint-concurrent-handoff-finish"),
+                transcriptionCommandID: CommandID("endpoint-concurrent-handoff-transcribe")
+            )
+        }
+        await classifier.waitUntilInvoked()
+        let handedOff = try await coordinator.handOff(
+            commandID: CommandID("endpoint-concurrent-handoff-turn")
+        )
+        XCTAssertEqual(handedOff.phase, .interviewerTurn)
+        await classifier.resume()
+
+        let completed = try await finishing.value
+        let evaluation = try XCTUnwrap(completed.endpointEvaluations.first)
+        XCTAssertEqual(completed.phase, .interviewerTurn)
+        XCTAssertEqual(evaluation.lifecycle, .failed)
+        XCTAssertEqual(evaluation.failure?.reason, .interrupted)
+        XCTAssertNil(evaluation.proposal)
+    }
+
     func testPatientAutoMapsClassifierErrorsToSafeDurableFailures() async throws {
         let cases: [(
             name: String,
@@ -1830,6 +2017,41 @@ private actor RecordingSemanticEndpointClassifier: SemanticEndpointClassifying {
     func authorizationStatesAtEntry() -> [Bool] { authorizationStates }
 }
 
+private actor SuspendedSemanticEndpointClassifier: SemanticEndpointClassifying {
+    private let proposal: SemanticEndpointProposal
+    private var didEnter = false
+    private var entryWaiters: [CheckedContinuation<Void, Never>] = []
+    private var resultContinuation: CheckedContinuation<SemanticEndpointProposal, Never>?
+
+    init(proposal: SemanticEndpointProposal) {
+        self.proposal = proposal
+    }
+
+    func classify(
+        _ context: SemanticEndpointContext
+    ) async throws -> SemanticEndpointProposal {
+        didEnter = true
+        let waiters = entryWaiters
+        entryWaiters.removeAll()
+        waiters.forEach { $0.resume() }
+        return await withCheckedContinuation { continuation in
+            resultContinuation = continuation
+        }
+    }
+
+    func waitUntilInvoked() async {
+        if didEnter { return }
+        await withCheckedContinuation { continuation in
+            entryWaiters.append(continuation)
+        }
+    }
+
+    func resume() {
+        resultContinuation?.resume(returning: proposal)
+        resultContinuation = nil
+    }
+}
+
 private actor CountingInterviewerRuntime: InterviewerRuntime {
     private var calls = 0
 
@@ -1888,6 +2110,52 @@ private actor FailingRevisionSessionManifestStore: SessionManifestStore {
                 expected: expectedRevision,
                 actual: current?.revision
             )
+        }
+        manifests[manifest.sessionID] = manifest
+    }
+}
+
+private enum EndpointWriteFailurePoint {
+    case authorization
+    case outcome
+}
+
+private actor EndpointWriteFailingSessionManifestStore: SessionManifestStore {
+    private var manifests: [SessionID: SessionManifest] = [:]
+    private let failurePoint: EndpointWriteFailurePoint
+    private var didFail = false
+
+    init(failurePoint: EndpointWriteFailurePoint) {
+        self.failurePoint = failurePoint
+    }
+
+    func load(sessionID: SessionID) -> SessionManifest? {
+        manifests[sessionID]
+    }
+
+    func save(
+        _ manifest: SessionManifest,
+        expectedRevision: Int?
+    ) throws {
+        let current = manifests[manifest.sessionID]
+        guard current?.revision == expectedRevision else {
+            throw SessionManifestStoreError.revisionConflict(
+                expected: expectedRevision,
+                actual: current?.revision
+            )
+        }
+        let isAuthorization = current?.endpointEvaluations.count
+            != manifest.endpointEvaluations.count
+            && manifest.endpointEvaluations.last?.lifecycle == .authorized
+        let isOutcome = current?.endpointEvaluations.last?.lifecycle == .authorized
+            && manifest.endpointEvaluations.last?.lifecycle != .authorized
+        let shouldFail = switch failurePoint {
+        case .authorization: isAuthorization
+        case .outcome: isOutcome
+        }
+        if shouldFail, !didFail {
+            didFail = true
+            throw InjectedStoreError.writeFailed
         }
         manifests[manifest.sessionID] = manifest
     }

--- a/Tests/InterviewArcLiveCoreTests/SegmentLifecycleTests.swift
+++ b/Tests/InterviewArcLiveCoreTests/SegmentLifecycleTests.swift
@@ -684,7 +684,7 @@ final class SegmentLifecycleTests: XCTestCase {
         XCTAssertEqual(failed.lifecycle, .failed)
         XCTAssertEqual(failed.captureFailureReason, .noPlayableAudio)
         XCTAssertEqual(failed.capturedAudio, nonPlayable)
-        let durable = try await store.load(sessionID: finalized.sessionID)
+        let durable = await store.load(sessionID: finalized.sessionID)
         XCTAssertEqual(durable?.segments.first?.capturedAudio, nonPlayable)
 
         let next = try await coordinator.beginSegment(
@@ -787,8 +787,671 @@ final class SegmentLifecycleTests: XCTestCase {
             recovered.segments[0].capturedAudio?.audioIdentity.fileName,
             "start-persistence-recovery.m4a"
         )
-        let durable = try await store.load(sessionID: coordinator.snapshot.sessionID)
+        let durable = await store.load(sessionID: coordinator.snapshot.sessionID)
         XCTAssertEqual(durable?.segments[0].lifecycle, .audioReady)
+    }
+
+    func testManualAndCueOnlyNeverInvokeSemanticEndpointClassifier() async throws {
+        for mode in [TurnMode.manual, .cueOnly] {
+            let classifier = RecordingSemanticEndpointClassifier(
+                results: [
+                    .success(
+                        SemanticEndpointProposal(
+                            decision: .likelyEnd,
+                            reasonCode: .answerResolvesQuestion
+                        )
+                    )
+                ]
+            )
+            let coordinator = try await SegmentSpeechCoordinator.open(
+                sessionID: SessionID("endpoint-off-\(mode.rawValue)"),
+                activityID: "endpoint-off-activity",
+                activityPrompt: try fixtureActivityPrompt(),
+                turnMode: mode,
+                manifestStore: InMemorySessionManifestStore(),
+                interviewerRuntime: fixtureRuntime(),
+                recording: StubSegmentRecorder(
+                    capture: try capturedAudio(fileName: "endpoint-off.m4a")
+                ),
+                transcriber: SequencedSegmentTranscriber(
+                    results: [
+                        .success(
+                            SegmentTranscriptionResult(
+                                body: "A durable manual answer.",
+                                quality: .verified
+                            )
+                        )
+                    ]
+                ),
+                credentialReader: FixedCredentialReader(value: "credential"),
+                semanticEndpointClassifier: classifier
+            )
+            _ = try await coordinator.giveCandidateFloor(
+                commandID: CommandID("endpoint-off-floor-\(mode.rawValue)")
+            )
+            _ = try await coordinator.beginSegment(
+                commandID: CommandID("endpoint-off-begin-\(mode.rawValue)")
+            )
+            let completed = try await coordinator.finishSegment(
+                commandID: CommandID("endpoint-off-finish-\(mode.rawValue)"),
+                transcriptionCommandID: CommandID("endpoint-off-transcribe-\(mode.rawValue)")
+            )
+
+            let classifierCalls = await classifier.invocationCount()
+            XCTAssertEqual(classifierCalls, 0)
+            XCTAssertTrue(completed.endpointEvaluations.isEmpty)
+            XCTAssertEqual(completed.phase, .candidateFloor)
+            XCTAssertTrue(completed.turns.isEmpty)
+        }
+    }
+
+    func testPatientAutoPersistsAuthorizationBeforeExactShadowContextAndProposal() async throws {
+        let store = InMemorySessionManifestStore()
+        let session = try await makeCandidateFloorSession(
+            store: store,
+            turnMode: .patientAuto
+        )
+        _ = try await makeTranscribedSegment(
+            session: session,
+            commandStem: "endpoint-first",
+            body: "  first spoken part  ",
+            quality: .verified
+        )
+        let restored = await session.snapshot()
+        let classifier = RecordingSemanticEndpointClassifier(
+            results: [
+                .success(
+                    SemanticEndpointProposal(
+                        decision: .likelyContinue,
+                        reasonCode: .requestedPartUnanswered
+                    )
+                )
+            ],
+            authorizationStore: store,
+            sessionID: restored.sessionID
+        )
+        let interviewerRuntime = CountingInterviewerRuntime()
+        let coordinator = try await SegmentSpeechCoordinator.open(
+            sessionID: restored.sessionID,
+            activityID: restored.activityID,
+            activityPrompt: restored.activityPrompt,
+            manifestStore: store,
+            interviewerRuntime: interviewerRuntime,
+            recording: StubSegmentRecorder(
+                capture: try capturedAudio(fileName: "endpoint-second.m4a")
+            ),
+            transcriber: SequencedSegmentTranscriber(
+                results: [
+                    .success(
+                        SegmentTranscriptionResult(
+                            body: "\n second spoken part \n",
+                            quality: .verified
+                        )
+                    )
+                ]
+            ),
+            credentialReader: FixedCredentialReader(value: "credential"),
+            semanticEndpointClassifier: classifier
+        )
+        _ = try await coordinator.beginSegment(
+            commandID: CommandID("endpoint-second-begin")
+        )
+        let completed = try await coordinator.finishSegment(
+            commandID: CommandID("endpoint-second-finish"),
+            transcriptionCommandID: CommandID("endpoint-second-transcribe")
+        )
+
+        let contexts = await classifier.recordedContexts()
+        let context = try XCTUnwrap(contexts.first)
+        XCTAssertEqual(context.interviewerQuestion, restored.activityPrompt.question)
+        XCTAssertEqual(context.requestedParts, restored.activityPrompt.requestedParts)
+        XCTAssertEqual(context.accumulatedAnswer, "first spoken part\n\nsecond spoken part")
+        XCTAssertEqual(context.latestSegment, "second spoken part")
+        XCTAssertEqual(context.silenceDurationMilliseconds, 0)
+        XCTAssertEqual(context.specialty, "system_design")
+        XCTAssertEqual(context.stage, restored.activityPrompt.stage)
+        XCTAssertFalse(context.explicitCue)
+        XCTAssertTrue(context.workspaceActivity.isEmpty)
+
+        let authorizationStates = await classifier.authorizationStatesAtEntry()
+        XCTAssertEqual(authorizationStates, [true])
+        let evaluation = try XCTUnwrap(completed.endpointEvaluations.last)
+        XCTAssertEqual(evaluation.lifecycle, .proposalStored)
+        XCTAssertEqual(
+            evaluation.proposal,
+            SemanticEndpointProposal(
+                decision: .likelyContinue,
+                reasonCode: .requestedPartUnanswered
+            )
+        )
+        let selectedCandidateIDs = completed.segments
+            .filter { $0.committedTurnID == nil && $0.lifecycle != .excluded }
+            .sorted { $0.ordinal < $1.ordinal }
+            .compactMap(\.selectedCandidateID)
+        XCTAssertEqual(evaluation.selectedCandidateIDs, selectedCandidateIDs)
+        XCTAssertNil(evaluation.questionTurnID)
+        XCTAssertEqual(completed.phase, .candidateFloor)
+        XCTAssertTrue(completed.turns.isEmpty)
+        let interviewerCalls = await interviewerRuntime.invocationCount()
+        XCTAssertEqual(interviewerCalls, 0)
+    }
+
+    func testPatientAutoLaterFloorUsesLatestCanonicalInterviewerQuestionAndRestoresMode() async throws {
+        let store = InMemorySessionManifestStore()
+        let classifier = RecordingSemanticEndpointClassifier(
+            results: [
+                .success(
+                    SemanticEndpointProposal(
+                        decision: .likelyEnd,
+                        reasonCode: .answerResolvesQuestion
+                    )
+                ),
+                .success(
+                    SemanticEndpointProposal(
+                        decision: .likelyContinue,
+                        reasonCode: .unfinishedThought
+                    )
+                ),
+            ]
+        )
+        let runtime = CountingInterviewerRuntime()
+        let coordinator = try await SegmentSpeechCoordinator.open(
+            sessionID: SessionID("endpoint-later-floor"),
+            activityID: "endpoint-later-floor-activity",
+            activityPrompt: try fixtureActivityPrompt(),
+            turnMode: .patientAuto,
+            manifestStore: store,
+            interviewerRuntime: runtime,
+            recording: StubSegmentRecorder(
+                capture: try capturedAudio(fileName: "endpoint-later-floor.m4a")
+            ),
+            transcriber: SequencedSegmentTranscriber(
+                results: [
+                    .success(
+                        SegmentTranscriptionResult(
+                            body: "Initial answer.",
+                            quality: .verified
+                        )
+                    ),
+                    .success(
+                        SegmentTranscriptionResult(
+                            body: "Later-floor answer.",
+                            quality: .verified
+                        )
+                    ),
+                ]
+            ),
+            credentialReader: FixedCredentialReader(value: "credential"),
+            semanticEndpointClassifier: classifier
+        )
+        _ = try await coordinator.giveCandidateFloor(
+            commandID: CommandID("endpoint-later-floor-initial-floor")
+        )
+        _ = try await coordinator.beginSegment(
+            commandID: CommandID("endpoint-later-floor-first-begin")
+        )
+        _ = try await coordinator.finishSegment(
+            commandID: CommandID("endpoint-later-floor-first-finish"),
+            transcriptionCommandID: CommandID("endpoint-later-floor-first-transcribe")
+        )
+        let interviewerTurn = try await coordinator.handOff(
+            commandID: CommandID("endpoint-later-floor-hand-off")
+        )
+        guard case .interviewer(let canonicalQuestion) = interviewerTurn.turns.last else {
+            return XCTFail("Expected the canonical Interviewer Turn")
+        }
+        _ = try await coordinator.giveCandidateFloor(
+            commandID: CommandID("endpoint-later-floor-second-floor")
+        )
+        _ = try await coordinator.beginSegment(
+            commandID: CommandID("endpoint-later-floor-second-begin")
+        )
+        let completed = try await coordinator.finishSegment(
+            commandID: CommandID("endpoint-later-floor-second-finish"),
+            transcriptionCommandID: CommandID("endpoint-later-floor-second-transcribe")
+        )
+
+        let contexts = await classifier.recordedContexts()
+        XCTAssertEqual(contexts.count, 2)
+        XCTAssertEqual(contexts[1].interviewerQuestion, canonicalQuestion.displayMarkdown)
+        XCTAssertEqual(contexts[1].requestedParts, [])
+        XCTAssertEqual(contexts[1].accumulatedAnswer, "Later-floor answer.")
+        XCTAssertEqual(completed.endpointEvaluations.last?.questionTurnID, canonicalQuestion.id)
+
+        let restored = try await SegmentSpeechCoordinator.open(
+            sessionID: completed.sessionID,
+            activityID: completed.activityID,
+            activityPrompt: completed.activityPrompt,
+            manifestStore: store,
+            interviewerRuntime: runtime,
+            recording: StubSegmentRecorder(
+                capture: try capturedAudio(fileName: "endpoint-later-floor-restore.m4a")
+            ),
+            transcriber: SequencedSegmentTranscriber(results: []),
+            credentialReader: FixedCredentialReader(value: "credential"),
+            semanticEndpointClassifier: classifier
+        )
+        XCTAssertEqual(restored.snapshot.turnMode, .patientAuto)
+    }
+
+    func testPatientAutoStoresSafeClassifierFailureWithoutFailingTranscription() async throws {
+        let classifier = RecordingSemanticEndpointClassifier(
+            results: [.failure(.rejected(statusCode: 429))]
+        )
+        let coordinator = try await SegmentSpeechCoordinator.open(
+            sessionID: SessionID("endpoint-safe-failure"),
+            activityID: "endpoint-safe-failure-activity",
+            activityPrompt: try fixtureActivityPrompt(),
+            turnMode: .patientAuto,
+            manifestStore: InMemorySessionManifestStore(),
+            interviewerRuntime: fixtureRuntime(),
+            recording: StubSegmentRecorder(
+                capture: try capturedAudio(fileName: "endpoint-safe-failure.m4a")
+            ),
+            transcriber: SequencedSegmentTranscriber(
+                results: [
+                    .success(
+                        SegmentTranscriptionResult(
+                            body: "The transcript succeeds independently.",
+                            quality: .verified
+                        )
+                    )
+                ]
+            ),
+            credentialReader: FixedCredentialReader(value: "credential"),
+            semanticEndpointClassifier: classifier
+        )
+        _ = try await coordinator.giveCandidateFloor(
+            commandID: CommandID("endpoint-safe-failure-floor")
+        )
+        _ = try await coordinator.beginSegment(
+            commandID: CommandID("endpoint-safe-failure-begin")
+        )
+
+        let completed = try await coordinator.finishSegment(
+            commandID: CommandID("endpoint-safe-failure-finish"),
+            transcriptionCommandID: CommandID("endpoint-safe-failure-transcribe")
+        )
+
+        XCTAssertEqual(
+            completed.segments.first?.selectedCandidate?.body,
+            "The transcript succeeds independently."
+        )
+        let evaluation = try XCTUnwrap(completed.endpointEvaluations.first)
+        XCTAssertEqual(evaluation.lifecycle, .failed)
+        XCTAssertEqual(evaluation.failure?.reason, .providerRejected)
+        XCTAssertEqual(evaluation.failure?.providerStatusCode, 429)
+        XCTAssertNil(evaluation.proposal)
+        XCTAssertEqual(completed.phase, .candidateFloor)
+    }
+
+    func testPatientAutoMapsClassifierErrorsToSafeDurableFailures() async throws {
+        let cases: [(
+            name: String,
+            error: GroqEndpointClassifierError,
+            expectedReason: EndpointEvaluationFailureReason
+        )] = [
+            ("missing", .missingCredential, .missingCredential),
+            ("transport", .transportFailure, .transportFailure),
+            ("malformed", .malformedResponse, .invalidResponse),
+            (
+                "context-limit",
+                .contextLimitExceeded(.accumulatedAnswer),
+                .contextRejected
+            ),
+        ]
+
+        for testCase in cases {
+            let classifier = RecordingSemanticEndpointClassifier(
+                results: [.failure(testCase.error)]
+            )
+            let coordinator = try await SegmentSpeechCoordinator.open(
+                sessionID: SessionID("endpoint-safe-\(testCase.name)"),
+                activityID: "endpoint-safe-\(testCase.name)-activity",
+                activityPrompt: try fixtureActivityPrompt(),
+                turnMode: .patientAuto,
+                manifestStore: InMemorySessionManifestStore(),
+                interviewerRuntime: fixtureRuntime(),
+                recording: StubSegmentRecorder(
+                    capture: try capturedAudio(
+                        fileName: "endpoint-safe-\(testCase.name).m4a"
+                    )
+                ),
+                transcriber: SequencedSegmentTranscriber(
+                    results: [
+                        .success(
+                            SegmentTranscriptionResult(
+                                body: "Durable transcript for \(testCase.name).",
+                                quality: .verified
+                            )
+                        )
+                    ]
+                ),
+                credentialReader: FixedCredentialReader(value: "credential"),
+                semanticEndpointClassifier: classifier
+            )
+            _ = try await coordinator.giveCandidateFloor(
+                commandID: CommandID("endpoint-safe-\(testCase.name)-floor")
+            )
+            _ = try await coordinator.beginSegment(
+                commandID: CommandID("endpoint-safe-\(testCase.name)-begin")
+            )
+
+            let completed = try await coordinator.finishSegment(
+                commandID: CommandID("endpoint-safe-\(testCase.name)-finish"),
+                transcriptionCommandID: CommandID(
+                    "endpoint-safe-\(testCase.name)-transcribe"
+                )
+            )
+
+            XCTAssertEqual(completed.phase, .candidateFloor, testCase.name)
+            XCTAssertEqual(
+                completed.segments.first?.selectedCandidate?.body,
+                "Durable transcript for \(testCase.name).",
+                testCase.name
+            )
+            XCTAssertNotNil(completed.segments.first?.capturedAudio, testCase.name)
+            let evaluation = try XCTUnwrap(
+                completed.endpointEvaluations.first,
+                testCase.name
+            )
+            XCTAssertEqual(evaluation.lifecycle, .failed, testCase.name)
+            XCTAssertEqual(evaluation.failure?.reason, testCase.expectedReason, testCase.name)
+            XCTAssertNil(evaluation.failure?.providerStatusCode, testCase.name)
+            XCTAssertNil(evaluation.proposal, testCase.name)
+        }
+    }
+
+    func testEndpointEvaluationPersistsEveryValidDecisionReasonPairObservationally() async throws {
+        let pairs: [SemanticEndpointProposal] = [
+            .init(decision: .likelyEnd, reasonCode: .explicitHandoffCue),
+            .init(decision: .likelyEnd, reasonCode: .answerResolvesQuestion),
+            .init(decision: .likelyContinue, reasonCode: .unfinishedThought),
+            .init(decision: .likelyContinue, reasonCode: .requestedPartUnanswered),
+            .init(decision: .likelyContinue, reasonCode: .recentWorkspaceActivity),
+            .init(decision: .ambiguous, reasonCode: .insufficientEvidence),
+        ]
+        let store = InMemorySessionManifestStore()
+        let session = try await makeCandidateFloorSession(
+            store: store,
+            turnMode: .patientAuto
+        )
+        let segmentID = try await makeTranscribedSegment(
+            session: session,
+            commandStem: "endpoint-valid-pairs",
+            body: "Durable evidence remains on the Candidate Floor.",
+            quality: .verified
+        )
+        let selected = await session.snapshot()
+        let selectedCandidateIDs = selected.segments
+            .filter { $0.committedTurnID == nil && $0.lifecycle != .excluded }
+            .sorted { $0.ordinal < $1.ordinal }
+            .compactMap(\.selectedCandidateID)
+
+        for (index, proposal) in pairs.enumerated() {
+            let authorizationCommandID = CommandID("endpoint-valid-pair-\(index)-authorization")
+            let authorized = try await session.apply(
+                .authorizeEndpointEvaluation(
+                    commandID: authorizationCommandID,
+                    triggerSegmentID: segmentID,
+                    selectedCandidateIDs: selectedCandidateIDs,
+                    questionTurnID: nil,
+                    contextFingerprint: "sha256:v1:\(String(repeating: String(index), count: 64))"
+                )
+            )
+            XCTAssertEqual(authorized.disposition, .accepted)
+            let evaluation = try XCTUnwrap(
+                authorized.snapshot.endpointEvaluations.first {
+                    $0.authorizationCommandID == authorizationCommandID
+                }
+            )
+            let recorded = try await session.execute(
+                .recordEndpointEvaluationOutcome(
+                    commandID: CommandID("endpoint-valid-pair-\(index)-outcome"),
+                    evaluationID: evaluation.id,
+                    outcome: .proposal(proposal)
+                )
+            )
+
+            XCTAssertEqual(recorded.endpointEvaluations.last?.lifecycle, .proposalStored)
+            XCTAssertEqual(recorded.endpointEvaluations.last?.proposal, proposal)
+            XCTAssertEqual(recorded.phase, .candidateFloor)
+            XCTAssertTrue(recorded.turns.isEmpty)
+            XCTAssertNil(recorded.segments.first?.committedTurnID)
+        }
+    }
+
+    func testPatientAutoSkipsEvaluationWhenAnotherDraftSegmentIsUnresolved() async throws {
+        let classifier = RecordingSemanticEndpointClassifier(
+            results: [
+                .success(
+                    SemanticEndpointProposal(
+                        decision: .ambiguous,
+                        reasonCode: .insufficientEvidence
+                    )
+                )
+            ]
+        )
+        let coordinator = try await SegmentSpeechCoordinator.open(
+            sessionID: SessionID("endpoint-unresolved-draft"),
+            activityID: "endpoint-unresolved-draft-activity",
+            activityPrompt: try fixtureActivityPrompt(),
+            turnMode: .patientAuto,
+            manifestStore: InMemorySessionManifestStore(),
+            interviewerRuntime: fixtureRuntime(),
+            recording: StubSegmentRecorder(
+                capture: try capturedAudio(fileName: "endpoint-unresolved-draft.m4a")
+            ),
+            transcriber: SequencedSegmentTranscriber(
+                results: [
+                    .success(
+                        SegmentTranscriptionResult(
+                            body: "The later Segment still transcribes.",
+                            quality: .verified
+                        )
+                    )
+                ]
+            ),
+            credentialReader: FixedCredentialReader(value: "credential"),
+            semanticEndpointClassifier: classifier
+        )
+        _ = try await coordinator.giveCandidateFloor(
+            commandID: CommandID("endpoint-unresolved-floor")
+        )
+        _ = try await coordinator.beginSegment(
+            commandID: CommandID("endpoint-unresolved-first-begin")
+        )
+        _ = try await coordinator.finalizeSegment(
+            commandID: CommandID("endpoint-unresolved-first-finish")
+        )
+        _ = try await coordinator.beginSegment(
+            commandID: CommandID("endpoint-unresolved-second-begin")
+        )
+
+        let completed = try await coordinator.finishSegment(
+            commandID: CommandID("endpoint-unresolved-second-finish"),
+            transcriptionCommandID: CommandID("endpoint-unresolved-second-transcribe")
+        )
+
+        XCTAssertEqual(completed.segments[0].lifecycle, .audioReady)
+        XCTAssertNil(completed.segments[0].selectedCandidate)
+        XCTAssertEqual(
+            completed.segments[1].selectedCandidate?.body,
+            "The later Segment still transcribes."
+        )
+        XCTAssertTrue(completed.endpointEvaluations.isEmpty)
+        let classifierCalls = await classifier.invocationCount()
+        XCTAssertEqual(classifierCalls, 0)
+    }
+
+    func testPatientAutoEvaluatesOnlyWhenRetryChangesSelectedEvidence() async throws {
+        let classifier = RecordingSemanticEndpointClassifier(
+            results: [
+                .success(
+                    SemanticEndpointProposal(
+                        decision: .likelyEnd,
+                        reasonCode: .answerResolvesQuestion
+                    )
+                )
+            ]
+        )
+        let coordinator = try await SegmentSpeechCoordinator.open(
+            sessionID: SessionID("endpoint-selected-retry"),
+            activityID: "endpoint-selected-retry-activity",
+            activityPrompt: try fixtureActivityPrompt(),
+            turnMode: .manual,
+            manifestStore: InMemorySessionManifestStore(),
+            interviewerRuntime: fixtureRuntime(),
+            recording: StubSegmentRecorder(
+                capture: try capturedAudio(fileName: "endpoint-selected-retry.m4a")
+            ),
+            transcriber: SequencedSegmentTranscriber(
+                results: [
+                    .success(
+                        SegmentTranscriptionResult(
+                            body: "Selected best-available answer.",
+                            quality: .bestAvailable
+                        )
+                    ),
+                    .success(
+                        SegmentTranscriptionResult(
+                            body: "A lower-quality retry must stay observationally silent.",
+                            quality: .possibleContamination
+                        )
+                    ),
+                    .success(
+                        SegmentTranscriptionResult(
+                            body: "  Newly selected verified answer.  ",
+                            quality: .verified
+                        )
+                    ),
+                ]
+            ),
+            credentialReader: FixedCredentialReader(value: "credential"),
+            semanticEndpointClassifier: classifier
+        )
+        _ = try await coordinator.giveCandidateFloor(
+            commandID: CommandID("endpoint-selected-retry-floor")
+        )
+        _ = try await coordinator.beginSegment(
+            commandID: CommandID("endpoint-selected-retry-begin")
+        )
+        let initial = try await coordinator.finishSegment(
+            commandID: CommandID("endpoint-selected-retry-finish"),
+            transcriptionCommandID: CommandID("endpoint-selected-retry-initial")
+        )
+        let segmentID = try XCTUnwrap(initial.segments.first?.id)
+        let initiallySelectedID = try XCTUnwrap(initial.segments.first?.selectedCandidateID)
+        XCTAssertTrue(initial.endpointEvaluations.isEmpty)
+
+        _ = try await coordinator.setTurnMode(
+            .patientAuto,
+            commandID: CommandID("endpoint-selected-retry-mode")
+        )
+        let lowerQuality = try await coordinator.transcribeSegment(
+            segmentID: segmentID,
+            commandID: CommandID("endpoint-selected-retry-lower")
+        )
+        XCTAssertEqual(lowerQuality.segments.first?.selectedCandidateID, initiallySelectedID)
+        XCTAssertTrue(lowerQuality.endpointEvaluations.isEmpty)
+        let callsAfterLowerQualityRetry = await classifier.invocationCount()
+        XCTAssertEqual(callsAfterLowerQualityRetry, 0)
+
+        let higherQuality = try await coordinator.transcribeSegment(
+            segmentID: segmentID,
+            commandID: CommandID("endpoint-selected-retry-higher")
+        )
+        XCTAssertNotEqual(higherQuality.segments.first?.selectedCandidateID, initiallySelectedID)
+        XCTAssertEqual(higherQuality.endpointEvaluations.count, 1)
+        let contexts = await classifier.recordedContexts()
+        XCTAssertEqual(contexts.count, 1)
+        XCTAssertEqual(contexts.first?.accumulatedAnswer, "Newly selected verified answer.")
+        XCTAssertEqual(contexts.first?.latestSegment, "Newly selected verified answer.")
+    }
+
+    func testResumeMarksAuthorizedEndpointEvaluationInterruptedWithoutProviderReplay() async throws {
+        let store = InMemorySessionManifestStore()
+        let session = try await makeCandidateFloorSession(
+            store: store,
+            turnMode: .patientAuto
+        )
+        let segmentID = try await makeTranscribedSegment(
+            session: session,
+            commandStem: "endpoint-interrupted",
+            body: "Durable selected evidence.",
+            quality: .verified
+        )
+        let selectedSnapshot = await session.snapshot()
+        let selectedCandidateIDs = selectedSnapshot.segments
+            .filter { $0.committedTurnID == nil && $0.lifecycle != .excluded }
+            .sorted { $0.ordinal < $1.ordinal }
+            .compactMap(\.selectedCandidateID)
+        _ = try await session.execute(
+            .authorizeEndpointEvaluation(
+                commandID: CommandID("endpoint-interrupted-authorization"),
+                triggerSegmentID: segmentID,
+                selectedCandidateIDs: selectedCandidateIDs,
+                questionTurnID: nil,
+                contextFingerprint: "sha256:v1:\(String(repeating: "a", count: 64))"
+            )
+        )
+        let classifier = RecordingSemanticEndpointClassifier(results: [])
+        let coordinator = try await SegmentSpeechCoordinator.open(
+            sessionID: selectedSnapshot.sessionID,
+            activityID: selectedSnapshot.activityID,
+            activityPrompt: selectedSnapshot.activityPrompt,
+            manifestStore: store,
+            interviewerRuntime: fixtureRuntime(),
+            recording: StubSegmentRecorder(
+                capture: try capturedAudio(fileName: "endpoint-interrupted-unused.m4a")
+            ),
+            transcriber: SequencedSegmentTranscriber(results: []),
+            credentialReader: FixedCredentialReader(value: "credential"),
+            semanticEndpointClassifier: classifier
+        )
+
+        let reconciled = try await coordinator.resumePendingWork()
+
+        let evaluation = try XCTUnwrap(reconciled.endpointEvaluations.first)
+        XCTAssertEqual(evaluation.lifecycle, .failed)
+        XCTAssertEqual(evaluation.failure?.reason, .interrupted)
+        let classifierCalls = await classifier.invocationCount()
+        XCTAssertEqual(classifierCalls, 0)
+    }
+
+    func testResumeDoesNotFabricateMissingEndpointBoundaryOrCallProvider() async throws {
+        let store = InMemorySessionManifestStore()
+        let session = try await makeCandidateFloorSession(
+            store: store,
+            turnMode: .patientAuto
+        )
+        _ = try await makeTranscribedSegment(
+            session: session,
+            commandStem: "endpoint-preauthorization-crash",
+            body: "Transcript persisted before authorization.",
+            quality: .verified
+        )
+        let snapshot = await session.snapshot()
+        let classifier = RecordingSemanticEndpointClassifier(results: [])
+        let coordinator = try await SegmentSpeechCoordinator.open(
+            sessionID: snapshot.sessionID,
+            activityID: snapshot.activityID,
+            activityPrompt: snapshot.activityPrompt,
+            manifestStore: store,
+            interviewerRuntime: fixtureRuntime(),
+            recording: StubSegmentRecorder(
+                capture: try capturedAudio(fileName: "endpoint-preauthorization-unused.m4a")
+            ),
+            transcriber: SequencedSegmentTranscriber(results: []),
+            credentialReader: FixedCredentialReader(value: "credential"),
+            semanticEndpointClassifier: classifier
+        )
+
+        let resumed = try await coordinator.resumePendingWork()
+
+        XCTAssertTrue(resumed.endpointEvaluations.isEmpty)
+        let classifierCalls = await classifier.invocationCount()
+        XCTAssertEqual(classifierCalls, 0)
     }
 
     func testRestoreRejectsDuplicateCandidateTurnIDsWithoutTrapping() async throws {
@@ -853,12 +1516,14 @@ final class SegmentLifecycleTests: XCTestCase {
     }
 
     private func makeCandidateFloorSession(
-        store: InMemorySessionManifestStore
+        store: InMemorySessionManifestStore,
+        turnMode: TurnMode = .manual
     ) async throws -> InterviewRoomSession {
         let session = try await InterviewRoomSession.start(
             sessionID: SessionID("session-\(UUID().uuidString)"),
             activityID: "activity-segment-fixture",
             activityPrompt: try fixtureActivityPrompt(),
+            turnMode: turnMode,
             manifestStore: store,
             interviewerRuntime: fixtureRuntime()
         )
@@ -1122,6 +1787,60 @@ private actor SequencedSegmentTranscriber: SegmentTranscribing {
             throw SegmentTranscriptionAdapterFailure(reason: .providerUnavailable)
         }
         return try results.removeFirst().get()
+    }
+
+    func invocationCount() -> Int { calls }
+}
+
+private actor RecordingSemanticEndpointClassifier: SemanticEndpointClassifying {
+    private var results: [Result<SemanticEndpointProposal, GroqEndpointClassifierError>]
+    private let authorizationStore: InMemorySessionManifestStore?
+    private let sessionID: SessionID?
+    private var contexts: [SemanticEndpointContext] = []
+    private var authorizationStates: [Bool] = []
+
+    init(
+        results: [Result<SemanticEndpointProposal, GroqEndpointClassifierError>],
+        authorizationStore: InMemorySessionManifestStore? = nil,
+        sessionID: SessionID? = nil
+    ) {
+        self.results = results
+        self.authorizationStore = authorizationStore
+        self.sessionID = sessionID
+    }
+
+    func classify(
+        _ context: SemanticEndpointContext
+    ) async throws -> SemanticEndpointProposal {
+        contexts.append(context)
+        if let authorizationStore, let sessionID {
+            let manifest = await authorizationStore.load(sessionID: sessionID)
+            authorizationStates.append(
+                manifest?.endpointEvaluations.last?.lifecycle == .authorized
+            )
+        }
+        guard !results.isEmpty else {
+            throw GroqEndpointClassifierError.transportFailure
+        }
+        return try results.removeFirst().get()
+    }
+
+    func invocationCount() -> Int { contexts.count }
+    func recordedContexts() -> [SemanticEndpointContext] { contexts }
+    func authorizationStatesAtEntry() -> [Bool] { authorizationStates }
+}
+
+private actor CountingInterviewerRuntime: InterviewerRuntime {
+    private var calls = 0
+
+    func respond(
+        to request: InterviewerRequest
+    ) -> CanonicalInterviewerResponse {
+        calls += 1
+        return CanonicalInterviewerResponse(
+            displayMarkdown: "What trade-off comes next?",
+            spokenText: "What trade-off comes next?"
+        )
     }
 
     func invocationCount() -> Int { calls }

--- a/Tests/InterviewArcLiveCoreTests/SessionManifestStoreTests.swift
+++ b/Tests/InterviewArcLiveCoreTests/SessionManifestStoreTests.swift
@@ -86,6 +86,25 @@ final class SessionManifestStoreTests: XCTestCase {
         XCTAssertEqual(try Data(contentsOf: manifestURL), legacyData)
     }
 
+    func testLegacyManifestWithoutEndpointEvaluationsDecodesEmptyHistory() throws {
+        let current = try manifest(
+            sessionID: SessionID("public-legacy-endpoint-history"),
+            revision: 0
+        )
+        let currentData = try JSONEncoder().encode(current)
+        var object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: currentData) as? [String: Any]
+        )
+        object.removeValue(forKey: "endpointEvaluations")
+        let legacyData = try JSONSerialization.data(withJSONObject: object)
+
+        let decoded = try JSONDecoder().decode(SessionManifest.self, from: legacyData)
+
+        XCTAssertTrue(decoded.endpointEvaluations.isEmpty)
+        XCTAssertEqual(decoded.sessionID, current.sessionID)
+        XCTAssertEqual(decoded.revision, current.revision)
+    }
+
     func testFileAdapterForcesPrivateDirectoryAndManifestModes() async throws {
         let temporaryRoot = makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: temporaryRoot) }

--- a/Tests/InterviewArcLiveTests/SystemDesignRoomModelTests.swift
+++ b/Tests/InterviewArcLiveTests/SystemDesignRoomModelTests.swift
@@ -227,6 +227,38 @@ final class SystemDesignRoomModelTests: XCTestCase {
         )
     }
 
+    func testRemovingAllSelectedEvidenceKeepsLatestEvaluationVisiblyStale() {
+        let latestEvaluation = endpointEvaluation(
+            selectedCandidateIDs: [TranscriptCandidateID("candidate-a")],
+            lifecycle: .proposalStored,
+            proposal: SemanticEndpointProposal(
+                decision: .likelyEnd,
+                reasonCode: .answerResolvesQuestion
+            )
+        )
+        let evaluations = [latestEvaluation]
+        let currentEvaluation = EndpointShadowPresentation.currentEvaluation(
+            in: evaluations,
+            selectedCandidateIDs: [],
+            questionTurnID: nil,
+            hasUnresolvedDraft: false
+        )
+
+        XCTAssertNil(currentEvaluation)
+        let presentation = EndpointShadowPresentation.make(
+            turnMode: .patientAuto,
+            phase: .candidateFloor,
+            currentEvaluation: currentEvaluation,
+            hasSelectedDraft: false,
+            hasUnresolvedDraft: false,
+            hasStaleEvaluation: evaluations.last != nil
+                && currentEvaluation == nil
+        )
+
+        XCTAssertEqual(presentation.title, "Evidence changed · Shadow waiting")
+        XCTAssertFalse(presentation.detail.contains("likely complete"))
+    }
+
     private func endpointEvaluation(
         id: String = "endpoint-evaluation",
         selectedCandidateIDs: [TranscriptCandidateID],

--- a/Tests/InterviewArcLiveTests/SystemDesignRoomModelTests.swift
+++ b/Tests/InterviewArcLiveTests/SystemDesignRoomModelTests.swift
@@ -235,17 +235,47 @@ final class SystemDesignRoomModelTests: XCTestCase {
         proposal: SemanticEndpointProposal? = nil,
         failure: EndpointEvaluationFailure? = nil
     ) -> EndpointEvaluation {
-        EndpointEvaluation(
-            id: EndpointEvaluationID(id),
-            authorizationCommandID: CommandID("authorization-\(id)"),
-            triggerSegmentID: SegmentID("trigger-segment"),
-            selectedCandidateIDs: selectedCandidateIDs,
-            questionTurnID: questionTurnID,
-            contextFingerprint: "sha256:v1:\(String(repeating: "a", count: 64))",
-            lifecycle: lifecycle,
-            proposal: proposal,
-            failure: failure
-        )
+        let endpointID = EndpointEvaluationID(id)
+        let commandID = CommandID("authorization-\(id)")
+        let triggerSegmentID = SegmentID("trigger-segment")
+        let fingerprint = "sha256:v1:\(String(repeating: "a", count: 64))"
+        switch lifecycle {
+        case .authorized:
+            return .authorized(
+                id: endpointID,
+                authorizationCommandID: commandID,
+                triggerSegmentID: triggerSegmentID,
+                selectedCandidateIDs: selectedCandidateIDs,
+                questionTurnID: questionTurnID,
+                contextFingerprint: fingerprint
+            )
+        case .proposalStored:
+            guard let proposal else {
+                preconditionFailure("A stored proposal fixture requires a proposal")
+            }
+            return .proposalStored(
+                id: endpointID,
+                authorizationCommandID: commandID,
+                triggerSegmentID: triggerSegmentID,
+                selectedCandidateIDs: selectedCandidateIDs,
+                questionTurnID: questionTurnID,
+                contextFingerprint: fingerprint,
+                proposal: proposal
+            )
+        case .failed:
+            guard let failure else {
+                preconditionFailure("A failed evaluation fixture requires a failure")
+            }
+            return .failed(
+                id: endpointID,
+                authorizationCommandID: commandID,
+                triggerSegmentID: triggerSegmentID,
+                selectedCandidateIDs: selectedCandidateIDs,
+                questionTurnID: questionTurnID,
+                contextFingerprint: fingerprint,
+                failure: failure
+            )
+        }
     }
 }
 

--- a/Tests/InterviewArcLiveTests/SystemDesignRoomModelTests.swift
+++ b/Tests/InterviewArcLiveTests/SystemDesignRoomModelTests.swift
@@ -92,6 +92,161 @@ final class SystemDesignRoomModelTests: XCTestCase {
             XCTAssertFalse(message.contains(String(privateServerCode)))
         }
     }
+
+    func testTurnModeSurfaceOffersOnlyManualAndPatientAutoShadow() {
+        let model = SystemDesignRoomModel(
+            codexRuntime: CodexRuntimeFixture(readiness: .ready)
+        )
+
+        XCTAssertEqual(model.availableTurnModes, [.manual, .patientAuto])
+        XCTAssertFalse(model.availableTurnModes.contains(.cueOnly))
+        XCTAssertEqual(model.turnMode, .manual)
+        XCTAssertEqual(model.turnModeTitle(.manual), "Manual")
+        XCTAssertEqual(model.turnModeTitle(.patientAuto), "Patient Auto · Shadow")
+        XCTAssertEqual(
+            model.endpointShadowPresentation.detail,
+            "Semantic endpoint calls are off. Hand off remains explicit."
+        )
+    }
+
+    func testLikelyEndShadowCopyRemainsExplicitlyAdvisory() {
+        let evaluation = endpointEvaluation(
+            selectedCandidateIDs: [TranscriptCandidateID("candidate-a")],
+            lifecycle: .proposalStored,
+            proposal: SemanticEndpointProposal(
+                decision: .likelyEnd,
+                reasonCode: .answerResolvesQuestion
+            )
+        )
+
+        let presentation = EndpointShadowPresentation.make(
+            turnMode: .patientAuto,
+            phase: .candidateFloor,
+            currentEvaluation: evaluation,
+            hasSelectedDraft: true,
+            hasUnresolvedDraft: false,
+            hasStaleEvaluation: false
+        )
+
+        XCTAssertEqual(presentation.title, "Shadow: likely complete")
+        XCTAssertTrue(presentation.detail.contains("advisory only"))
+        XCTAssertTrue(presentation.detail.contains("choose Hand off"))
+        XCTAssertEqual(presentation.tone, .advisory)
+    }
+
+    func testShadowFailureCopyDoesNotExposeProviderStatus() {
+        let privateProviderStatus = 599
+        let evaluation = endpointEvaluation(
+            selectedCandidateIDs: [TranscriptCandidateID("candidate-a")],
+            lifecycle: .failed,
+            failure: EndpointEvaluationFailure(
+                reason: .providerRejected,
+                providerStatusCode: privateProviderStatus
+            )
+        )
+
+        let presentation = EndpointShadowPresentation.make(
+            turnMode: .patientAuto,
+            phase: .candidateFloor,
+            currentEvaluation: evaluation,
+            hasSelectedDraft: true,
+            hasUnresolvedDraft: false,
+            hasStaleEvaluation: false
+        )
+
+        XCTAssertEqual(presentation.title, "Shadow request rejected")
+        XCTAssertTrue(presentation.detail.contains("transcript is saved"))
+        XCTAssertFalse(presentation.detail.contains(String(privateProviderStatus)))
+        XCTAssertEqual(presentation.tone, .warning)
+    }
+
+    func testOnlyLatestExactEvidenceEvaluationCanBeCurrent() {
+        let candidateA = TranscriptCandidateID("candidate-a")
+        let candidateB = TranscriptCandidateID("candidate-b")
+        let olderMatching = endpointEvaluation(
+            id: "older-evaluation",
+            selectedCandidateIDs: [candidateA],
+            lifecycle: .proposalStored,
+            proposal: SemanticEndpointProposal(
+                decision: .likelyEnd,
+                reasonCode: .answerResolvesQuestion
+            )
+        )
+        let latestChanged = endpointEvaluation(
+            id: "latest-evaluation",
+            selectedCandidateIDs: [candidateA, candidateB],
+            lifecycle: .proposalStored,
+            proposal: SemanticEndpointProposal(
+                decision: .likelyContinue,
+                reasonCode: .unfinishedThought
+            )
+        )
+
+        let stale = EndpointShadowPresentation.currentEvaluation(
+            in: [olderMatching, latestChanged],
+            selectedCandidateIDs: [candidateA],
+            questionTurnID: nil,
+            hasUnresolvedDraft: false
+        )
+        XCTAssertNil(stale)
+
+        let presentation = EndpointShadowPresentation.make(
+            turnMode: .patientAuto,
+            phase: .candidateFloor,
+            currentEvaluation: stale,
+            hasSelectedDraft: true,
+            hasUnresolvedDraft: false,
+            hasStaleEvaluation: true
+        )
+        XCTAssertEqual(presentation.title, "Evidence changed · Shadow waiting")
+        XCTAssertFalse(presentation.detail.contains("likely complete"))
+
+        let current = EndpointShadowPresentation.currentEvaluation(
+            in: [olderMatching, latestChanged],
+            selectedCandidateIDs: [candidateA, candidateB],
+            questionTurnID: nil,
+            hasUnresolvedDraft: false
+        )
+        XCTAssertEqual(current?.id, latestChanged.id)
+    }
+
+    func testFreshFloorWithHistoryWaitsForFirstNewTranscript() {
+        let presentation = EndpointShadowPresentation.make(
+            turnMode: .patientAuto,
+            phase: .candidateFloor,
+            currentEvaluation: nil,
+            hasSelectedDraft: false,
+            hasUnresolvedDraft: false,
+            hasStaleEvaluation: false
+        )
+
+        XCTAssertEqual(presentation.title, "Shadow waiting for a transcript")
+        XCTAssertEqual(
+            presentation.detail,
+            "It checks only after a new selected transcript is saved."
+        )
+    }
+
+    private func endpointEvaluation(
+        id: String = "endpoint-evaluation",
+        selectedCandidateIDs: [TranscriptCandidateID],
+        questionTurnID: TurnID? = nil,
+        lifecycle: EndpointEvaluationLifecycle,
+        proposal: SemanticEndpointProposal? = nil,
+        failure: EndpointEvaluationFailure? = nil
+    ) -> EndpointEvaluation {
+        EndpointEvaluation(
+            id: EndpointEvaluationID(id),
+            authorizationCommandID: CommandID("authorization-\(id)"),
+            triggerSegmentID: SegmentID("trigger-segment"),
+            selectedCandidateIDs: selectedCandidateIDs,
+            questionTurnID: questionTurnID,
+            contextFingerprint: "sha256:v1:\(String(repeating: "a", count: 64))",
+            lifecycle: lifecycle,
+            proposal: proposal,
+            failure: failure
+        )
+    }
 }
 
 private actor CodexRuntimeFixture: LiveCodexInterviewerRuntime {

--- a/Tests/ScriptTests/codex-smoke-tests.zsh
+++ b/Tests/ScriptTests/codex-smoke-tests.zsh
@@ -21,6 +21,7 @@ make_bundle() {
   local bundle="$1"
   local identifier="$2"
   local helper="$bundle/Contents/Helpers/InterviewArcLiveCodexSmoke"
+  local endpoint_helper="$bundle/Contents/Helpers/InterviewArcLiveEndpointSmoke"
 
   mkdir -p "$bundle/Contents/Helpers" "$bundle/Contents/Resources"
   /usr/bin/plutil -create xml1 "$bundle/Contents/Info.plist"
@@ -33,8 +34,10 @@ make_bundle() {
   mkdir -p "$bundle/Contents/MacOS"
   print -r -- $'#!/bin/zsh\nexit 0' > "$bundle/Contents/MacOS/InterviewArcLive"
   print -r -- $'#!/bin/zsh\n[[ "${INTERVIEW_ARC_LIVE_RUN_CODEX_SMOKE:-0}" == "1" ]] || exit 64\nprint -r -- "$PWD" > "${INTERVIEW_ARC_LIVE_TEST_OBSERVED_CWD:?}"' > "$helper"
-  chmod 0755 "$bundle/Contents/MacOS/InterviewArcLive" "$helper"
+  print -r -- $'#!/bin/zsh\nexit 0' > "$endpoint_helper"
+  chmod 0755 "$bundle/Contents/MacOS/InterviewArcLive" "$helper" "$endpoint_helper"
   /usr/bin/codesign --force --sign - --timestamp=none "$helper" >/dev/null
+  /usr/bin/codesign --force --sign - --timestamp=none "$endpoint_helper" >/dev/null
   /usr/bin/codesign --force --sign - --timestamp=none "$bundle" >/dev/null
 }
 
@@ -51,16 +54,19 @@ fi
 manifest="$test_root/InterviewArcLive.package-manifest.txt"
 app_executable="$installed_app/Contents/MacOS/InterviewArcLive"
 smoke_executable="$installed_app/Contents/Helpers/InterviewArcLiveCodexSmoke"
+endpoint_smoke_executable="$installed_app/Contents/Helpers/InterviewArcLiveEndpointSmoke"
 info_plist="$installed_app/Contents/Info.plist"
 cdhash="$(/usr/bin/codesign -dvvv "$installed_app" 2>&1 | /usr/bin/awk -F= '/^CDHash=/{print $2; exit}')"
 app_sha="$(/usr/bin/shasum -a 256 "$app_executable" | /usr/bin/awk '{print $1}')"
 smoke_sha="$(/usr/bin/shasum -a 256 "$smoke_executable" | /usr/bin/awk '{print $1}')"
+endpoint_smoke_sha="$(/usr/bin/shasum -a 256 "$endpoint_smoke_executable" | /usr/bin/awk '{print $1}')"
 info_sha="$(/usr/bin/shasum -a 256 "$info_plist" | /usr/bin/awk '{print $1}')"
 {
   print -r -- "bundle_identifier=app.interviewarc.live"
   print -r -- "code_directory_hash=$cdhash"
   print -r -- "executable_sha256=$app_sha"
   print -r -- "codex_smoke_executable_sha256=$smoke_sha"
+  print -r -- "endpoint_smoke_executable_sha256=$endpoint_smoke_sha"
   print -r -- "info_plist_sha256=$info_sha"
   print -r -- "resource_bundle_count=0"
 } > "$manifest"

--- a/Tests/ScriptTests/endpoint-smoke-tests.zsh
+++ b/Tests/ScriptTests/endpoint-smoke-tests.zsh
@@ -1,0 +1,109 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+repo_root="${0:A:h:h:h}"
+smoke_script="$repo_root/scripts/smoke-installed-endpoint.sh"
+manifest_verifier="$repo_root/scripts/verify-package-manifest.sh"
+test_root="$(/usr/bin/mktemp -d "${TMPDIR:-/tmp}/interview-arc-live-endpoint-smoke-tests.XXXXXX")"
+
+cleanup() {
+  rm -rf "$test_root"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+installed_app="$test_root/Applications/Interview Arc Live.app"
+app_executable="$installed_app/Contents/MacOS/InterviewArcLive"
+codex_helper="$installed_app/Contents/Helpers/InterviewArcLiveCodexSmoke"
+endpoint_helper="$installed_app/Contents/Helpers/InterviewArcLiveEndpointSmoke"
+info_plist="$installed_app/Contents/Info.plist"
+observed_cwd="$test_root/observed-cwd"
+
+mkdir -p "$installed_app/Contents/MacOS" "$installed_app/Contents/Helpers" \
+  "$installed_app/Contents/Resources"
+/usr/bin/plutil -create xml1 "$info_plist"
+/usr/libexec/PlistBuddy -c 'Add :CFBundleIdentifier string app.interviewarc.live' "$info_plist"
+/usr/libexec/PlistBuddy -c 'Add :CFBundleExecutable string InterviewArcLive' "$info_plist"
+/usr/libexec/PlistBuddy -c 'Add :CFBundlePackageType string APPL' "$info_plist"
+print -r -- $'#!/bin/zsh\nexit 0' > "$app_executable"
+print -r -- $'#!/bin/zsh\nexit 0' > "$codex_helper"
+print -r -- $'#!/bin/zsh\n[[ "${INTERVIEW_ARC_LIVE_RUN_ENDPOINT_SMOKE:-0}" == "1" ]] || exit 64\nprint -r -- "$PWD" > "${INTERVIEW_ARC_LIVE_TEST_OBSERVED_CWD:?}"' > "$endpoint_helper"
+chmod 0755 "$app_executable" "$codex_helper" "$endpoint_helper"
+/usr/bin/codesign --force --sign - --timestamp=none "$codex_helper" >/dev/null
+/usr/bin/codesign --force --sign - --timestamp=none "$endpoint_helper" >/dev/null
+/usr/bin/codesign --force --sign - --timestamp=none "$installed_app" >/dev/null
+
+if INTERVIEW_ARC_LIVE_TEST_OBSERVED_CWD="$observed_cwd" \
+  "$smoke_script" "$installed_app" >/dev/null 2>&1; then
+  fail "smoke ran without explicit opt-in"
+fi
+[[ ! -e "$observed_cwd" ]] || fail "non-opt-in smoke invoked the helper"
+
+if INTERVIEW_ARC_LIVE_RUN_ENDPOINT_SMOKE=1 \
+  INTERVIEW_ARC_LIVE_TEST_OBSERVED_CWD="$observed_cwd" \
+  "$smoke_script" "$installed_app" >/dev/null 2>&1; then
+  fail "ad-hoc smoke ran without an exact package manifest"
+fi
+[[ ! -e "$observed_cwd" ]] || fail "manifest-less smoke invoked the helper"
+
+manifest="$test_root/InterviewArcLive.package-manifest.txt"
+cdhash="$(/usr/bin/codesign -dvvv "$installed_app" 2>&1 | /usr/bin/awk -F= '/^CDHash=/{print $2; exit}')"
+app_sha="$(/usr/bin/shasum -a 256 "$app_executable" | /usr/bin/awk '{print $1}')"
+codex_sha="$(/usr/bin/shasum -a 256 "$codex_helper" | /usr/bin/awk '{print $1}')"
+endpoint_sha="$(/usr/bin/shasum -a 256 "$endpoint_helper" | /usr/bin/awk '{print $1}')"
+info_sha="$(/usr/bin/shasum -a 256 "$info_plist" | /usr/bin/awk '{print $1}')"
+{
+  print -r -- "bundle_identifier=app.interviewarc.live"
+  print -r -- "code_directory_hash=$cdhash"
+  print -r -- "executable_sha256=$app_sha"
+  print -r -- "codex_smoke_executable_sha256=$codex_sha"
+  print -r -- "endpoint_smoke_executable_sha256=$endpoint_sha"
+  print -r -- "info_plist_sha256=$info_sha"
+  print -r -- "resource_bundle_count=0"
+} > "$manifest"
+"$manifest_verifier" "$installed_app" "$manifest" >/dev/null
+
+INTERVIEW_ARC_LIVE_RUN_ENDPOINT_SMOKE=1 \
+INTERVIEW_ARC_LIVE_TEST_OBSERVED_CWD="$observed_cwd" \
+  "$smoke_script" "$installed_app" "$manifest" >/dev/null
+[[ -f "$observed_cwd" ]] || fail "opt-in smoke did not invoke the installed helper"
+helper_cwd="$(<"$observed_cwd")"
+[[ "$helper_cwd" != "${repo_root:A}"/* ]] || fail "helper ran inside the repository"
+[[ "${helper_cwd:t}" == interview-arc-live-endpoint-smoke.* ]] \
+  || fail "helper did not run in an isolated smoke directory"
+[[ ! -e "$helper_cwd" ]] || fail "smoke directory was not removed"
+
+tampered_manifest="$test_root/InterviewArcLive.tampered-package-manifest.txt"
+{
+  print -r -- "bundle_identifier=app.interviewarc.live"
+  print -r -- "code_directory_hash=$cdhash"
+  print -r -- "executable_sha256=$app_sha"
+  print -r -- "codex_smoke_executable_sha256=$codex_sha"
+  print -r -- "endpoint_smoke_executable_sha256=0000000000000000000000000000000000000000000000000000000000000000"
+  print -r -- "info_plist_sha256=$info_sha"
+  print -r -- "resource_bundle_count=0"
+} > "$tampered_manifest"
+rm -f "$observed_cwd"
+if INTERVIEW_ARC_LIVE_RUN_ENDPOINT_SMOKE=1 \
+  INTERVIEW_ARC_LIVE_TEST_OBSERVED_CWD="$observed_cwd" \
+  "$smoke_script" "$installed_app" "$tampered_manifest" >/dev/null 2>&1; then
+  fail "smoke accepted a tampered package manifest"
+fi
+[[ ! -e "$observed_cwd" ]] || fail "manifest mismatch invoked the helper"
+
+print -r -- $'#!/bin/zsh\nexit 1' > "$endpoint_helper"
+chmod 0755 "$endpoint_helper"
+rm -f "$observed_cwd"
+if INTERVIEW_ARC_LIVE_RUN_ENDPOINT_SMOKE=1 \
+  INTERVIEW_ARC_LIVE_TEST_OBSERVED_CWD="$observed_cwd" \
+  "$smoke_script" "$installed_app" "$manifest" >/dev/null 2>&1; then
+  fail "smoke accepted an endpoint helper that did not match the package manifest"
+fi
+[[ ! -e "$observed_cwd" ]] || fail "unverified endpoint helper was executed"
+
+echo "Installed endpoint smoke opt-in, isolated cwd, and manifest-tamper tests passed."

--- a/scripts/installed-smoke-common.zsh
+++ b/scripts/installed-smoke-common.zsh
@@ -1,0 +1,91 @@
+#!/bin/zsh
+
+# Shared installed-bundle gate for the opt-in smoke wrappers. Callers retain
+# their product-specific opt-in and helper environment while this function
+# owns bundle identity, signature, manifest, and isolated-workspace checks.
+_interview_arc_live_smoke_scripts_dir="${${(%):-%N}:A:h}"
+
+interview_arc_live_run_installed_smoke() {
+  local helper_name="$1"
+  local smoke_directory_prefix="$2"
+  shift 2
+
+  case "$helper_name:$smoke_directory_prefix" in
+    InterviewArcLiveCodexSmoke:interview-arc-live-codex-smoke|\
+    InterviewArcLiveEndpointSmoke:interview-arc-live-endpoint-smoke)
+      ;;
+    *)
+      echo "Refusing an unsupported installed smoke helper." >&2
+      return 65
+      ;;
+  esac
+
+  local bundle_identifier="app.interviewarc.live"
+  local app_name="Interview Arc Live.app"
+  local installed_app
+  local package_manifest
+
+  if [[ $# -eq 2 ]]; then
+    installed_app="${1:A}"
+    package_manifest="${2:A}"
+  elif [[ $# -eq 1 && -d "/Applications/$app_name" ]]; then
+    installed_app="/Applications/$app_name"
+    package_manifest="${1:A}"
+  elif [[ $# -eq 1 \
+      && -d "${HOME:?Current user home directory is unavailable.}/Applications/$app_name" ]]; then
+    installed_app="${HOME}/Applications/$app_name"
+    package_manifest="${1:A}"
+  else
+    echo "Interview Arc Live is not installed in a standard Applications directory." >&2
+    return 66
+  fi
+
+  local info_plist="$installed_app/Contents/Info.plist"
+  local helper="$installed_app/Contents/Helpers/$helper_name"
+  if [[ ! -d "$installed_app" || ! -f "$info_plist" || ! -x "$helper" ]]; then
+    echo "The installed Interview Arc Live bundle does not include the requested smoke helper." >&2
+    return 66
+  fi
+
+  local actual_identifier
+  actual_identifier="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$info_plist")"
+  if [[ "$actual_identifier" != "$bundle_identifier" ]]; then
+    echo "Refusing to smoke an application that is not Interview Arc Live." >&2
+    return 65
+  fi
+  if ! /usr/bin/codesign --verify --deep --strict "$installed_app" >/dev/null 2>&1; then
+    echo "Installed Interview Arc Live signature verification failed." >&2
+    return 65
+  fi
+  "$_interview_arc_live_smoke_scripts_dir/verify-package-manifest.sh" \
+    "$installed_app" \
+    "$package_manifest"
+
+  local smoke_root
+  smoke_root="$(/usr/bin/mktemp -d \
+    "${TMPDIR:-/tmp}/${smoke_directory_prefix}.XXXXXX")"
+  cleanup_installed_smoke() {
+    if [[ -n "${smoke_root:-}" \
+        && -d "$smoke_root" \
+        && "${smoke_root:t}" == ${smoke_directory_prefix}.* ]]; then
+      rm -rf -- "$smoke_root"
+    fi
+  }
+  trap cleanup_installed_smoke EXIT
+  trap 'exit 129' HUP
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+
+  local repo_root="${_interview_arc_live_smoke_scripts_dir:h}"
+  if [[ "${smoke_root:A}" == "${repo_root:A}"/* ]]; then
+    echo "Refusing to run the installed smoke inside the source repository." >&2
+    return 65
+  fi
+
+  cd "$smoke_root"
+  local helper_status=0
+  "$helper" || helper_status=$?
+  cleanup_installed_smoke
+  trap - EXIT HUP INT TERM
+  return "$helper_status"
+}

--- a/scripts/package-app.sh
+++ b/scripts/package-app.sh
@@ -10,6 +10,7 @@ app_dir="$repo_root/dist/$app_name"
 contents_dir="$app_dir/Contents"
 executable_name="InterviewArcLive"
 smoke_executable_name="InterviewArcLiveCodexSmoke"
+endpoint_smoke_executable_name="InterviewArcLiveEndpointSmoke"
 info_plist="$repo_root/Resources/Info.plist"
 signing_identity="${INTERVIEW_ARC_LIVE_SIGNING_IDENTITY:--}"
 manifest_path="$repo_root/dist/InterviewArcLive.package-manifest.txt"
@@ -39,9 +40,11 @@ fi
 
 swift build -c "$configuration" --product "$executable_name"
 swift build -c "$configuration" --product "$smoke_executable_name"
+swift build -c "$configuration" --product "$endpoint_smoke_executable_name"
 bin_dir="$(swift build -c "$configuration" --show-bin-path)"
 executable="$bin_dir/$executable_name"
 smoke_executable="$bin_dir/$smoke_executable_name"
+endpoint_smoke_executable="$bin_dir/$endpoint_smoke_executable_name"
 
 if [[ -n "$(git status --porcelain --untracked-files=all)" ]]; then
   source_tree_clean="false"
@@ -51,8 +54,9 @@ if [[ -n "$(git status --porcelain --untracked-files=all)" ]]; then
   fi
 fi
 
-if [[ ! -x "$executable" || ! -x "$smoke_executable" ]]; then
-  echo "A built application executable or Codex smoke helper is missing." >&2
+if [[ ! -x "$executable" || ! -x "$smoke_executable" \
+    || ! -x "$endpoint_smoke_executable" ]]; then
+  echo "A built application executable or installed-smoke helper is missing." >&2
   exit 66
 fi
 
@@ -68,8 +72,10 @@ mkdir -p "$contents_dir/MacOS" "$contents_dir/Helpers" "$contents_dir/Resources"
 cp "$info_plist" "$contents_dir/Info.plist"
 cp "$executable" "$contents_dir/MacOS/$executable_name"
 cp "$smoke_executable" "$contents_dir/Helpers/$smoke_executable_name"
+cp "$endpoint_smoke_executable" "$contents_dir/Helpers/$endpoint_smoke_executable_name"
 chmod 0755 "$contents_dir/MacOS/$executable_name"
 chmod 0755 "$contents_dir/Helpers/$smoke_executable_name"
+chmod 0755 "$contents_dir/Helpers/$endpoint_smoke_executable_name"
 
 for resource_bundle in "$bin_dir"/*.bundle; do
   if [[ -d "$resource_bundle" ]]; then
@@ -82,6 +88,12 @@ done
   --sign "$signing_identity" \
   --timestamp=none \
   "$contents_dir/Helpers/$smoke_executable_name"
+
+/usr/bin/codesign \
+  --force \
+  --sign "$signing_identity" \
+  --timestamp=none \
+  "$contents_dir/Helpers/$endpoint_smoke_executable_name"
 
 /usr/bin/codesign \
   --force \
@@ -101,6 +113,7 @@ fi
 
 executable_sha256="$(/usr/bin/shasum -a 256 "$contents_dir/MacOS/$executable_name" | /usr/bin/awk '{print $1}')"
 smoke_executable_sha256="$(/usr/bin/shasum -a 256 "$contents_dir/Helpers/$smoke_executable_name" | /usr/bin/awk '{print $1}')"
+endpoint_smoke_executable_sha256="$(/usr/bin/shasum -a 256 "$contents_dir/Helpers/$endpoint_smoke_executable_name" | /usr/bin/awk '{print $1}')"
 info_plist_sha256="$(/usr/bin/shasum -a 256 "$contents_dir/Info.plist" | /usr/bin/awk '{print $1}')"
 code_directory_hash="$(/usr/bin/codesign -dvvv "$app_dir" 2>&1 | /usr/bin/awk -F= '/^CDHash=/{print $2; exit}')"
 resource_bundle_count="$(/usr/bin/find "$contents_dir/Resources" -mindepth 1 -maxdepth 1 -type d -name '*.bundle' | /usr/bin/wc -l | /usr/bin/tr -d ' ')"
@@ -118,6 +131,7 @@ fi
   print -r -- "code_directory_hash=$code_directory_hash"
   print -r -- "executable_sha256=$executable_sha256"
   print -r -- "codex_smoke_executable_sha256=$smoke_executable_sha256"
+  print -r -- "endpoint_smoke_executable_sha256=$endpoint_smoke_executable_sha256"
   print -r -- "info_plist_sha256=$info_plist_sha256"
   print -r -- "resource_bundle_count=$resource_bundle_count"
 } > "$manifest_path"

--- a/scripts/smoke-installed-codex.sh
+++ b/scripts/smoke-installed-codex.sh
@@ -2,9 +2,6 @@
 
 set -euo pipefail
 
-bundle_identifier="app.interviewarc.live"
-app_name="Interview Arc Live.app"
-helper_name="InterviewArcLiveCodexSmoke"
 opt_in="${INTERVIEW_ARC_LIVE_RUN_CODEX_SMOKE:-0}"
 
 if [[ $# -lt 1 || $# -gt 2 ]]; then
@@ -17,49 +14,8 @@ if [[ "$opt_in" != "1" ]]; then
   exit 64
 fi
 
-if [[ $# -eq 2 ]]; then
-  installed_app="${1:A}"
-  package_manifest="${2:A}"
-elif [[ -d "/Applications/$app_name" ]]; then
-  installed_app="/Applications/$app_name"
-  package_manifest="${1:A}"
-elif [[ -d "${HOME:?Current user home directory is unavailable.}/Applications/$app_name" ]]; then
-  installed_app="${HOME}/Applications/$app_name"
-  package_manifest="${1:A}"
-else
-  echo "Interview Arc Live is not installed in a standard Applications directory." >&2
-  exit 66
-fi
-
-info_plist="$installed_app/Contents/Info.plist"
-helper="$installed_app/Contents/Helpers/$helper_name"
-if [[ ! -d "$installed_app" || ! -f "$info_plist" || ! -x "$helper" ]]; then
-  echo "The installed Interview Arc Live bundle does not include the Codex smoke helper." >&2
-  exit 66
-fi
-
-actual_identifier="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$info_plist")"
-if [[ "$actual_identifier" != "$bundle_identifier" ]]; then
-  echo "Refusing to smoke an application that is not Interview Arc Live." >&2
-  exit 65
-fi
-/usr/bin/codesign --verify --deep --strict --verbose=2 "$installed_app"
-"${0:A:h}/verify-package-manifest.sh" "$installed_app" "$package_manifest"
-
-smoke_root="$(/usr/bin/mktemp -d "${TMPDIR:-/tmp}/interview-arc-live-codex-smoke.XXXXXX")"
-cleanup() {
-  rm -rf "$smoke_root"
-}
-trap cleanup EXIT
-trap 'exit 129' HUP
-trap 'exit 130' INT
-trap 'exit 143' TERM
-
-repo_root="${0:A:h:h}"
-if [[ "${smoke_root:A}" == "${repo_root:A}"/* ]]; then
-  echo "Refusing to run the installed smoke inside the source repository." >&2
-  exit 65
-fi
-
-cd "$smoke_root"
-INTERVIEW_ARC_LIVE_RUN_CODEX_SMOKE=1 "$helper"
+source "${0:A:h}/installed-smoke-common.zsh"
+interview_arc_live_run_installed_smoke \
+  "InterviewArcLiveCodexSmoke" \
+  "interview-arc-live-codex-smoke" \
+  "$@"

--- a/scripts/smoke-installed-endpoint.sh
+++ b/scripts/smoke-installed-endpoint.sh
@@ -2,9 +2,6 @@
 
 set -euo pipefail
 
-bundle_identifier="app.interviewarc.live"
-app_name="Interview Arc Live.app"
-helper_name="InterviewArcLiveEndpointSmoke"
 opt_in="${INTERVIEW_ARC_LIVE_RUN_ENDPOINT_SMOKE:-0}"
 
 if [[ $# -lt 1 || $# -gt 2 ]]; then
@@ -17,52 +14,8 @@ if [[ "$opt_in" != "1" ]]; then
   exit 64
 fi
 
-if [[ $# -eq 2 ]]; then
-  installed_app="${1:A}"
-  package_manifest="${2:A}"
-elif [[ -d "/Applications/$app_name" ]]; then
-  installed_app="/Applications/$app_name"
-  package_manifest="${1:A}"
-elif [[ -d "${HOME:?Current user home directory is unavailable.}/Applications/$app_name" ]]; then
-  installed_app="${HOME}/Applications/$app_name"
-  package_manifest="${1:A}"
-else
-  echo "Interview Arc Live is not installed in a standard Applications directory." >&2
-  exit 66
-fi
-
-info_plist="$installed_app/Contents/Info.plist"
-helper="$installed_app/Contents/Helpers/$helper_name"
-if [[ ! -d "$installed_app" || ! -f "$info_plist" || ! -x "$helper" ]]; then
-  echo "The installed Interview Arc Live bundle does not include the endpoint smoke helper." >&2
-  exit 66
-fi
-
-actual_identifier="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$info_plist")"
-if [[ "$actual_identifier" != "$bundle_identifier" ]]; then
-  echo "Refusing to smoke an application that is not Interview Arc Live." >&2
-  exit 65
-fi
-if ! /usr/bin/codesign --verify --deep --strict "$installed_app" >/dev/null 2>&1; then
-  echo "Installed Interview Arc Live signature verification failed." >&2
-  exit 65
-fi
-"${0:A:h}/verify-package-manifest.sh" "$installed_app" "$package_manifest"
-
-smoke_root="$(/usr/bin/mktemp -d "${TMPDIR:-/tmp}/interview-arc-live-endpoint-smoke.XXXXXX")"
-cleanup() {
-  rm -rf "$smoke_root"
-}
-trap cleanup EXIT
-trap 'exit 129' HUP
-trap 'exit 130' INT
-trap 'exit 143' TERM
-
-repo_root="${0:A:h:h}"
-if [[ "${smoke_root:A}" == "${repo_root:A}"/* ]]; then
-  echo "Refusing to run the installed smoke inside the source repository." >&2
-  exit 65
-fi
-
-cd "$smoke_root"
-INTERVIEW_ARC_LIVE_RUN_ENDPOINT_SMOKE=1 "$helper"
+source "${0:A:h}/installed-smoke-common.zsh"
+interview_arc_live_run_installed_smoke \
+  "InterviewArcLiveEndpointSmoke" \
+  "interview-arc-live-endpoint-smoke" \
+  "$@"

--- a/scripts/smoke-installed-endpoint.sh
+++ b/scripts/smoke-installed-endpoint.sh
@@ -1,0 +1,68 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+bundle_identifier="app.interviewarc.live"
+app_name="Interview Arc Live.app"
+helper_name="InterviewArcLiveEndpointSmoke"
+opt_in="${INTERVIEW_ARC_LIVE_RUN_ENDPOINT_SMOKE:-0}"
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "Usage: $0 ['/installed/path/Interview Arc Live.app'] '/path/to/InterviewArcLive.package-manifest.txt'" >&2
+  exit 64
+fi
+if [[ "$opt_in" != "1" ]]; then
+  echo "Installed endpoint smoke is opt-in." >&2
+  echo "Set INTERVIEW_ARC_LIVE_RUN_ENDPOINT_SMOKE=1 to run one Groq classification request." >&2
+  exit 64
+fi
+
+if [[ $# -eq 2 ]]; then
+  installed_app="${1:A}"
+  package_manifest="${2:A}"
+elif [[ -d "/Applications/$app_name" ]]; then
+  installed_app="/Applications/$app_name"
+  package_manifest="${1:A}"
+elif [[ -d "${HOME:?Current user home directory is unavailable.}/Applications/$app_name" ]]; then
+  installed_app="${HOME}/Applications/$app_name"
+  package_manifest="${1:A}"
+else
+  echo "Interview Arc Live is not installed in a standard Applications directory." >&2
+  exit 66
+fi
+
+info_plist="$installed_app/Contents/Info.plist"
+helper="$installed_app/Contents/Helpers/$helper_name"
+if [[ ! -d "$installed_app" || ! -f "$info_plist" || ! -x "$helper" ]]; then
+  echo "The installed Interview Arc Live bundle does not include the endpoint smoke helper." >&2
+  exit 66
+fi
+
+actual_identifier="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$info_plist")"
+if [[ "$actual_identifier" != "$bundle_identifier" ]]; then
+  echo "Refusing to smoke an application that is not Interview Arc Live." >&2
+  exit 65
+fi
+if ! /usr/bin/codesign --verify --deep --strict "$installed_app" >/dev/null 2>&1; then
+  echo "Installed Interview Arc Live signature verification failed." >&2
+  exit 65
+fi
+"${0:A:h}/verify-package-manifest.sh" "$installed_app" "$package_manifest"
+
+smoke_root="$(/usr/bin/mktemp -d "${TMPDIR:-/tmp}/interview-arc-live-endpoint-smoke.XXXXXX")"
+cleanup() {
+  rm -rf "$smoke_root"
+}
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+repo_root="${0:A:h:h}"
+if [[ "${smoke_root:A}" == "${repo_root:A}"/* ]]; then
+  echo "Refusing to run the installed smoke inside the source repository." >&2
+  exit 65
+fi
+
+cd "$smoke_root"
+INTERVIEW_ARC_LIVE_RUN_ENDPOINT_SMOKE=1 "$helper"

--- a/scripts/verify-package-manifest.sh
+++ b/scripts/verify-package-manifest.sh
@@ -11,9 +11,11 @@ app_dir="${1:A}"
 manifest_path="${2:A}"
 executable="$app_dir/Contents/MacOS/InterviewArcLive"
 smoke_executable="$app_dir/Contents/Helpers/InterviewArcLiveCodexSmoke"
+endpoint_smoke_executable="$app_dir/Contents/Helpers/InterviewArcLiveEndpointSmoke"
 info_plist="$app_dir/Contents/Info.plist"
 
 if [[ ! -x "$executable" || ! -x "$smoke_executable" \
+    || ! -x "$endpoint_smoke_executable" \
     || ! -f "$info_plist" || ! -f "$manifest_path" ]]; then
   echo "Package manifest verification requires a complete application bundle and manifest." >&2
   exit 66
@@ -37,6 +39,7 @@ actual_identifier="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$in
 actual_cdhash="$(/usr/bin/codesign -dvvv "$app_dir" 2>&1 | /usr/bin/awk -F= '/^CDHash=/{print $2; exit}')"
 actual_executable_sha="$(/usr/bin/shasum -a 256 "$executable" | /usr/bin/awk '{print $1}')"
 actual_smoke_sha="$(/usr/bin/shasum -a 256 "$smoke_executable" | /usr/bin/awk '{print $1}')"
+actual_endpoint_smoke_sha="$(/usr/bin/shasum -a 256 "$endpoint_smoke_executable" | /usr/bin/awk '{print $1}')"
 actual_info_sha="$(/usr/bin/shasum -a 256 "$info_plist" | /usr/bin/awk '{print $1}')"
 actual_bundle_count="$(/usr/bin/find "$app_dir/Contents/Resources" -mindepth 1 -maxdepth 1 -type d -name '*.bundle' | /usr/bin/wc -l | /usr/bin/tr -d ' ')"
 
@@ -48,9 +51,11 @@ actual_bundle_count="$(/usr/bin/find "$app_dir/Contents/Resources" -mindepth 1 -
   || { echo "Package manifest application executable mismatch." >&2; exit 65; }
 [[ "$(manifest_value codex_smoke_executable_sha256)" == "$actual_smoke_sha" ]] \
   || { echo "Package manifest Codex smoke helper mismatch." >&2; exit 65; }
+[[ "$(manifest_value endpoint_smoke_executable_sha256)" == "$actual_endpoint_smoke_sha" ]] \
+  || { echo "Package manifest endpoint smoke helper mismatch." >&2; exit 65; }
 [[ "$(manifest_value info_plist_sha256)" == "$actual_info_sha" ]] \
   || { echo "Package manifest Info.plist mismatch." >&2; exit 65; }
 [[ "$(manifest_value resource_bundle_count)" == "$actual_bundle_count" ]] \
   || { echo "Package manifest resource-bundle count mismatch." >&2; exit 65; }
 
-echo "Package manifest application and Codex smoke hashes verified."
+echo "Package manifest application and installed-smoke hashes verified."


### PR DESCRIPTION
## **User description**
Refs #11

## Summary
- add durable, idempotent Patient Auto Shadow endpoint evaluations at explicit Segment boundaries
- keep Manual default and every semantic decision observational: no grace, Hand off, Candidate Turn, or Codex side effect
- surface current/stale/safe-failure Shadow status and package an opt-in exact-installed Groq orchestration smoke

## Verification
- macOS 15.4 Core and app warnings-as-errors typechecks
- focused Core/model test typechecks and full Swift source parse
- installer, Codex-smoke, and endpoint-smoke safety suites
- independent Reliability gate: GO
- hosted macOS CI required for canonical SwiftPM XCTest/package execution due the documented local PackageDescription toolchain mismatch


___

## **CodeAnt-AI Description**
Add durable Patient Auto shadow feedback without changing explicit handoff

### What Changed
- Users can switch between Manual and Patient Auto · Shadow while the interview stays on the Candidate Floor until they choose Hand off.
- Patient Auto checks newly selected, completed transcripts and saves the advisory result, authorization, or safe failure for recovery.
- The interface shows waiting, checking, likely complete, keep going, stale, and unavailable states without exposing provider details.
- Transcripts remain saved when credentials are missing, evidence changes, the provider fails, or a check is interrupted; interrupted checks are not replayed automatically.
- Added opt-in installed endpoint smoke coverage and package verification for the Groq check.

### Impact
`✅ Manual Hand off remains explicit`
`✅ Durable transcript endpoint feedback`
`✅ Clearer stale and provider-failure status`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
