### PR TITLE
Isolate Xcode packaging build products

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -69,10 +69,9 @@ jobs:
         run: Tests/ScriptTests/endpoint-smoke-tests.zsh
       - name: Test installed local-speech smoke safety
         run: Tests/ScriptTests/speech-smoke-tests.zsh
-      - name: Package merged application
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      - name: Package application
         env:
-          INTERVIEW_ARC_LIVE_DERIVED_DATA_PATH: ${{ runner.temp }}/InterviewArcLiveDerivedData
+          INTERVIEW_ARC_LIVE_DERIVED_DATA_PATH: ${{ runner.temp }}/InterviewArcLivePackageDerivedData
         run: scripts/package-app.sh release
       - name: Upload merged application
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
## **User description**
Refs #13

## Summary
- run application packaging in a fresh package-only Xcode DerivedData directory
- execute the exact packaging path on pull requests so release-only regressions fail before merge
- keep distributable upload restricted to merged main

## Root cause
Merged-main run 31352097969 reused the build-for-testing DerivedData for a second plain Release build. Xcode explicit-module discovery then lost EventSource transitive C shim modules even though the first build and all tests passed.

## Verification
- Ruby YAML parse
- git diff --check
- focused workflow contract: build/test share InterviewArcLiveDerivedData; packaging uses InterviewArcLivePackageDerivedData
- independent release-provenance review: GO

Hosted PR packaging is the authoritative regression check.


___

## **CodeAnt-AI Description**
Isolate application packaging and validate it on every pull request

### What Changed
- Application packaging now runs with a fresh build-data location instead of reusing test build products
- Pull requests now execute the same packaging path used for releases, catching packaging regressions before merge
- Distributable application uploads remain limited to merged changes on the main branch

### Impact
`✅ Fewer release-only packaging failures`
`✅ Earlier detection of broken pull-request builds`
`✅ Release uploads remain restricted to main`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
