### PR TITLE
Stage verified MLX resource for installed speech smoke

### DIFF
--- a/Tests/ScriptTests/speech-smoke-tests.zsh
+++ b/Tests/ScriptTests/speech-smoke-tests.zsh
@@ -36,7 +36,7 @@ mkdir -p "$installed_app/Contents/MacOS" "$installed_app/Contents/Helpers" \
 print -r -- $'#!/bin/zsh\nexit 0' > "$app_executable"
 print -r -- $'#!/bin/zsh\nexit 0' > "$codex_helper"
 print -r -- $'#!/bin/zsh\nexit 0' > "$endpoint_helper"
-print -r -- $'#!/bin/zsh\n[[ "${INTERVIEW_ARC_LIVE_RUN_SPEECH_SMOKE:-0}" == "1" ]] || exit 64\nprint -r -- "$PWD|${INTERVIEW_ARC_LIVE_ALLOW_MODEL_DOWNLOAD:-0}" > "${INTERVIEW_ARC_LIVE_TEST_OBSERVED:?}"\nprint -r -- "public upstream status that must be filtered"\nprint -r -- "model_revision=049ef77fe8816b536193c0c25f9a214d17921282"\nprint -r -- "chunk_count=2"\nprint -r -- "time_to_first_audio_ms=120"\nprint -r -- "generation_total_ms=920"\nprint -r -- "audio_duration_ms=1400"\nprint -r -- "audio_bytes=134444"' > "$speech_helper"
+print -r -- $'#!/bin/zsh\n[[ "${INTERVIEW_ARC_LIVE_RUN_SPEECH_SMOKE:-0}" == "1" ]] || exit 64\n[[ -f "$PWD/default.metallib" && ! -L "$PWD/default.metallib" ]] || exit 65\n[[ "$(/usr/bin/shasum -a 256 "$PWD/default.metallib" | /usr/bin/awk \'{print $1}\')" == "${INTERVIEW_ARC_LIVE_TEST_EXPECTED_MLX_SHA:?}" ]] || exit 65\n[[ "$(/usr/bin/stat -f \'%z\' "$PWD/default.metallib")" == "${INTERVIEW_ARC_LIVE_TEST_EXPECTED_MLX_BYTES:?}" ]] || exit 65\nprint -r -- "$PWD|${INTERVIEW_ARC_LIVE_ALLOW_MODEL_DOWNLOAD:-0}" > "${INTERVIEW_ARC_LIVE_TEST_OBSERVED:?}"\nprint -r -- "public upstream status that must be filtered"\nprint -r -- "model_revision=049ef77fe8816b536193c0c25f9a214d17921282"\nprint -r -- "chunk_count=2"\nprint -r -- "time_to_first_audio_ms=120"\nprint -r -- "generation_total_ms=920"\nprint -r -- "audio_duration_ms=1400"\nprint -r -- "audio_bytes=134444"' > "$speech_helper"
 print -rn -- 'fixture-metallib' > "$mlx_metallib"
 print -rn -- 'fixture-notice' > "$sealed_unmanifested_resource"
 chmod 0755 "$app_executable" "$codex_helper" "$endpoint_helper" "$speech_helper"
@@ -86,6 +86,8 @@ report="$test_root/speech-report.txt"
 INTERVIEW_ARC_LIVE_RUN_SPEECH_SMOKE=1 \
 INTERVIEW_ARC_LIVE_ALLOW_MODEL_DOWNLOAD=1 \
 INTERVIEW_ARC_LIVE_TEST_OBSERVED="$observed" \
+INTERVIEW_ARC_LIVE_TEST_EXPECTED_MLX_SHA="$mlx_sha" \
+INTERVIEW_ARC_LIVE_TEST_EXPECTED_MLX_BYTES="$mlx_bytes" \
   "$smoke_script" "$installed_app" "$manifest" > "$report"
 [[ -f "$observed" ]] || fail "opt-in speech smoke did not invoke the helper"
 observed_value="$(<"$observed")"
@@ -126,4 +128,4 @@ if "$manifest_verifier" "$installed_app" "$manifest" >/dev/null 2>&1; then
   fail "standalone package verification accepted a changed sealed resource"
 fi
 
-echo "Installed speech smoke opt-in, download authorization, isolated cwd, helper hash, and MLX manifest tests passed."
+echo "Installed speech smoke opt-in, download authorization, isolated cwd, helper hash, and staged MLX resource tests passed."

--- a/docs/adr/0006-local-interviewer-speech.md
+++ b/docs/adr/0006-local-interviewer-speech.md
@@ -72,4 +72,8 @@ Speech remains optional derived presentation instead of interview state. The
 Session Manifest has additional lifecycle history and revisions, but a model,
 storage, provider, or playback failure cannot erase or delay canonical Turns.
 The installed package must carry and verify MLX runtime resources, while the
-large model remains an explicit separately managed local asset.
+large model remains an explicit separately managed local asset. The installed
+speech smoke projects the already manifest-verified `default.metallib` into its
+private ephemeral working directory because its standalone helper is not hosted
+by the application bundle; the production application continues loading the
+canonical SwiftPM resource bundle from `Contents/Resources`.

--- a/scripts/installed-smoke-common.zsh
+++ b/scripts/installed-smoke-common.zsh
@@ -83,6 +83,77 @@ interview_arc_live_run_installed_smoke() {
     return 65
   fi
 
+  if [[ "$helper_name" == "InterviewArcLiveSpeechSmoke" ]]; then
+    local -a mlx_metallib_candidates=(
+      "$installed_app/Contents/Resources/mlx-swift_Cmlx.bundle"/**/default.metallib(N)
+    )
+    if (( ${#mlx_metallib_candidates} != 1 )) \
+        || [[ ! -f "${mlx_metallib_candidates[1]}" \
+        || -L "${mlx_metallib_candidates[1]}" ]]; then
+      echo "Installed local-speech smoke requires exactly one regular MLX Metal resource." >&2
+      return 65
+    fi
+
+    local manifest_mlx_output
+    if ! manifest_mlx_output="$(/usr/bin/awk -F= '
+      $1 == "mlx_metallib_relative_path" {
+        path_count += 1
+        path_value = substr($0, length($1) + 2)
+      }
+      $1 == "mlx_metallib_sha256" {
+        hash_count += 1
+        hash_value = substr($0, length($1) + 2)
+      }
+      $1 == "mlx_metallib_byte_count" {
+        byte_count += 1
+        byte_value = substr($0, length($1) + 2)
+      }
+      END {
+        if (path_count != 1 || hash_count != 1 || byte_count != 1 \
+            || path_value == "" || hash_value == "" || byte_value == "") exit 65
+        print path_value
+        print hash_value
+        print byte_value
+      }
+    ' "$package_manifest")"; then
+      echo "Installed local-speech smoke requires unique MLX manifest fields." >&2
+      return 65
+    fi
+    local -a manifest_mlx_values=("${(@f)manifest_mlx_output}")
+    local mlx_metallib="${mlx_metallib_candidates[1]}"
+    local mlx_relative_path="${mlx_metallib#$installed_app/}"
+    local mlx_sha256="$(/usr/bin/shasum -a 256 "$mlx_metallib" | /usr/bin/awk '{print $1}')"
+    local mlx_byte_count="$(/usr/bin/stat -f '%z' "$mlx_metallib")"
+    if (( ${#manifest_mlx_values} != 3 )) \
+        || [[ "${manifest_mlx_values[1]}" != "$mlx_relative_path" \
+        || "${manifest_mlx_values[2]}" != "$mlx_sha256" \
+        || "${manifest_mlx_values[3]}" != "$mlx_byte_count" ]]; then
+      echo "Installed local-speech smoke MLX resource no longer matches its verified manifest." >&2
+      return 65
+    fi
+
+    local staged_metallib="$smoke_root/default.metallib"
+    if [[ -e "$staged_metallib" || -L "$staged_metallib" ]]; then
+      echo "Installed local-speech smoke workspace is not empty." >&2
+      return 65
+    fi
+    local previous_umask="$(umask)"
+    umask 077
+    if ! /bin/cp -p "$mlx_metallib" "$staged_metallib"; then
+      umask "$previous_umask"
+      echo "Installed local-speech smoke could not stage its verified MLX resource." >&2
+      return 65
+    fi
+    umask "$previous_umask"
+    if ! /bin/chmod 0400 "$staged_metallib" \
+        || [[ ! -f "$staged_metallib" || -L "$staged_metallib" ]] \
+        || [[ "$(/usr/bin/shasum -a 256 "$staged_metallib" | /usr/bin/awk '{print $1}')" != "$mlx_sha256" ]] \
+        || [[ "$(/usr/bin/stat -f '%z' "$staged_metallib")" != "$mlx_byte_count" ]]; then
+      echo "Installed local-speech smoke staged an invalid MLX resource." >&2
+      return 65
+    fi
+  fi
+
   cd "$smoke_root"
   local helper_status=0
   if [[ "$helper_name" == "InterviewArcLiveSpeechSmoke" ]]; then


### PR DESCRIPTION
## **User description**
Refs #13

## Summary
- stage the already manifest-verified MLX metallib into the private installed-speech smoke workspace
- keep signed application bytes and the package-manifest schema unchanged
- verify the staged resource path, hash, size, and cleanup in the smoke safety fixture

## Verification
- Tests/ScriptTests/speech-smoke-tests.zsh
- Tests/ScriptTests/codex-smoke-tests.zsh
- Tests/ScriptTests/endpoint-smoke-tests.zsh
- zsh -n focused scripts
- git diff --check
- real installed Qwen smoke: 14 chunks, 4.32 s audio, first audio 8.719 s


___

## **CodeAnt-AI Description**
Stage and verify the MLX speech resource during installed smoke tests

### What Changed
- Installed speech smoke runs now copy the verified MLX Metal resource into the isolated smoke workspace before starting the helper
- The smoke fails when the resource is missing, duplicated, modified, symlinked, or inconsistent with the package manifest
- Tests confirm the staged file’s expected hash, size, permissions, and cleanup without changing signed application contents
- Documentation records why the temporary resource staging is required for the standalone speech helper

### Impact
`✅ Reliable installed speech smoke coverage`
`✅ Detection of tampered or incomplete MLX resources`
`✅ Unchanged production package and signed application bytes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
