### PR TITLE
Project one room into full and compact presentations

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@ Current product design: [specialty room concepts](docs/design/specialty-rooms.md
 ## Current implementation
 
 Interview Arc Live is a standalone Swift package with a locally durable
-system-design room. It records and recovers candidate segments, transcribes
-through Groq, keeps semantic endpointing advisory, obtains canonical written
-interviewer turns through the locally authenticated Codex App Server, and can
-explicitly generate or replay a private local interviewer voice. Product
-decisions live in
+system-design room. One process-owned room model is retained across its full
+window and nonactivating compact controls. It records and recovers candidate
+segments, transcribes through Groq, keeps semantic endpointing advisory,
+obtains canonical written interviewer turns through the locally authenticated
+Codex App Server, and can explicitly generate or replay a private local
+interviewer voice. Product decisions live in
 [issue #1](https://github.com/Vinosaamaa/interview-arc-live/issues/1); the
 foundation is tracked by
 [issue #3](https://github.com/Vinosaamaa/interview-arc-live/issues/3), and the

--- a/Sources/InterviewArcLive/CompactRoomPresentation.swift
+++ b/Sources/InterviewArcLive/CompactRoomPresentation.swift
@@ -1,0 +1,449 @@
+import InterviewArcLiveCore
+
+enum CompactRoomAction: String, CaseIterable, Hashable {
+    case recordSegment
+    case stopRecording
+    case primaryPhaseAction
+    case stopSpeech
+    case toggleSpeechMute
+    case expand
+}
+
+struct CompactRoomControl: Equatable, Identifiable {
+    let action: CompactRoomAction
+    let title: String
+    let systemImage: String
+    let isEnabled: Bool
+    let accessibilityHint: String
+    let accessibilityValue: String?
+
+    var id: CompactRoomAction { action }
+}
+
+struct CompactRoomPresentation: Equatable {
+    enum StatusKind: Equatable {
+        case restoring
+        case preparing
+        case candidateFloor
+        case recording
+        case saving
+        case transcribing
+        case interviewerWorking
+        case retryRequired
+        case interviewerTurn
+        case speechGenerating
+        case speechPlayback
+        case recoveryAttention
+        case completed
+    }
+
+    enum Tone: Equatable {
+        case quiet
+        case candidate
+        case working
+        case interviewer
+        case warning
+        case completed
+    }
+
+    enum SpeechActivity: Equatable {
+        case generating
+        case playing
+    }
+
+    struct Input {
+        var phase: InterviewRoomPhase?
+        var candidateSegmentLifecycles: [CandidateSegmentLifecycle]
+        var statusMessage: String
+        var attentionMessage: String?
+        var speechActivity: SpeechActivity?
+        var isInterviewerRequestInFlight: Bool
+        var isWorking: Bool
+        var canStopRecording: Bool
+        var stopRecordingTitle: String
+        var stopRecordingSystemImage: String
+        var showsRecordControl: Bool
+        var canRecordSegment: Bool
+        var recordTitle: String
+        var phaseActionTitle: String
+        var phaseActionSystemImage: String
+        var canPerformPhaseAction: Bool
+        var canStopSpeech: Bool
+        var showsSpeechMuteControl: Bool
+        var canToggleSpeechMute: Bool
+        var isSpeechMuted: Bool
+
+        init(
+            phase: InterviewRoomPhase? = nil,
+            candidateSegmentLifecycles: [CandidateSegmentLifecycle] = [],
+            statusMessage: String = "Restoring local session…",
+            attentionMessage: String? = nil,
+            speechActivity: SpeechActivity? = nil,
+            isInterviewerRequestInFlight: Bool = false,
+            isWorking: Bool = false,
+            canStopRecording: Bool = false,
+            stopRecordingTitle: String = "Stop segment",
+            stopRecordingSystemImage: String = "stop.fill",
+            showsRecordControl: Bool = false,
+            canRecordSegment: Bool = false,
+            recordTitle: String = "Record segment",
+            phaseActionTitle: String = "Hand off",
+            phaseActionSystemImage: String = "arrowshape.right.circle.fill",
+            canPerformPhaseAction: Bool = false,
+            canStopSpeech: Bool = false,
+            showsSpeechMuteControl: Bool = false,
+            canToggleSpeechMute: Bool = false,
+            isSpeechMuted: Bool = false
+        ) {
+            self.phase = phase
+            self.candidateSegmentLifecycles = candidateSegmentLifecycles
+            self.statusMessage = statusMessage
+            self.attentionMessage = attentionMessage
+            self.speechActivity = speechActivity
+            self.isInterviewerRequestInFlight = isInterviewerRequestInFlight
+            self.isWorking = isWorking
+            self.canStopRecording = canStopRecording
+            self.stopRecordingTitle = stopRecordingTitle
+            self.stopRecordingSystemImage = stopRecordingSystemImage
+            self.showsRecordControl = showsRecordControl
+            self.canRecordSegment = canRecordSegment
+            self.recordTitle = recordTitle
+            self.phaseActionTitle = phaseActionTitle
+            self.phaseActionSystemImage = phaseActionSystemImage
+            self.canPerformPhaseAction = canPerformPhaseAction
+            self.canStopSpeech = canStopSpeech
+            self.showsSpeechMuteControl = showsSpeechMuteControl
+            self.canToggleSpeechMute = canToggleSpeechMute
+            self.isSpeechMuted = isSpeechMuted
+        }
+    }
+
+    let statusKind: StatusKind
+    let tone: Tone
+    let floorTitle: String
+    let statusValue: String
+    let systemImage: String
+    let controls: [CompactRoomControl]
+
+    var candidateControl: CompactRoomControl? {
+        controls.first {
+            $0.action == .recordSegment || $0.action == .stopRecording
+        }
+    }
+
+    var phaseControl: CompactRoomControl? {
+        controls.first { $0.action == .primaryPhaseAction }
+    }
+
+    var speechControls: [CompactRoomControl] {
+        controls.filter {
+            $0.action == .stopSpeech || $0.action == .toggleSpeechMute
+        }
+    }
+
+    var expandControl: CompactRoomControl {
+        controls.first { $0.action == .expand }!
+    }
+
+    static func make(input: Input) -> CompactRoomPresentation {
+        let status = status(for: input)
+        var controls: [CompactRoomControl] = []
+
+        if input.phase == .candidateFloor {
+            if input.canStopRecording {
+                controls.append(
+                    CompactRoomControl(
+                        action: .stopRecording,
+                        title: input.stopRecordingTitle,
+                        systemImage: input.stopRecordingSystemImage,
+                        isEnabled: !input.isWorking,
+                        accessibilityHint: "Stops the existing candidate capture path "
+                            + "and preserves its source recording.",
+                        accessibilityValue: nil
+                    )
+                )
+            } else if input.showsRecordControl {
+                controls.append(
+                    CompactRoomControl(
+                        action: .recordSegment,
+                        title: input.recordTitle,
+                        systemImage: "record.circle",
+                        isEnabled: input.canRecordSegment,
+                        accessibilityHint: "Starts the existing candidate Segment capture path.",
+                        accessibilityValue: nil
+                    )
+                )
+            }
+        }
+
+        if input.phase == .candidateFloor
+            || input.phase == .interviewerProcessing
+            || input.phase == .interviewerTurn {
+            controls.append(
+                CompactRoomControl(
+                    action: .primaryPhaseAction,
+                    title: input.phaseActionTitle,
+                    systemImage: input.phaseActionSystemImage,
+                    isEnabled: input.canPerformPhaseAction,
+                    accessibilityHint: phaseActionHint(for: input.phase),
+                    accessibilityValue: nil
+                )
+            )
+        }
+
+        if input.canStopSpeech {
+            controls.append(
+                CompactRoomControl(
+                    action: .stopSpeech,
+                    title: "Stop speech",
+                    systemImage: "stop.fill",
+                    isEnabled: true,
+                    accessibilityHint: "Stops current local speech generation "
+                        + "and playback without changing the written turn.",
+                    accessibilityValue: nil
+                )
+            )
+        }
+
+        if input.showsSpeechMuteControl {
+            controls.append(
+                CompactRoomControl(
+                    action: .toggleSpeechMute,
+                    title: input.isSpeechMuted ? "Unmute Mara" : "Mute Mara",
+                    systemImage: input.isSpeechMuted
+                        ? "speaker.wave.2.fill"
+                        : "speaker.slash.fill",
+                    isEnabled: input.canToggleSpeechMute,
+                    accessibilityHint: input.isSpeechMuted
+                        ? "Allows future local interviewer speech without "
+                            + "replaying historical turns."
+                        : "Immediately stops current speech and suppresses "
+                            + "future automatic speech.",
+                    accessibilityValue: input.isSpeechMuted ? "Muted" : "Unmuted"
+                )
+            )
+        }
+
+        controls.append(
+            CompactRoomControl(
+                action: .expand,
+                title: "Expand",
+                systemImage: "rectangle.expand.vertical",
+                isEnabled: true,
+                accessibilityHint: "Returns to the retained full interview "
+                    + "room and restores keyboard focus.",
+                accessibilityValue: nil
+            )
+        )
+
+        return CompactRoomPresentation(
+            statusKind: status.kind,
+            tone: status.tone,
+            floorTitle: floorTitle(for: input.phase),
+            statusValue: status.value,
+            systemImage: status.systemImage,
+            controls: controls
+        )
+    }
+
+    private static func status(
+        for input: Input
+    ) -> (kind: StatusKind, tone: Tone, value: String, systemImage: String) {
+        if input.phase == .completed {
+            return (
+                .completed,
+                .completed,
+                input.statusMessage,
+                "checkmark.circle.fill"
+            )
+        }
+
+        let normalizedStatus = input.statusMessage.lowercased()
+        if input.candidateSegmentLifecycles.contains(.finalizationAuthorized)
+            || normalizedStatus.contains("saving recording")
+            || normalizedStatus.contains("saving source")
+            || normalizedStatus.contains("recovering the source") {
+            return (.saving, .working, input.statusMessage, "square.and.arrow.down")
+        }
+        if input.candidateSegmentLifecycles.contains(.transcribing)
+            || normalizedStatus.contains("transcrib") {
+            return (.transcribing, .working, input.statusMessage, "waveform")
+        }
+        if input.candidateSegmentLifecycles.contains(.recording) {
+            return (.recording, .candidate, input.statusMessage, "record.circle.fill")
+        }
+        if input.candidateSegmentLifecycles.contains(.captureAuthorized)
+            || normalizedStatus.contains("preparing microphone") {
+            return (.preparing, .working, input.statusMessage, "mic.badge.plus")
+        }
+
+        switch input.speechActivity {
+        case .generating:
+            return (
+                .speechGenerating,
+                .working,
+                "Generating Mara’s response locally",
+                "waveform"
+            )
+        case .playing:
+            return (
+                .speechPlayback,
+                .interviewer,
+                "Mara is speaking",
+                "speaker.wave.2.fill"
+            )
+        case nil:
+            break
+        }
+
+        if input.isInterviewerRequestInFlight {
+            return (
+                .interviewerWorking,
+                .working,
+                input.statusMessage,
+                "ellipsis.bubble.fill"
+            )
+        }
+
+        if let attentionMessage = input.attentionMessage {
+            return (
+                .recoveryAttention,
+                .warning,
+                attentionMessage,
+                "exclamationmark.triangle.fill"
+            )
+        }
+        if input.candidateSegmentLifecycles.contains(.audioReady)
+            || input.candidateSegmentLifecycles.contains(.failed)
+            || normalizedStatus.contains("recovery")
+            || normalizedStatus.contains("required") {
+            return (
+                .recoveryAttention,
+                .warning,
+                input.statusMessage,
+                "exclamationmark.triangle.fill"
+            )
+        }
+
+        switch input.phase {
+        case .candidateFloor:
+            return (
+                .candidateFloor,
+                .candidate,
+                input.statusMessage,
+                "person.wave.2.fill"
+            )
+        case .interviewerProcessing:
+            return (
+                .retryRequired,
+                .warning,
+                input.statusMessage,
+                "arrow.clockwise.circle.fill"
+            )
+        case .interviewerTurn:
+            return (
+                .interviewerTurn,
+                .interviewer,
+                input.statusMessage,
+                "bubble.left.and.bubble.right.fill"
+            )
+        case .ready:
+            return (
+                .preparing,
+                .quiet,
+                input.statusMessage,
+                "hourglass"
+            )
+        case .completed:
+            preconditionFailure("Completed status is handled above")
+        case nil:
+            return (
+                .restoring,
+                .quiet,
+                input.statusMessage,
+                "clock.arrow.circlepath"
+            )
+        }
+    }
+
+    private static func floorTitle(
+        for phase: InterviewRoomPhase?
+    ) -> String {
+        switch phase {
+        case .candidateFloor: return "Your floor"
+        case .interviewerProcessing: return "Answer saved"
+        case .interviewerTurn: return "Interviewer turn"
+        case .completed: return "Interview complete"
+        case .ready, nil: return "Preparing room"
+        }
+    }
+
+    private static func phaseActionHint(
+        for phase: InterviewRoomPhase?
+    ) -> String {
+        switch phase {
+        case .candidateFloor:
+            return "Commits the ready Segment transcripts as one candidate answer."
+        case .interviewerProcessing:
+            return "Starts one explicit retry of the saved interviewer request."
+        case .interviewerTurn:
+            return "Returns the existing room to the candidate floor."
+        case .ready, .completed, nil:
+            return "Uses the current room phase action."
+        }
+    }
+}
+
+extension SystemDesignRoomModel {
+    var compactPresentation: CompactRoomPresentation {
+        let draftLifecycles = snapshot?.segments
+            .filter { $0.committedTurnID == nil }
+            .map(\.lifecycle) ?? []
+
+        let speechActivity: CompactRoomPresentation.SpeechActivity?
+        if playingUtteranceID != nil
+            || snapshot?.interviewerUtterances.contains(where: {
+                $0.lifecycle == .speaking
+            }) == true {
+            speechActivity = .playing
+        } else if snapshot?.interviewerUtterances.contains(where: {
+            $0.lifecycle == .generating
+        }) == true {
+            speechActivity = .generating
+        } else {
+            speechActivity = nil
+        }
+
+        let canStopSpeech = playingUtteranceID != nil
+            || snapshot?.interviewerUtterances.contains(where: {
+                speechPresentation(for: $0).canStop
+            }) == true
+
+        return CompactRoomPresentation.make(
+            input: CompactRoomPresentation.Input(
+                phase: snapshot?.phase,
+                candidateSegmentLifecycles: draftLifecycles,
+                statusMessage: statusMessage,
+                attentionMessage: errorMessage
+                    ?? speechErrorMessage
+                    ?? codexAttentionMessage,
+                speechActivity: speechActivity,
+                isInterviewerRequestInFlight: isInterviewerRequestInFlight,
+                isWorking: isWorking,
+                canStopRecording: canStopRecording,
+                stopRecordingTitle: stopActionTitle,
+                stopRecordingSystemImage: stopActionIcon,
+                showsRecordControl: showsRecordControl,
+                canRecordSegment: canRecordSegment,
+                recordTitle: recordActionTitle,
+                phaseActionTitle: actionTitle,
+                phaseActionSystemImage: actionIcon,
+                canPerformPhaseAction: canAct,
+                canStopSpeech: canStopSpeech,
+                showsSpeechMuteControl: showsSpeechMuteControl,
+                canToggleSpeechMute: canToggleSpeechMute,
+                isSpeechMuted: isSpeechMuted
+            )
+        )
+    }
+}

--- a/Sources/InterviewArcLive/CompactSystemDesignRoomView.swift
+++ b/Sources/InterviewArcLive/CompactSystemDesignRoomView.swift
@@ -1,0 +1,233 @@
+import SwiftUI
+
+struct CompactSystemDesignRoomView: View {
+    @ObservedObject var model: SystemDesignRoomModel
+    let onExpand: () -> Void
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private var presentation: CompactRoomPresentation {
+        model.compactPresentation
+    }
+
+    var body: some View {
+        ViewThatFits(in: .vertical) {
+            capsuleContent
+
+            ScrollView(.vertical) {
+                capsuleContent
+            }
+            .scrollIndicators(.visible)
+            .frame(height: CompactPanelLayout.maximumContentHeight)
+        }
+        .frame(width: CompactPanelLayout.contentWidth)
+        .frame(
+            minHeight: CompactPanelLayout.minimumContentHeight,
+            maxHeight: CompactPanelLayout.maximumContentHeight,
+            alignment: .topLeading
+        )
+        .background(
+            LivePalette.shell,
+            in: RoundedRectangle(cornerRadius: 22, style: .continuous)
+        )
+        .foregroundStyle(LivePalette.paper)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Interview Arc Live compact interview controls")
+        .animation(
+            reduceMotion ? nil : .easeOut(duration: 0.16),
+            value: presentation.statusKind
+        )
+    }
+
+    private var capsuleContent: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            status
+
+            Rectangle()
+                .fill(LivePalette.line.opacity(0.42))
+                .frame(height: 1)
+                .accessibilityHidden(true)
+
+            if !conversationControls.isEmpty {
+                controlRow(conversationControls)
+            }
+            bottomControlRow
+        }
+        .padding(18)
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private var status: some View {
+        HStack(alignment: .top, spacing: 13) {
+            Image(systemName: presentation.systemImage)
+                .font(.system(size: 22, weight: .semibold))
+                .foregroundStyle(statusColor)
+                .frame(width: 30, height: 30)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(presentation.floorTitle)
+                    .font(.system(.headline, design: .rounded, weight: .semibold))
+                Text(presentation.statusValue)
+                    .font(.system(.body, design: .rounded))
+                    .foregroundStyle(LivePalette.line)
+                    .lineLimit(3)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .help(presentation.statusValue)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("compact-room-status")
+        .accessibilityLabel("Current interview status")
+        .accessibilityValue(
+            "\(presentation.floorTitle). \(presentation.statusValue)"
+        )
+        .accessibilitySortPriority(60)
+    }
+
+    private var conversationControls: [CompactRoomControl] {
+        [presentation.candidateControl, presentation.phaseControl]
+            .compactMap { $0 }
+    }
+
+    private func controlRow(
+        _ controls: [CompactRoomControl]
+    ) -> some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 10) {
+                ForEach(controls) { control in
+                    controlButton(control)
+                }
+                Spacer(minLength: 0)
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                ForEach(controls) { control in
+                    controlButton(control)
+                }
+            }
+        }
+    }
+
+    private var bottomControlRow: some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 10) {
+                ForEach(presentation.speechControls) { control in
+                    controlButton(control)
+                }
+                Spacer(minLength: 12)
+                controlButton(presentation.expandControl)
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                ForEach(presentation.speechControls) { control in
+                    controlButton(control)
+                }
+                controlButton(presentation.expandControl)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func controlButton(
+        _ control: CompactRoomControl
+    ) -> some View {
+        let button = Button {
+            dispatch(control.action)
+        } label: {
+            Label(control.title, systemImage: control.systemImage)
+                .font(.system(.body, design: .rounded, weight: .semibold))
+        }
+        .disabled(!control.isEnabled)
+        .frame(minHeight: 34)
+        .help(control.accessibilityHint)
+        .accessibilityIdentifier("compact-room-\(control.action.rawValue)")
+        .accessibilityHint(control.accessibilityHint)
+        .optionalAccessibilityValue(control.accessibilityValue)
+        .accessibilitySortPriority(accessibilityPriority(for: control.action))
+
+        switch control.action {
+        case .stopRecording, .primaryPhaseAction:
+            button
+                .buttonStyle(.borderedProminent)
+                .tint(LivePalette.handoff)
+        case .recordSegment:
+            button
+                .buttonStyle(.bordered)
+                .tint(LivePalette.paper)
+        case .stopSpeech:
+            button
+                .buttonStyle(.borderedProminent)
+                .tint(LivePalette.interviewer)
+        case .toggleSpeechMute, .expand:
+            button
+                .buttonStyle(.bordered)
+                .tint(LivePalette.paper)
+        }
+    }
+
+    private var statusColor: Color {
+        switch presentation.tone {
+        case .quiet: return LivePalette.line
+        case .candidate: return LivePalette.liveSignal
+        case .working: return LivePalette.interviewer
+        case .interviewer: return LivePalette.interviewer
+        case .warning: return LivePalette.handoff
+        case .completed: return LivePalette.liveSignal
+        }
+    }
+
+    private func accessibilityPriority(
+        for action: CompactRoomAction
+    ) -> Double {
+        switch action {
+        case .recordSegment, .stopRecording: return 50
+        case .primaryPhaseAction: return 40
+        case .stopSpeech: return 30
+        case .toggleSpeechMute: return 20
+        case .expand: return 10
+        }
+    }
+
+    private func dispatch(_ action: CompactRoomAction) {
+        switch action {
+        case .recordSegment:
+            Task { await model.recordSegment() }
+        case .stopRecording:
+            Task { await model.stopRecording() }
+        case .primaryPhaseAction:
+            Task { await model.performPrimaryAction() }
+        case .stopSpeech:
+            Task { await model.stopSpeech() }
+        case .toggleSpeechMute:
+            Task { await model.toggleSpeechMute() }
+        case .expand:
+            onExpand()
+        }
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func optionalAccessibilityValue(_ value: String?) -> some View {
+        if let value {
+            accessibilityValue(value)
+        } else {
+            self
+        }
+    }
+}
+
+private struct CompactSystemDesignRoomViewPreview: PreviewProvider {
+    static var previews: some View {
+        CompactSystemDesignRoomView(
+            model: SystemDesignRoomModel(),
+            onExpand: {}
+        )
+        .padding(30)
+        .background(Color.gray.opacity(0.2))
+        .previewDisplayName("Compact system design room")
+    }
+}

--- a/Sources/InterviewArcLive/InterviewArcLiveApp.swift
+++ b/Sources/InterviewArcLive/InterviewArcLiveApp.swift
@@ -1,15 +1,252 @@
-import SwiftUI
+import AppKit
 
 @main
-struct InterviewArcLiveApp: App {
-    @StateObject private var model = SystemDesignRoomModel()
+@MainActor
+final class InterviewArcLiveApp: NSObject, NSApplicationDelegate {
+    private static var retainedDelegate: InterviewArcLiveApp?
 
-    var body: some Scene {
-        WindowGroup("Interview Arc Live") {
-            SystemDesignRoomView(model: model)
-                .frame(minWidth: 1_080, minHeight: 700)
-        }
-        .windowStyle(.hiddenTitleBar)
-        .defaultSize(width: 1_180, height: 760)
+    private let model = SystemDesignRoomModel()
+    private var presentationCoordinator: InterviewRoomPresentationCoordinator?
+
+    static func main() {
+        let application = NSApplication.shared
+        let delegate = InterviewArcLiveApp()
+        retainedDelegate = delegate
+        application.delegate = delegate
+        application.setActivationPolicy(.regular)
+        application.run()
+        retainedDelegate = nil
+    }
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        installMainMenu()
+        let coordinator = InterviewRoomPresentationCoordinator(model: model)
+        presentationCoordinator = coordinator
+        coordinator.start()
+    }
+
+    func applicationShouldHandleReopen(
+        _ sender: NSApplication,
+        hasVisibleWindows flag: Bool
+    ) -> Bool {
+        presentationCoordinator?.reopen()
+        return false
+    }
+
+    func applicationShouldTerminateAfterLastWindowClosed(
+        _ sender: NSApplication
+    ) -> Bool {
+        false
+    }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        presentationCoordinator?.prepareForTermination()
+    }
+
+    @objc
+    private func showInterviewRoom(_ sender: Any?) {
+        presentationCoordinator?.reopen()
+    }
+
+    @objc
+    private func closeInterviewRoom(_ sender: Any?) {
+        presentationCoordinator?.requestFullWindowClose()
+    }
+
+    private func installMainMenu() {
+        NSApp.mainMenu = makeMainMenu()
+    }
+
+    func makeMainMenu() -> NSMenu {
+        let mainMenu = NSMenu()
+        mainMenu.addItem(applicationMenuItem())
+        mainMenu.addItem(fileMenuItem())
+        mainMenu.addItem(editMenuItem())
+        mainMenu.addItem(windowMenuItem())
+        return mainMenu
+    }
+
+    private func applicationMenuItem() -> NSMenuItem {
+        let root = NSMenuItem()
+        let menu = NSMenu(title: "Interview Arc Live")
+        root.submenu = menu
+
+        menu.addItem(
+            NSMenuItem(
+                title: "About Interview Arc Live",
+                action: #selector(NSApplication.orderFrontStandardAboutPanel(_:)),
+                keyEquivalent: ""
+            )
+        )
+        menu.addItem(.separator())
+
+        let servicesItem = NSMenuItem(title: "Services", action: nil, keyEquivalent: "")
+        let servicesMenu = NSMenu(title: "Services")
+        servicesItem.submenu = servicesMenu
+        menu.addItem(servicesItem)
+        NSApp.servicesMenu = servicesMenu
+
+        menu.addItem(.separator())
+        menu.addItem(
+            NSMenuItem(
+                title: "Hide Interview Arc Live",
+                action: #selector(NSApplication.hide(_:)),
+                keyEquivalent: "h"
+            )
+        )
+        let hideOthers = NSMenuItem(
+            title: "Hide Others",
+            action: #selector(NSApplication.hideOtherApplications(_:)),
+            keyEquivalent: "h"
+        )
+        hideOthers.keyEquivalentModifierMask = [.command, .option]
+        menu.addItem(hideOthers)
+        menu.addItem(
+            NSMenuItem(
+                title: "Show All",
+                action: #selector(NSApplication.unhideAllApplications(_:)),
+                keyEquivalent: ""
+            )
+        )
+        menu.addItem(.separator())
+        menu.addItem(
+            NSMenuItem(
+                title: "Quit Interview Arc Live",
+                action: #selector(NSApplication.terminate(_:)),
+                keyEquivalent: "q"
+            )
+        )
+        return root
+    }
+
+    private func fileMenuItem() -> NSMenuItem {
+        let root = NSMenuItem()
+        let menu = NSMenu(title: "File")
+        root.submenu = menu
+
+        let close = NSMenuItem(
+            title: "Close Interview Room",
+            action: #selector(closeInterviewRoom(_:)),
+            keyEquivalent: "w"
+        )
+        close.target = self
+        menu.addItem(close)
+        return root
+    }
+
+    private func editMenuItem() -> NSMenuItem {
+        let root = NSMenuItem()
+        let menu = NSMenu(title: "Edit")
+        root.submenu = menu
+
+        menu.addItem(
+            responderMenuItem(
+                title: "Undo",
+                action: Selector(("undo:")),
+                keyEquivalent: "z"
+            )
+        )
+        menu.addItem(
+            responderMenuItem(
+                title: "Redo",
+                action: Selector(("redo:")),
+                keyEquivalent: "z",
+                modifiers: [.command, .shift]
+            )
+        )
+        menu.addItem(.separator())
+        menu.addItem(
+            responderMenuItem(
+                title: "Cut",
+                action: #selector(NSText.cut(_:)),
+                keyEquivalent: "x"
+            )
+        )
+        menu.addItem(
+            responderMenuItem(
+                title: "Copy",
+                action: #selector(NSText.copy(_:)),
+                keyEquivalent: "c"
+            )
+        )
+        menu.addItem(
+            responderMenuItem(
+                title: "Paste",
+                action: #selector(NSText.paste(_:)),
+                keyEquivalent: "v"
+            )
+        )
+        menu.addItem(
+            responderMenuItem(
+                title: "Paste and Match Style",
+                action: #selector(NSTextView.pasteAsPlainText(_:)),
+                keyEquivalent: "v",
+                modifiers: [.command, .option, .shift]
+            )
+        )
+        menu.addItem(
+            responderMenuItem(
+                title: "Delete",
+                action: #selector(NSText.delete(_:)),
+                keyEquivalent: "\u{8}",
+                modifiers: []
+            )
+        )
+        menu.addItem(.separator())
+        menu.addItem(
+            responderMenuItem(
+                title: "Select All",
+                action: #selector(NSResponder.selectAll(_:)),
+                keyEquivalent: "a"
+            )
+        )
+        return root
+    }
+
+    private func responderMenuItem(
+        title: String,
+        action: Selector,
+        keyEquivalent: String,
+        modifiers: NSEvent.ModifierFlags = [.command]
+    ) -> NSMenuItem {
+        let item = NSMenuItem(
+            title: title,
+            action: action,
+            keyEquivalent: keyEquivalent
+        )
+        item.target = nil
+        item.keyEquivalentModifierMask = modifiers
+        return item
+    }
+
+    private func windowMenuItem() -> NSMenuItem {
+        let root = NSMenuItem()
+        let menu = NSMenu(title: "Window")
+        root.submenu = menu
+
+        menu.addItem(
+            NSMenuItem(
+                title: "Minimize",
+                action: #selector(NSWindow.performMiniaturize(_:)),
+                keyEquivalent: "m"
+            )
+        )
+        menu.addItem(
+            NSMenuItem(
+                title: "Zoom",
+                action: #selector(NSWindow.performZoom(_:)),
+                keyEquivalent: ""
+            )
+        )
+        menu.addItem(.separator())
+        let show = NSMenuItem(
+            title: "Show Interview Room",
+            action: #selector(showInterviewRoom(_:)),
+            keyEquivalent: "0"
+        )
+        show.target = self
+        menu.addItem(show)
+        NSApp.windowsMenu = menu
+        return root
     }
 }

--- a/Sources/InterviewArcLive/InterviewRoomPresentationCoordinator.swift
+++ b/Sources/InterviewArcLive/InterviewRoomPresentationCoordinator.swift
@@ -1,0 +1,696 @@
+import AppKit
+import InterviewArcLiveCore
+import SwiftUI
+
+enum InterviewRoomPresentationState: Equatable {
+    case notStarted
+    case full
+    case compact
+    case closed
+    case terminated
+}
+
+enum InterviewRoomCloseChoice: Equatable {
+    case continueCompact
+    case endInterview
+    case cancel
+}
+
+enum CompactPanelLayout {
+    static let contentWidth: CGFloat = 640
+    static let minimumContentHeight: CGFloat = 214
+    static let maximumContentHeight: CGFloat = 420
+
+    static func boundedContentHeight(_ measuredHeight: CGFloat) -> CGFloat {
+        guard !measuredHeight.isNaN else { return minimumContentHeight }
+        if !measuredHeight.isFinite {
+            return measuredHeight > 0
+                ? maximumContentHeight
+                : minimumContentHeight
+        }
+        return min(
+            max(ceil(measuredHeight), minimumContentHeight),
+            maximumContentHeight
+        )
+    }
+
+    static func framePreservingTopEdge(
+        _ frame: NSRect,
+        measuredContentHeight: CGFloat
+    ) -> NSRect {
+        let height = boundedContentHeight(measuredContentHeight)
+        return NSRect(
+            x: frame.minX,
+            y: frame.maxY - height,
+            width: contentWidth,
+            height: height
+        )
+    }
+}
+
+/// Owns the two process-level Presentations while the interview model remains
+/// the single interaction writer. Hiding a Presentation never tears down its
+/// hosting tree or creates session/provider state.
+@MainActor
+final class InterviewRoomPresentationCoordinator: NSObject, NSWindowDelegate {
+    let model: SystemDesignRoomModel
+
+    private(set) var presentationState: InterviewRoomPresentationState = .notStarted
+    private(set) var didRequestModelOpen = false
+    private(set) var fullWindow: NSWindow!
+    private(set) var compactPanel: NSPanel!
+
+    private var fullHostingController: NSHostingController<SystemDesignRoomView>!
+    private var compactHostingController: CompactRoomHostingController!
+    private var fullContainerController: FullRoomContainerController!
+    private let frameAutosaveName: String
+
+    private var didStart = false
+    private var didRegisterObservers = false
+    private var isAllowingFullWindowClose = false
+    private(set) var isResolvingCloseChoice = false
+    private var isAdjustingFrames = false
+    private var closeAlert: NSAlert?
+    private var modelOpenTask: Task<Void, Never>?
+    private var compactSizeReconciliationTask: Task<Void, Never>?
+    private var savedFullFrame: NSRect?
+    private var savedCompactOrigin: NSPoint?
+    private weak var savedFullFirstResponder: NSResponder?
+    private weak var closeGuardFirstResponder: NSResponder?
+
+    init(
+        model: SystemDesignRoomModel,
+        frameAutosaveName: String = "InterviewArcLive.SystemDesignRoom"
+    ) {
+        self.model = model
+        self.frameAutosaveName = frameAutosaveName
+        super.init()
+        installPresentations()
+        registerLifecycleObservers()
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    var fullHostingTreeIdentity: ObjectIdentifier {
+        ObjectIdentifier(fullHostingController)
+    }
+
+    var compactHostingTreeIdentity: ObjectIdentifier {
+        ObjectIdentifier(compactHostingController)
+    }
+
+    var fullHostedModelIdentity: ObjectIdentifier {
+        ObjectIdentifier(fullHostingController.rootView.model)
+    }
+
+    var compactHostedModelIdentity: ObjectIdentifier {
+        ObjectIdentifier(compactHostingController.rootView.model)
+    }
+
+    var fallbackFirstResponder: NSResponder {
+        fullContainerController.fallbackFirstResponder
+    }
+
+    var isCloseGuardPresented: Bool {
+        closeAlert != nil
+    }
+
+    func start() {
+        guard presentationState != .terminated, !didStart else { return }
+        didStart = true
+        showFullPresentation(activating: true)
+
+        guard !didRequestModelOpen else { return }
+        didRequestModelOpen = true
+        modelOpenTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            await model.open()
+        }
+    }
+
+    func collapse() {
+        guard presentationState != .terminated,
+              !isResolvingCloseChoice else {
+            return
+        }
+        if presentationState == .compact {
+            reconcileCompactPanelSize()
+            clampCompactPanelToVisibleScreens()
+            if !compactPanel.isVisible {
+                compactPanel.orderFrontRegardless()
+            }
+            return
+        }
+
+        captureFullPresentationState()
+        fullWindow.orderOut(nil)
+        reconcileCompactPanelSize()
+        clampCompactPanelToVisibleScreens()
+        compactPanel.orderFrontRegardless()
+        presentationState = .compact
+    }
+
+    func expand() {
+        guard presentationState != .terminated,
+              !isResolvingCloseChoice else {
+            return
+        }
+        showFullPresentation(activating: true)
+    }
+
+    func reopen() {
+        guard presentationState != .terminated,
+              !isResolvingCloseChoice else {
+            return
+        }
+        expand()
+    }
+
+    func requestFullWindowClose() {
+        guard presentationState != .terminated,
+              !isResolvingCloseChoice else {
+            return
+        }
+        if !fullWindow.isVisible {
+            expand()
+        }
+        fullWindow.performClose(nil)
+    }
+
+    func resolveCloseChoice(_ choice: InterviewRoomCloseChoice) async {
+        guard presentationState != .terminated,
+              !isResolvingCloseChoice else {
+            return
+        }
+
+        switch choice {
+        case .continueCompact:
+            collapse()
+        case .cancel:
+            presentationState = .full
+            fullWindow.makeKeyAndOrderFront(nil)
+            restoreFullFirstResponder(preferred: closeGuardFirstResponder)
+        case .endInterview:
+            isResolvingCloseChoice = true
+            defer { isResolvingCloseChoice = false }
+            let didFinish = await model.finishInterview()
+
+            guard presentationState != .terminated else { return }
+
+            guard didFinish else {
+                compactPanel.orderOut(nil)
+                presentationState = .full
+                fullWindow.makeKeyAndOrderFront(nil)
+                restoreFullFirstResponder(preferred: closeGuardFirstResponder)
+                return
+            }
+
+            compactPanel.orderOut(nil)
+            isAllowingFullWindowClose = true
+            fullWindow.performClose(nil)
+            isAllowingFullWindowClose = false
+            presentationState = .closed
+        }
+    }
+
+    func prepareForTermination() {
+        guard presentationState != .terminated else { return }
+        presentationState = .terminated
+        if didRegisterObservers {
+            NotificationCenter.default.removeObserver(self)
+            didRegisterObservers = false
+        }
+        closeAlert = nil
+        compactSizeReconciliationTask?.cancel()
+        compactSizeReconciliationTask = nil
+        compactPanel.orderOut(nil)
+        fullWindow.orderOut(nil)
+        // Do not finish the Session or cancel/replay durable provider work.
+        // Process termination owns the remaining task lifetime.
+        modelOpenTask = nil
+    }
+
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        guard sender === fullWindow else { return true }
+        if presentationState == .terminated
+            || isAllowingFullWindowClose
+            || model.snapshot?.phase == .completed {
+            return true
+        }
+        if isResolvingCloseChoice {
+            return false
+        }
+
+        presentCloseGuardIfNeeded()
+        return false
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        guard let window = notification.object as? NSWindow,
+              window === fullWindow,
+              presentationState != .terminated else {
+            return
+        }
+        presentationState = .closed
+    }
+
+    func windowDidMove(_ notification: Notification) {
+        guard !isAdjustingFrames,
+              let window = notification.object as? NSWindow else {
+            return
+        }
+        if window === compactPanel {
+            savedCompactOrigin = compactPanel.frame.origin
+        } else if window === fullWindow, !fullWindow.isMiniaturized {
+            savedFullFrame = fullWindow.frame
+        }
+    }
+
+    func windowDidResize(_ notification: Notification) {
+        guard !isAdjustingFrames,
+              let window = notification.object as? NSWindow,
+              window === fullWindow,
+              !fullWindow.isMiniaturized else {
+            return
+        }
+        savedFullFrame = fullWindow.frame
+    }
+
+    func windowDidChangeScreen(_ notification: Notification) {
+        clampPresentationFramesToVisibleScreens()
+    }
+
+    static func clampedFrame(
+        _ frame: NSRect,
+        to visibleFrames: [NSRect],
+        margin: CGFloat = 12
+    ) -> NSRect {
+        guard !visibleFrames.isEmpty else { return frame }
+
+        let target = visibleFrames.max { lhs, rhs in
+            let lhsIntersection = lhs.intersection(frame)
+            let rhsIntersection = rhs.intersection(frame)
+            let lhsArea = max(lhsIntersection.width, 0)
+                * max(lhsIntersection.height, 0)
+            let rhsArea = max(rhsIntersection.width, 0)
+                * max(rhsIntersection.height, 0)
+            if lhsArea != rhsArea {
+                return lhsArea < rhsArea
+            }
+            return squaredDistance(from: frame.center, to: lhs.center)
+                > squaredDistance(from: frame.center, to: rhs.center)
+        } ?? visibleFrames[0]
+
+        let maximumWidth = max(target.width - margin * 2, 1)
+        let maximumHeight = max(target.height - margin * 2, 1)
+        let size = NSSize(
+            width: min(frame.width, maximumWidth),
+            height: min(frame.height, maximumHeight)
+        )
+        let minimumX = target.minX + margin
+        let maximumX = max(minimumX, target.maxX - margin - size.width)
+        let minimumY = target.minY + margin
+        let maximumY = max(minimumY, target.maxY - margin - size.height)
+
+        return NSRect(
+            x: min(max(frame.minX, minimumX), maximumX),
+            y: min(max(frame.minY, minimumY), maximumY),
+            width: size.width,
+            height: size.height
+        )
+    }
+
+    private func installPresentations() {
+        let fullRoot = SystemDesignRoomView(
+            model: model,
+            onCollapse: { [weak self] in self?.collapse() }
+        )
+        fullHostingController = NSHostingController(rootView: fullRoot)
+        fullContainerController = FullRoomContainerController(
+            hostingController: fullHostingController
+        )
+
+        let full = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 1_180, height: 760),
+            styleMask: [
+                .titled,
+                .closable,
+                .miniaturizable,
+                .resizable,
+                .fullSizeContentView,
+            ],
+            backing: .buffered,
+            defer: false
+        )
+        full.title = "Interview Arc Live"
+        full.titleVisibility = .hidden
+        full.titlebarAppearsTransparent = true
+        full.isReleasedWhenClosed = false
+        full.contentMinSize = NSSize(width: 1_080, height: 700)
+        full.animationBehavior = .none
+        full.contentViewController = fullContainerController
+        full.delegate = self
+        full.identifier = NSUserInterfaceItemIdentifier("interview-room-full")
+        full.setAccessibilityIdentifier("interview-room-full")
+        full.setAccessibilityLabel("Interview Arc Live full interview room")
+        let restoredFrame = full.setFrameUsingName(frameAutosaveName)
+        _ = full.setFrameAutosaveName(frameAutosaveName)
+        if !restoredFrame {
+            full.center()
+        }
+        fullWindow = full
+        savedFullFrame = full.frame
+
+        let compactRoot = CompactSystemDesignRoomView(
+            model: model,
+            onExpand: { [weak self] in self?.expand() }
+        )
+        compactHostingController = CompactRoomHostingController(
+            rootView: compactRoot
+        )
+        compactHostingController.sizingOptions = [.intrinsicContentSize]
+        compactHostingController.onLayout = { [weak self] in
+            self?.scheduleCompactPanelSizeReconciliation()
+        }
+
+        let panel = NonactivatingInterviewPanel(
+            contentRect: NSRect(
+                x: 0,
+                y: 0,
+                width: CompactPanelLayout.contentWidth,
+                height: CompactPanelLayout.minimumContentHeight
+            ),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.title = "Interview Arc Live compact interview controls"
+        panel.contentViewController = compactHostingController
+        panel.contentMinSize = NSSize(
+            width: CompactPanelLayout.contentWidth,
+            height: CompactPanelLayout.minimumContentHeight
+        )
+        panel.contentMaxSize = NSSize(
+            width: CompactPanelLayout.contentWidth,
+            height: CompactPanelLayout.maximumContentHeight
+        )
+        panel.isReleasedWhenClosed = false
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = true
+        panel.isFloatingPanel = true
+        panel.hidesOnDeactivate = false
+        panel.becomesKeyOnlyIfNeeded = true
+        panel.worksWhenModal = true
+        panel.isMovable = true
+        panel.isMovableByWindowBackground = true
+        panel.isExcludedFromWindowsMenu = true
+        panel.level = .floating
+        panel.collectionBehavior = [.fullScreenNone]
+        panel.animationBehavior = .none
+        panel.delegate = self
+        panel.identifier = NSUserInterfaceItemIdentifier("interview-room-compact")
+        panel.setAccessibilityIdentifier("interview-room-compact")
+        panel.setAccessibilityLabel(
+            "Interview Arc Live compact interview controls"
+        )
+        panel.contentView?.wantsLayer = true
+        panel.contentView?.layer?.cornerRadius = 22
+        panel.contentView?.layer?.masksToBounds = true
+        compactPanel = panel
+        reconcileCompactPanelSize()
+        placeCompactPanelInitially()
+    }
+
+    private func registerLifecycleObservers() {
+        guard !didRegisterObservers else { return }
+        didRegisterObservers = true
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(screenParametersDidChange(_:)),
+            name: NSApplication.didChangeScreenParametersNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(applicationWillTerminate(_:)),
+            name: NSApplication.willTerminateNotification,
+            object: nil
+        )
+    }
+
+    private func showFullPresentation(activating: Bool) {
+        let frameToRestore = savedFullFrame ?? fullWindow.frame
+        compactPanel.orderOut(nil)
+        if fullWindow.isMiniaturized {
+            fullWindow.deminiaturize(nil)
+        }
+        if activating {
+            NSApp.activate(ignoringOtherApps: true)
+        }
+        fullWindow.makeKeyAndOrderFront(nil)
+        fullWindow.makeMain()
+        clampFullWindowToVisibleScreens(source: frameToRestore)
+        restoreFullFirstResponder(preferred: savedFullFirstResponder)
+        presentationState = .full
+    }
+
+    private func captureFullPresentationState() {
+        guard fullWindow != nil else { return }
+        if !fullWindow.isMiniaturized {
+            savedFullFrame = fullWindow.frame
+        }
+        if let responder = fullWindow.firstResponder {
+            savedFullFirstResponder = responder
+        }
+    }
+
+    private func restoreFullFirstResponder(
+        preferred: NSResponder?
+    ) {
+        if let preferred,
+           fullWindow.makeFirstResponder(preferred) {
+            savedFullFirstResponder = preferred
+            return
+        }
+        _ = fullWindow.makeFirstResponder(
+            fullContainerController.fallbackFirstResponder
+        )
+        savedFullFirstResponder = fullContainerController.fallbackFirstResponder
+    }
+
+    private func presentCloseGuardIfNeeded() {
+        guard closeAlert == nil else { return }
+        closeGuardFirstResponder = fullWindow.firstResponder
+
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "What should happen to this interview?"
+        alert.informativeText = "Closing the full room does not silently end "
+            + "an unfinished interview. Keep the same room available in "
+            + "compact controls, end it safely, or cancel."
+        alert.addButton(withTitle: "Continue compact")
+        alert.addButton(withTitle: "End interview")
+        alert.addButton(withTitle: "Cancel")
+        alert.buttons[1].hasDestructiveAction = true
+        alert.buttons[2].keyEquivalent = "\u{1b}"
+        closeAlert = alert
+
+        alert.beginSheetModal(for: fullWindow) { [weak self] response in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                closeAlert = nil
+                let choice: InterviewRoomCloseChoice
+                switch response {
+                case .alertFirstButtonReturn:
+                    choice = .continueCompact
+                case .alertSecondButtonReturn:
+                    choice = .endInterview
+                default:
+                    choice = .cancel
+                }
+                await resolveCloseChoice(choice)
+            }
+        }
+    }
+
+    private func placeCompactPanelInitially() {
+        let visibleFrame = fullWindow.screen?.visibleFrame
+            ?? NSScreen.main?.visibleFrame
+            ?? NSRect(x: 0, y: 0, width: 1_440, height: 900)
+        var frame = compactPanel.frame
+        frame.origin = NSPoint(
+            x: visibleFrame.maxX - frame.width - 24,
+            y: visibleFrame.maxY - frame.height - 24
+        )
+        setCompactPanelFrame(
+            Self.clampedFrame(frame, to: NSScreen.screens.map(\.visibleFrame))
+        )
+    }
+
+    private func clampPresentationFramesToVisibleScreens() {
+        clampFullWindowToVisibleScreens()
+        clampCompactPanelToVisibleScreens()
+    }
+
+    private func clampFullWindowToVisibleScreens(source: NSRect? = nil) {
+        let visibleFrames = NSScreen.screens.map(\.visibleFrame)
+        guard !visibleFrames.isEmpty else { return }
+        let frame = source ?? savedFullFrame ?? fullWindow.frame
+        let clamped = Self.clampedFrame(frame, to: visibleFrames)
+        isAdjustingFrames = true
+        fullWindow.setFrame(clamped, display: fullWindow.isVisible)
+        isAdjustingFrames = false
+        savedFullFrame = fullWindow.frame
+    }
+
+    private func clampCompactPanelToVisibleScreens() {
+        let visibleFrames = NSScreen.screens.map(\.visibleFrame)
+        guard !visibleFrames.isEmpty else { return }
+        var source = compactPanel.frame
+        if let savedCompactOrigin {
+            source.origin = savedCompactOrigin
+        }
+        setCompactPanelFrame(Self.clampedFrame(source, to: visibleFrames))
+    }
+
+    private func scheduleCompactPanelSizeReconciliation() {
+        guard compactPanel != nil,
+              presentationState != .terminated else {
+            return
+        }
+        compactSizeReconciliationTask?.cancel()
+        compactSizeReconciliationTask = Task { @MainActor [weak self] in
+            await Task.yield()
+            guard !Task.isCancelled else { return }
+            self?.reconcileCompactPanelSize()
+        }
+    }
+
+    private func reconcileCompactPanelSize() {
+        guard compactPanel != nil,
+              presentationState != .terminated else {
+            return
+        }
+        let measuredSize = compactHostingController.sizeThatFits(
+            in: NSSize(
+                width: CompactPanelLayout.contentWidth,
+                height: CompactPanelLayout.maximumContentHeight
+            )
+        )
+        let resized = CompactPanelLayout.framePreservingTopEdge(
+            compactPanel.frame,
+            measuredContentHeight: measuredSize.height
+        )
+        let clamped = Self.clampedFrame(
+            resized,
+            to: NSScreen.screens.map(\.visibleFrame)
+        )
+        guard abs(compactPanel.frame.height - clamped.height) > 0.5
+                || abs(compactPanel.frame.minX - clamped.minX) > 0.5
+                || abs(compactPanel.frame.minY - clamped.minY) > 0.5 else {
+            return
+        }
+        setCompactPanelFrame(clamped)
+    }
+
+    private func setCompactPanelFrame(_ frame: NSRect) {
+        isAdjustingFrames = true
+        compactPanel.setFrame(frame, display: compactPanel.isVisible)
+        isAdjustingFrames = false
+        savedCompactOrigin = compactPanel.frame.origin
+    }
+
+    @objc
+    private func screenParametersDidChange(_ notification: Notification) {
+        clampPresentationFramesToVisibleScreens()
+    }
+
+    @objc
+    private func applicationWillTerminate(_ notification: Notification) {
+        prepareForTermination()
+    }
+
+    private static func squaredDistance(
+        from lhs: NSPoint,
+        to rhs: NSPoint
+    ) -> CGFloat {
+        let dx = lhs.x - rhs.x
+        let dy = lhs.y - rhs.y
+        return dx * dx + dy * dy
+    }
+}
+
+private final class NonactivatingInterviewPanel: NSPanel {
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { false }
+}
+
+private final class CompactRoomHostingController:
+    NSHostingController<CompactSystemDesignRoomView>
+{
+    var onLayout: (() -> Void)?
+
+    override func viewDidLayout() {
+        super.viewDidLayout()
+        onLayout?()
+    }
+}
+
+private final class FullRoomContainerController: NSViewController {
+    let hostingController: NSHostingController<SystemDesignRoomView>
+    let fallbackFirstResponder = StableFallbackFirstResponderView()
+
+    init(hostingController: NSHostingController<SystemDesignRoomView>) {
+        self.hostingController = hostingController
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override func loadView() {
+        let container = NSView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+        view = container
+
+        addChild(hostingController)
+        let hostedView = hostingController.view
+        hostedView.translatesAutoresizingMaskIntoConstraints = false
+        fallbackFirstResponder.translatesAutoresizingMaskIntoConstraints = false
+        fallbackFirstResponder.setAccessibilityElement(false)
+
+        container.addSubview(fallbackFirstResponder)
+        container.addSubview(hostedView)
+        NSLayoutConstraint.activate([
+            hostedView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            hostedView.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            hostedView.topAnchor.constraint(equalTo: container.topAnchor),
+            hostedView.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+            fallbackFirstResponder.leadingAnchor.constraint(
+                equalTo: container.leadingAnchor
+            ),
+            fallbackFirstResponder.topAnchor.constraint(equalTo: container.topAnchor),
+            fallbackFirstResponder.widthAnchor.constraint(equalToConstant: 1),
+            fallbackFirstResponder.heightAnchor.constraint(equalToConstant: 1),
+        ])
+    }
+}
+
+private final class StableFallbackFirstResponderView: NSView {
+    override var acceptsFirstResponder: Bool { true }
+
+    override func becomeFirstResponder() -> Bool {
+        true
+    }
+}
+
+private extension NSRect {
+    var center: NSPoint {
+        NSPoint(x: midX, y: midY)
+    }
+}

--- a/Sources/InterviewArcLive/SystemDesignRoomModel.swift
+++ b/Sources/InterviewArcLive/SystemDesignRoomModel.swift
@@ -97,16 +97,21 @@ final class SystemDesignRoomModel: ObservableObject {
         codexRuntime: (any LiveCodexInterviewerRuntime)? = nil,
         activityPrompt: ActivityPrompt? = nil,
         speechDependencies: LiveInterviewerSpeechDependencies? = nil,
-        preferences: UserDefaults = .standard
+        preferences: UserDefaults = .standard,
+        initialCoordinator: SegmentSpeechCoordinator? = nil
     ) {
         self.credentialStore = credentialStore
         self.codexRuntime = codexRuntime ?? Self.makeDefaultCodexRuntime()
         self.activityPrompt = activityPrompt ?? Self.tracerActivityPrompt
         self.speechDependencies = speechDependencies
         self.preferences = preferences
+        coordinator = initialCoordinator
         isSpeechMuted = preferences.bool(
             forKey: Self.speechMutedPreferenceKey
         )
+        if let initialCoordinator {
+            publish(initialCoordinator.snapshot)
+        }
     }
 
     var question: String {
@@ -644,6 +649,39 @@ final class SystemDesignRoomModel: ObservableObject {
             publish(coordinator.snapshot)
             errorWasCodexFailure = applyCodexFailure(error)
             errorMessage = safeMessage(for: error)
+        }
+    }
+
+    /// Uses the existing durable finish command without broadening the phases
+    /// Core accepts. Presentation close remains fail-closed when the current
+    /// phase cannot finish safely. An operation already awaiting its Adapter
+    /// keeps sole ownership of the model's visible and durable state.
+    @discardableResult
+    func finishInterview() async -> Bool {
+        guard !isWorking else { return false }
+        guard let coordinator, let snapshot else { return false }
+        if snapshot.phase == .completed {
+            return true
+        }
+
+        isWorking = true
+        errorMessage = nil
+        statusMessage = "Ending interview…"
+        defer {
+            isWorking = false
+            statusMessage = status(for: self.snapshot)
+        }
+
+        do {
+            let updated = try await coordinator.finishSession(
+                commandID: commandID("finish-interview")
+            )
+            publish(updated)
+            return true
+        } catch {
+            publish(coordinator.snapshot)
+            errorMessage = safeMessage(for: error)
+            return false
         }
     }
 

--- a/Sources/InterviewArcLive/SystemDesignRoomView.swift
+++ b/Sources/InterviewArcLive/SystemDesignRoomView.swift
@@ -4,7 +4,16 @@ import SwiftUI
 
 struct SystemDesignRoomView: View {
     @ObservedObject var model: SystemDesignRoomModel
+    let onCollapse: () -> Void
     @State private var isModelRemovalConfirmationPresented = false
+
+    init(
+        model: SystemDesignRoomModel,
+        onCollapse: @escaping () -> Void = {}
+    ) {
+        self.model = model
+        self.onCollapse = onCollapse
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -30,7 +39,6 @@ struct SystemDesignRoomView: View {
         }
         .background(LivePalette.room)
         .foregroundStyle(LivePalette.ink)
-        .task { await model.open() }
         .sheet(isPresented: $model.isCredentialSetupPresented) {
             GroqCredentialSetupView(
                 isSaving: model.isSavingCredential,
@@ -674,6 +682,17 @@ struct SystemDesignRoomView: View {
             .tint(LivePalette.handoff)
             .disabled(!model.canAct)
             .keyboardShortcut(.return, modifiers: [.command])
+
+            Button(action: onCollapse) {
+                Label("Collapse", systemImage: "rectangle.compress.vertical")
+                    .font(.system(.body, design: .rounded, weight: .semibold))
+            }
+            .buttonStyle(.bordered)
+            .tint(LivePalette.paper)
+            .accessibilityIdentifier("full-room-collapse")
+            .accessibilityHint(
+                "Keeps this interview running in the compact controls without recreating the room"
+            )
         }
         .foregroundStyle(LivePalette.paper)
         .padding(.horizontal, 24)

--- a/Tests/InterviewArcLiveTests/CompactRoomPresentationTests.swift
+++ b/Tests/InterviewArcLiveTests/CompactRoomPresentationTests.swift
@@ -1,0 +1,225 @@
+import XCTest
+
+import InterviewArcLiveCore
+@testable import InterviewArcLive
+
+final class CompactRoomPresentationTests: XCTestCase {
+    func testRestoringAndCompletedExposeOnlyExpand() {
+        let restoring = CompactRoomPresentation.make(input: .init())
+        XCTAssertEqual(restoring.statusKind, .restoring)
+        XCTAssertEqual(restoring.floorTitle, "Preparing room")
+        XCTAssertEqual(restoring.controls.map(\.action), [.expand])
+
+        let completed = CompactRoomPresentation.make(
+            input: .init(
+                phase: .completed,
+                statusMessage: "Session complete",
+                showsRecordControl: true,
+                canRecordSegment: true,
+                canPerformPhaseAction: true
+            )
+        )
+        XCTAssertEqual(completed.statusKind, .completed)
+        XCTAssertEqual(completed.floorTitle, "Interview complete")
+        XCTAssertEqual(completed.controls.map(\.action), [.expand])
+    }
+
+    func testCandidateFloorUsesExactRecordAndHandOffEnablement() throws {
+        let presentation = CompactRoomPresentation.make(
+            input: .init(
+                phase: .candidateFloor,
+                statusMessage: "Ready to record",
+                showsRecordControl: true,
+                canRecordSegment: true,
+                recordTitle: "Add segment",
+                phaseActionTitle: "Hand off",
+                canPerformPhaseAction: false
+            )
+        )
+
+        XCTAssertEqual(presentation.statusKind, .candidateFloor)
+        XCTAssertEqual(
+            presentation.controls.map(\.action),
+            [.recordSegment, .primaryPhaseAction, .expand]
+        )
+        let record = try XCTUnwrap(presentation.candidateControl)
+        XCTAssertEqual(record.title, "Add segment")
+        XCTAssertTrue(record.isEnabled)
+        let handOff = try XCTUnwrap(presentation.phaseControl)
+        XCTAssertEqual(handOff.title, "Hand off")
+        XCTAssertFalse(handOff.isEnabled)
+    }
+
+    func testCaptureSavingAndTranscribingRemainDistinct() throws {
+        let recording = CompactRoomPresentation.make(
+            input: .init(
+                phase: .candidateFloor,
+                candidateSegmentLifecycles: [.recording],
+                statusMessage: "Recording segment",
+                isWorking: false,
+                canStopRecording: true,
+                stopRecordingTitle: "Stop segment"
+            )
+        )
+        XCTAssertEqual(recording.statusKind, .recording)
+        XCTAssertEqual(recording.candidateControl?.action, .stopRecording)
+        XCTAssertTrue(try XCTUnwrap(recording.candidateControl).isEnabled)
+
+        let saving = CompactRoomPresentation.make(
+            input: .init(
+                phase: .candidateFloor,
+                candidateSegmentLifecycles: [.recording],
+                statusMessage: "Saving recording before Groq transcription…",
+                isWorking: true,
+                canStopRecording: true
+            )
+        )
+        XCTAssertEqual(saving.statusKind, .saving)
+        XCTAssertFalse(try XCTUnwrap(saving.candidateControl).isEnabled)
+
+        let transcribing = CompactRoomPresentation.make(
+            input: .init(
+                phase: .candidateFloor,
+                candidateSegmentLifecycles: [.transcribing],
+                statusMessage: "Transcribing with Groq",
+                isWorking: true,
+                showsRecordControl: true,
+                canRecordSegment: false
+            )
+        )
+        XCTAssertEqual(transcribing.statusKind, .transcribing)
+        XCTAssertEqual(transcribing.statusValue, "Transcribing with Groq")
+        XCTAssertFalse(try XCTUnwrap(transcribing.candidateControl).isEnabled)
+    }
+
+    func testInterviewerWorkingRetryAndTurnUseOnePhaseAction() throws {
+        let working = CompactRoomPresentation.make(
+            input: .init(
+                phase: .interviewerProcessing,
+                statusMessage: "Answer saved · Codex is preparing the next question",
+                isInterviewerRequestInFlight: true,
+                phaseActionTitle: "Retry interviewer",
+                canPerformPhaseAction: false
+            )
+        )
+        XCTAssertEqual(working.statusKind, .interviewerWorking)
+        XCTAssertFalse(try XCTUnwrap(working.phaseControl).isEnabled)
+
+        let retry = CompactRoomPresentation.make(
+            input: .init(
+                phase: .interviewerProcessing,
+                statusMessage: "Answer saved · interviewer retry available",
+                phaseActionTitle: "Retry interviewer",
+                phaseActionSystemImage: "arrow.clockwise.circle.fill",
+                canPerformPhaseAction: true
+            )
+        )
+        XCTAssertEqual(retry.statusKind, .retryRequired)
+        XCTAssertEqual(retry.phaseControl?.title, "Retry interviewer")
+        XCTAssertTrue(try XCTUnwrap(retry.phaseControl).isEnabled)
+
+        let interviewerTurn = CompactRoomPresentation.make(
+            input: .init(
+                phase: .interviewerTurn,
+                statusMessage: "Interviewer response saved",
+                phaseActionTitle: "Give me the floor",
+                canPerformPhaseAction: true
+            )
+        )
+        XCTAssertEqual(interviewerTurn.statusKind, .interviewerTurn)
+        XCTAssertEqual(interviewerTurn.phaseControl?.title, "Give me the floor")
+    }
+
+    func testSpeechGenerationPlaybackMuteAndExpandHaveLogicalOrder() {
+        let generating = CompactRoomPresentation.make(
+            input: .init(
+                phase: .interviewerTurn,
+                statusMessage: "Interviewer response saved",
+                speechActivity: .generating,
+                phaseActionTitle: "Give me the floor",
+                canPerformPhaseAction: true,
+                canStopSpeech: true,
+                showsSpeechMuteControl: true,
+                canToggleSpeechMute: true,
+                isSpeechMuted: false
+            )
+        )
+        XCTAssertEqual(generating.statusKind, .speechGenerating)
+        XCTAssertEqual(
+            generating.controls.map(\.action),
+            [
+                .primaryPhaseAction,
+                .stopSpeech,
+                .toggleSpeechMute,
+                .expand,
+            ]
+        )
+        XCTAssertEqual(generating.speechControls.last?.accessibilityValue, "Unmuted")
+
+        let playing = CompactRoomPresentation.make(
+            input: .init(
+                phase: .interviewerTurn,
+                statusMessage: "Interviewer response saved",
+                attentionMessage: "An older recovery message",
+                speechActivity: .playing,
+                canStopSpeech: true,
+                showsSpeechMuteControl: true,
+                canToggleSpeechMute: true,
+                isSpeechMuted: true
+            )
+        )
+        XCTAssertEqual(playing.statusKind, .speechPlayback)
+        XCTAssertEqual(playing.statusValue, "Mara is speaking")
+        XCTAssertEqual(playing.speechControls.last?.title, "Unmute Mara")
+        XCTAssertEqual(playing.speechControls.last?.accessibilityValue, "Muted")
+
+        let recordingWhileSpeechStops = CompactRoomPresentation.make(
+            input: .init(
+                phase: .candidateFloor,
+                candidateSegmentLifecycles: [.recording],
+                statusMessage: "Recording segment",
+                speechActivity: .playing,
+                canStopRecording: true,
+                canStopSpeech: true
+            )
+        )
+        XCTAssertEqual(recordingWhileSpeechStops.statusKind, .recording)
+        XCTAssertEqual(
+            recordingWhileSpeechStops.controls.map(\.action),
+            [.stopRecording, .primaryPhaseAction, .stopSpeech, .expand]
+        )
+    }
+
+    func testRecoveryAttentionUsesCompleteTextAndClosedActionVocabulary() {
+        let message = "A recording recovery needs attention. "
+            + "Preserved evidence remains visible in the full room."
+        let presentation = CompactRoomPresentation.make(
+            input: .init(
+                phase: .candidateFloor,
+                candidateSegmentLifecycles: [.failed],
+                statusMessage: "Recording preserved · recovery available",
+                attentionMessage: message,
+                showsRecordControl: true,
+                canRecordSegment: true
+            )
+        )
+
+        XCTAssertEqual(presentation.statusKind, .recoveryAttention)
+        XCTAssertEqual(presentation.statusValue, message)
+        XCTAssertEqual(
+            Set(presentation.controls.map(\.action)),
+            Set([.recordSegment, .primaryPhaseAction, .expand])
+        )
+        XCTAssertEqual(
+            Set([
+                CompactRoomAction.recordSegment,
+                .stopRecording,
+                .primaryPhaseAction,
+                .stopSpeech,
+                .toggleSpeechMute,
+                .expand,
+            ]),
+            Set(CompactRoomAction.allCases)
+        )
+    }
+}

--- a/Tests/InterviewArcLiveTests/InterviewArcLiveAppTests.swift
+++ b/Tests/InterviewArcLiveTests/InterviewArcLiveAppTests.swift
@@ -1,0 +1,90 @@
+import AppKit
+import XCTest
+
+@testable import InterviewArcLive
+
+@MainActor
+final class InterviewArcLiveAppTests: XCTestCase {
+    func testHandledDockReopenSuppressesDefaultAppKitReopen() {
+        let delegate = InterviewArcLiveApp()
+        let application = NSApplication.shared
+
+        XCTAssertFalse(
+            delegate.applicationShouldHandleReopen(
+                application,
+                hasVisibleWindows: false
+            )
+        )
+        XCTAssertFalse(
+            delegate.applicationShouldHandleReopen(
+                application,
+                hasVisibleWindows: true
+            )
+        )
+    }
+
+    func testMainMenuRestoresStandardEditResponderActions() throws {
+        let delegate = InterviewArcLiveApp()
+        let application = NSApplication.shared
+        let previousServicesMenu = application.servicesMenu
+        let previousWindowsMenu = application.windowsMenu
+        defer {
+            application.servicesMenu = previousServicesMenu
+            application.windowsMenu = previousWindowsMenu
+        }
+
+        let mainMenu = delegate.makeMainMenu()
+
+        XCTAssertEqual(
+            mainMenu.items.compactMap { $0.submenu?.title },
+            ["Interview Arc Live", "File", "Edit", "Window"]
+        )
+        let editMenu = try XCTUnwrap(
+            mainMenu.items.first { $0.submenu?.title == "Edit" }?.submenu
+        )
+        let actions = editMenu.items.filter { !$0.isSeparatorItem }
+        XCTAssertEqual(
+            actions.map(\.title),
+            [
+                "Undo",
+                "Redo",
+                "Cut",
+                "Copy",
+                "Paste",
+                "Paste and Match Style",
+                "Delete",
+                "Select All",
+            ]
+        )
+        XCTAssertEqual(
+            actions.map { $0.action.map(NSStringFromSelector) },
+            [
+                "undo:",
+                "redo:",
+                "cut:",
+                "copy:",
+                "paste:",
+                "pasteAsPlainText:",
+                "delete:",
+                "selectAll:",
+            ]
+        )
+        XCTAssertTrue(actions.allSatisfy { $0.target == nil })
+        XCTAssertEqual(actions[0].keyEquivalent, "z")
+        XCTAssertEqual(actions[0].keyEquivalentModifierMask, [.command])
+        XCTAssertEqual(actions[1].keyEquivalent, "z")
+        XCTAssertEqual(
+            actions[1].keyEquivalentModifierMask,
+            [.command, .shift]
+        )
+        XCTAssertEqual(actions[2].keyEquivalent, "x")
+        XCTAssertEqual(actions[3].keyEquivalent, "c")
+        XCTAssertEqual(actions[4].keyEquivalent, "v")
+        XCTAssertEqual(
+            actions[5].keyEquivalentModifierMask,
+            [.command, .option, .shift]
+        )
+        XCTAssertEqual(actions[6].keyEquivalentModifierMask, [])
+        XCTAssertEqual(actions[7].keyEquivalent, "a")
+    }
+}

--- a/Tests/InterviewArcLiveTests/InterviewFinishTestFixtures.swift
+++ b/Tests/InterviewArcLiveTests/InterviewFinishTestFixtures.swift
@@ -1,0 +1,151 @@
+import Foundation
+
+import InterviewArcLiveCodexAdapter
+import InterviewArcLiveCore
+@testable import InterviewArcLive
+
+@MainActor
+func makeCompletionBlockingRoomModel() async throws -> (
+    model: SystemDesignRoomModel,
+    store: CompletionBlockingManifestStore
+) {
+    let store = CompletionBlockingManifestStore()
+    let prompt = try ActivityPrompt(
+        specialty: .systemDesign,
+        stage: "High-level design",
+        question: "Design a public-safe notification service.",
+        requestedParts: ["Clarify requirements."]
+    )
+    let runtime = FinishRuntimeFixture()
+    let coordinator = try await SegmentSpeechCoordinator.open(
+        sessionID: SessionID("finish-fixture-\(UUID().uuidString)"),
+        activityID: "finish-fixture",
+        activityPrompt: prompt,
+        manifestStore: store,
+        interviewerRuntime: runtime,
+        recording: UnusedFinishRecording(),
+        transcriber: UnusedFinishTranscriber(),
+        credentialReader: UnusedFinishCredentialReader()
+    )
+    return (
+        SystemDesignRoomModel(
+            codexRuntime: runtime,
+            activityPrompt: prompt,
+            initialCoordinator: coordinator
+        ),
+        store
+    )
+}
+
+actor CompletionBlockingManifestStore: SessionManifestStore {
+    private let backing = InMemorySessionManifestStore()
+    private var completionSaveCountValue = 0
+    private var completionSaveStarted = false
+    private var holdsCompletionSave = true
+    private var startedContinuation: CheckedContinuation<Void, Never>?
+    private var releaseContinuation: CheckedContinuation<Void, Never>?
+
+    func load(sessionID: SessionID) async throws -> SessionManifest? {
+        await backing.load(sessionID: sessionID)
+    }
+
+    func save(
+        _ manifest: SessionManifest,
+        expectedRevision: Int?
+    ) async throws {
+        if manifest.phase == .completed {
+            completionSaveCountValue += 1
+            completionSaveStarted = true
+            startedContinuation?.resume()
+            startedContinuation = nil
+            if holdsCompletionSave {
+                await withCheckedContinuation { continuation in
+                    releaseContinuation = continuation
+                }
+            }
+        }
+        try await backing.save(
+            manifest,
+            expectedRevision: expectedRevision
+        )
+    }
+
+    func waitUntilCompletionSaveStarts() async {
+        if completionSaveStarted { return }
+        await withCheckedContinuation { continuation in
+            startedContinuation = continuation
+        }
+    }
+
+    func releaseCompletionSave() {
+        holdsCompletionSave = false
+        releaseContinuation?.resume()
+        releaseContinuation = nil
+    }
+
+    func completionSaveCount() -> Int {
+        completionSaveCountValue
+    }
+}
+
+private struct FinishRuntimeFixture: LiveCodexInterviewerRuntime {
+    func preflight() async -> CodexAppServerReadiness {
+        .ready
+    }
+
+    func respond(
+        to request: InterviewerRequest
+    ) async throws -> CanonicalInterviewerResponse {
+        CanonicalInterviewerResponse(
+            displayMarkdown: "What reliability tradeoff would you test next?",
+            spokenText: "What reliability tradeoff would you test next?"
+        )
+    }
+}
+
+@MainActor
+private final class UnusedFinishRecording: SegmentRecording {
+    func setUnexpectedTerminationHandler(
+        _ handler: (@MainActor @Sendable () -> Void)?
+    ) {}
+
+    func beginCapture(_ request: SegmentCaptureRequest) async throws {
+        throw FinishFixtureError.unused
+    }
+
+    func finishCapture() async throws -> CapturedAudioSegment {
+        throw FinishFixtureError.unused
+    }
+
+    func recoverCapture(
+        _ request: SegmentCaptureRequest
+    ) async throws -> CapturedAudioSegment? {
+        nil
+    }
+
+    func playbackURL(
+        sessionID: SessionID,
+        audioIdentity: SegmentAudioIdentity
+    ) async throws -> URL {
+        throw FinishFixtureError.unused
+    }
+}
+
+private struct UnusedFinishTranscriber: SegmentTranscribing {
+    func transcribe(
+        _ request: SegmentTranscriptionRequest,
+        credential: String
+    ) async throws -> SegmentTranscriptionResult {
+        throw FinishFixtureError.unused
+    }
+}
+
+private struct UnusedFinishCredentialReader: GroqCredentialReading {
+    func readGroqCredential() async throws -> String {
+        throw FinishFixtureError.unused
+    }
+}
+
+private enum FinishFixtureError: Error {
+    case unused
+}

--- a/Tests/InterviewArcLiveTests/InterviewRoomPresentationCoordinatorTests.swift
+++ b/Tests/InterviewArcLiveTests/InterviewRoomPresentationCoordinatorTests.swift
@@ -1,0 +1,283 @@
+import AppKit
+import XCTest
+
+@testable import InterviewArcLive
+
+@MainActor
+final class InterviewRoomPresentationCoordinatorTests: XCTestCase {
+    func testCoordinatorOwnsOneFullWindowAndOneNonactivatingPanelWithSharedModel() {
+        let model = SystemDesignRoomModel()
+        let coordinator = makeCoordinator(model: model)
+        defer { coordinator.prepareForTermination() }
+
+        XCTAssertEqual(coordinator.presentationState, .notStarted)
+        XCTAssertFalse(coordinator.didRequestModelOpen)
+        XCTAssertFalse(coordinator.fullWindow.isVisible)
+        XCTAssertFalse(coordinator.compactPanel.isVisible)
+        XCTAssertEqual(
+            coordinator.fullHostedModelIdentity,
+            ObjectIdentifier(model)
+        )
+        XCTAssertEqual(
+            coordinator.compactHostedModelIdentity,
+            ObjectIdentifier(model)
+        )
+        XCTAssertTrue(
+            coordinator.compactPanel.styleMask.contains(.nonactivatingPanel)
+        )
+        XCTAssertTrue(coordinator.compactPanel.becomesKeyOnlyIfNeeded)
+        XCTAssertTrue(coordinator.compactPanel.canBecomeKey)
+        XCTAssertFalse(coordinator.compactPanel.canBecomeMain)
+        XCTAssertFalse(
+            coordinator.compactPanel.collectionBehavior.contains(.canJoinAllSpaces)
+        )
+        XCTAssertFalse(
+            coordinator.compactPanel.collectionBehavior.contains(.fullScreenAuxiliary)
+        )
+        XCTAssertTrue(
+            coordinator.compactPanel.collectionBehavior.contains(.fullScreenNone)
+        )
+        XCTAssertEqual(
+            coordinator.compactPanel.contentMinSize,
+            NSSize(
+                width: CompactPanelLayout.contentWidth,
+                height: CompactPanelLayout.minimumContentHeight
+            )
+        )
+        XCTAssertEqual(
+            coordinator.compactPanel.contentMaxSize,
+            NSSize(
+                width: CompactPanelLayout.contentWidth,
+                height: CompactPanelLayout.maximumContentHeight
+            )
+        )
+    }
+
+    func testCollapseAndExpandRetainWindowsHostingTreesFrameAndFocus() throws {
+        let coordinator = makeCoordinator()
+        defer { coordinator.prepareForTermination() }
+        let fullWindowIdentity = ObjectIdentifier(coordinator.fullWindow)
+        let panelIdentity = ObjectIdentifier(coordinator.compactPanel)
+        let fullTreeIdentity = coordinator.fullHostingTreeIdentity
+        let compactTreeIdentity = coordinator.compactHostingTreeIdentity
+
+        coordinator.expand()
+        let visibleFrame = try XCTUnwrap(NSScreen.main?.visibleFrame)
+        let requestedFrame = NSRect(
+            x: visibleFrame.minX + 30,
+            y: visibleFrame.minY + 30,
+            width: min(1_180, visibleFrame.width - 60),
+            height: min(760, visibleFrame.height - 60)
+        )
+        coordinator.fullWindow.setFrame(requestedFrame, display: false)
+        let retainedFrame = coordinator.fullWindow.frame
+        XCTAssertTrue(
+            coordinator.fullWindow.makeFirstResponder(
+                coordinator.fallbackFirstResponder
+            )
+        )
+
+        coordinator.collapse()
+        coordinator.collapse()
+        XCTAssertEqual(coordinator.presentationState, .compact)
+        XCTAssertFalse(coordinator.fullWindow.isVisible)
+        XCTAssertTrue(coordinator.compactPanel.isVisible)
+
+        coordinator.expand()
+        coordinator.expand()
+        XCTAssertEqual(coordinator.presentationState, .full)
+        XCTAssertTrue(coordinator.fullWindow.isVisible)
+        XCTAssertFalse(coordinator.compactPanel.isVisible)
+        XCTAssertEqual(ObjectIdentifier(coordinator.fullWindow), fullWindowIdentity)
+        XCTAssertEqual(ObjectIdentifier(coordinator.compactPanel), panelIdentity)
+        XCTAssertEqual(coordinator.fullHostingTreeIdentity, fullTreeIdentity)
+        XCTAssertEqual(coordinator.compactHostingTreeIdentity, compactTreeIdentity)
+        XCTAssertEqual(coordinator.fullWindow.frame, retainedFrame)
+        XCTAssertTrue(
+            coordinator.fullWindow.firstResponder
+                === coordinator.fallbackFirstResponder
+        )
+    }
+
+    func testContinueCompactAndCancelUseRetainedPresentation() async {
+        let coordinator = makeCoordinator()
+        defer { coordinator.prepareForTermination() }
+        coordinator.expand()
+        let fullIdentity = ObjectIdentifier(coordinator.fullWindow)
+
+        await coordinator.resolveCloseChoice(.cancel)
+        XCTAssertEqual(coordinator.presentationState, .full)
+        XCTAssertTrue(coordinator.fullWindow.isVisible)
+
+        await coordinator.resolveCloseChoice(.continueCompact)
+        XCTAssertEqual(coordinator.presentationState, .compact)
+        XCTAssertFalse(coordinator.fullWindow.isVisible)
+        XCTAssertTrue(coordinator.compactPanel.isVisible)
+        XCTAssertEqual(ObjectIdentifier(coordinator.fullWindow), fullIdentity)
+    }
+
+    func testFailedEndLeavesFullRoomVisibleAndFocusIntact() async {
+        let coordinator = makeCoordinator()
+        defer { coordinator.prepareForTermination() }
+        coordinator.expand()
+        XCTAssertTrue(
+            coordinator.fullWindow.makeFirstResponder(
+                coordinator.fallbackFirstResponder
+            )
+        )
+
+        // This unopened model has no coordinator to finish. The presentation
+        // must fail closed without creating production session dependencies.
+        await coordinator.resolveCloseChoice(.endInterview)
+
+        XCTAssertEqual(coordinator.presentationState, .full)
+        XCTAssertTrue(coordinator.fullWindow.isVisible)
+        XCTAssertFalse(coordinator.compactPanel.isVisible)
+        XCTAssertTrue(
+            coordinator.fullWindow.firstResponder
+                === coordinator.fallbackFirstResponder
+        )
+    }
+
+    func testEndSerializesCloseChoicesAndPresentationTransitions() async throws {
+        let fixture = try await makeCompletionBlockingRoomModel()
+        let coordinator = makeCoordinator(model: fixture.model)
+        defer { coordinator.prepareForTermination() }
+        coordinator.expand()
+        XCTAssertTrue(
+            coordinator.fullWindow.makeFirstResponder(
+                coordinator.fallbackFirstResponder
+            )
+        )
+
+        let endChoice = Task { @MainActor in
+            await coordinator.resolveCloseChoice(.endInterview)
+        }
+        await fixture.store.waitUntilCompletionSaveStarts()
+        XCTAssertTrue(coordinator.isResolvingCloseChoice)
+        XCTAssertEqual(coordinator.presentationState, .full)
+
+        await coordinator.resolveCloseChoice(.cancel)
+        await coordinator.resolveCloseChoice(.continueCompact)
+        coordinator.collapse()
+        coordinator.reopen()
+        coordinator.requestFullWindowClose()
+
+        XCTAssertEqual(coordinator.presentationState, .full)
+        XCTAssertTrue(coordinator.fullWindow.isVisible)
+        XCTAssertFalse(coordinator.compactPanel.isVisible)
+        XCTAssertFalse(coordinator.isCloseGuardPresented)
+        let suspendedSaveCount = await fixture.store.completionSaveCount()
+        XCTAssertEqual(suspendedSaveCount, 1)
+
+        await fixture.store.releaseCompletionSave()
+        await endChoice.value
+
+        XCTAssertFalse(coordinator.isResolvingCloseChoice)
+        XCTAssertEqual(coordinator.presentationState, .closed)
+        XCTAssertFalse(coordinator.fullWindow.isVisible)
+        XCTAssertFalse(coordinator.compactPanel.isVisible)
+        let finalSaveCount = await fixture.store.completionSaveCount()
+        XCTAssertEqual(finalSaveCount, 1)
+    }
+
+    func testTerminationWinsWhenSuspendedEndChoiceResumes() async throws {
+        let fixture = try await makeCompletionBlockingRoomModel()
+        let coordinator = makeCoordinator(model: fixture.model)
+        coordinator.expand()
+
+        let endChoice = Task { @MainActor in
+            await coordinator.resolveCloseChoice(.endInterview)
+        }
+        await fixture.store.waitUntilCompletionSaveStarts()
+        coordinator.prepareForTermination()
+        await fixture.store.releaseCompletionSave()
+        await endChoice.value
+
+        XCTAssertEqual(coordinator.presentationState, .terminated)
+        XCTAssertFalse(coordinator.fullWindow.isVisible)
+        XCTAssertFalse(coordinator.compactPanel.isVisible)
+        XCTAssertFalse(coordinator.isResolvingCloseChoice)
+    }
+
+    func testReopenRoutesToExistingWindowAndTerminationOnlyTearsDownPresentation() {
+        let coordinator = makeCoordinator()
+        let fullIdentity = ObjectIdentifier(coordinator.fullWindow)
+        let panelIdentity = ObjectIdentifier(coordinator.compactPanel)
+
+        coordinator.collapse()
+        coordinator.reopen()
+        XCTAssertEqual(coordinator.presentationState, .full)
+        XCTAssertEqual(ObjectIdentifier(coordinator.fullWindow), fullIdentity)
+        XCTAssertEqual(ObjectIdentifier(coordinator.compactPanel), panelIdentity)
+
+        coordinator.prepareForTermination()
+        coordinator.prepareForTermination()
+        XCTAssertEqual(coordinator.presentationState, .terminated)
+        XCTAssertFalse(coordinator.fullWindow.isVisible)
+        XCTAssertFalse(coordinator.compactPanel.isVisible)
+        XCTAssertFalse(coordinator.didRequestModelOpen)
+    }
+
+    func testClampedFrameKeepsMovedPanelInsideRemainingDisplay() {
+        let removedDisplayFrame = NSRect(x: 2_000, y: 200, width: 640, height: 254)
+        let remainingVisibleFrame = NSRect(x: 0, y: 0, width: 1_440, height: 900)
+
+        let clamped = InterviewRoomPresentationCoordinator.clampedFrame(
+            removedDisplayFrame,
+            to: [remainingVisibleFrame]
+        )
+
+        XCTAssertGreaterThanOrEqual(clamped.minX, remainingVisibleFrame.minX + 12)
+        XCTAssertGreaterThanOrEqual(clamped.minY, remainingVisibleFrame.minY + 12)
+        XCTAssertLessThanOrEqual(clamped.maxX, remainingVisibleFrame.maxX - 12)
+        XCTAssertLessThanOrEqual(clamped.maxY, remainingVisibleFrame.maxY - 12)
+        XCTAssertEqual(clamped.size, removedDisplayFrame.size)
+    }
+
+    func testCompactPanelSizingIsBoundedAndPreservesTopEdge() {
+        XCTAssertEqual(CompactPanelLayout.boundedContentHeight(180), 214)
+        XCTAssertEqual(CompactPanelLayout.boundedContentHeight(310), 310)
+        XCTAssertEqual(CompactPanelLayout.boundedContentHeight(600), 420)
+
+        let original = NSRect(x: 100, y: 200, width: 700, height: 254)
+        let resized = CompactPanelLayout.framePreservingTopEdge(
+            original,
+            measuredContentHeight: 310
+        )
+
+        XCTAssertEqual(resized.width, 640)
+        XCTAssertEqual(resized.height, 310)
+        XCTAssertEqual(resized.maxY, original.maxY)
+    }
+
+    func testGrowingCompactPanelRemainsInsideVisibleScreen() {
+        let visibleFrame = NSRect(x: 0, y: 0, width: 1_440, height: 900)
+        let panelNearBottom = NSRect(x: 780, y: 20, width: 640, height: 214)
+        let resized = CompactPanelLayout.framePreservingTopEdge(
+            panelNearBottom,
+            measuredContentHeight: 600
+        )
+
+        let clamped = InterviewRoomPresentationCoordinator.clampedFrame(
+            resized,
+            to: [visibleFrame]
+        )
+
+        XCTAssertGreaterThanOrEqual(clamped.minX, visibleFrame.minX + 12)
+        XCTAssertGreaterThanOrEqual(clamped.minY, visibleFrame.minY + 12)
+        XCTAssertLessThanOrEqual(clamped.maxX, visibleFrame.maxX - 12)
+        XCTAssertLessThanOrEqual(clamped.maxY, visibleFrame.maxY - 12)
+        XCTAssertEqual(clamped.size, NSSize(width: 640, height: 420))
+    }
+
+    private func makeCoordinator(
+        model: SystemDesignRoomModel = SystemDesignRoomModel()
+    ) -> InterviewRoomPresentationCoordinator {
+        _ = NSApplication.shared
+        return InterviewRoomPresentationCoordinator(
+            model: model,
+            frameAutosaveName: "InterviewArcLiveTests.TransientFrame"
+        )
+    }
+}

--- a/Tests/InterviewArcLiveTests/SystemDesignRoomFinishTests.swift
+++ b/Tests/InterviewArcLiveTests/SystemDesignRoomFinishTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+
+import InterviewArcLiveCore
+@testable import InterviewArcLive
+
+@MainActor
+final class SystemDesignRoomFinishTests: XCTestCase {
+    func testFinishInterviewFailsClosedWithoutMutatingWhileWorkIsInFlight() async throws {
+        let fixture = try await makeCompletionBlockingRoomModel()
+        let model = fixture.model
+        let store = fixture.store
+
+        let firstFinish = Task { @MainActor in
+            await model.finishInterview()
+        }
+        await store.waitUntilCompletionSaveStarts()
+
+        let statusBeforeSecondAttempt = model.statusMessage
+        let errorBeforeSecondAttempt = model.errorMessage
+        let snapshotBeforeSecondAttempt = model.snapshot
+        XCTAssertTrue(model.isWorking)
+
+        let secondResult = await model.finishInterview()
+
+        XCTAssertFalse(secondResult)
+        XCTAssertTrue(model.isWorking)
+        XCTAssertEqual(model.statusMessage, statusBeforeSecondAttempt)
+        XCTAssertEqual(model.errorMessage, errorBeforeSecondAttempt)
+        XCTAssertEqual(model.snapshot, snapshotBeforeSecondAttempt)
+        let saveCountWhileSuspended = await store.completionSaveCount()
+        XCTAssertEqual(saveCountWhileSuspended, 1)
+
+        await store.releaseCompletionSave()
+        let firstResult = await firstFinish.value
+        XCTAssertTrue(firstResult)
+        XCTAssertFalse(model.isWorking)
+        XCTAssertEqual(model.snapshot?.phase, .completed)
+        let finalSaveCount = await store.completionSaveCount()
+        XCTAssertEqual(finalSaveCount, 1)
+    }
+}

--- a/docs/adr/0007-retained-full-and-compact-presentations.md
+++ b/docs/adr/0007-retained-full-and-compact-presentations.md
@@ -1,0 +1,47 @@
+# ADR 0007: Retain one room across full and compact Presentations
+
+- Status: Accepted
+- Date: 2026-08-09
+- Issue: #16
+
+## Context
+
+The system-design room can remain active while the candidate works in another
+application. Recreating its SwiftUI root, opening a second model, or using a
+second scene would lose ephemeral window state and could duplicate recording,
+provider, recovery, or speech side effects.
+
+## Decision
+
+The application process creates one `SystemDesignRoomModel` and asks it to
+open once. A deep `InterviewRoomPresentationCoordinator` owns exactly one
+full `NSWindow`, one nonactivating compact `NSPanel`, and both SwiftUI hosting
+trees for the process lifetime. Full and compact roots receive the same model
+identity and only forward its existing actions.
+
+Collapse orders the retained full window out before showing the panel without
+activation. Expand orders the panel out, restores the retained full frame and
+valid first responder, and deliberately activates the existing full window.
+Dock reopen and application commands route to that same window. The panel
+does not join every Space or full-screen auxiliary spaces, and its process-
+local position is clamped after display changes. Its fixed width and bounded
+height reconcile to SwiftUI's current fitting size; content becomes vertically
+scrollable at the maximum so accessibility text and stacked controls remain
+reachable without overlap.
+
+An unfinished full-window close is guarded by Continue compact, End interview,
+and Cancel. End calls the existing durable finish path once and closes only
+after success. Close resolution is single-flight while that call awaits, and
+process termination wins if it occurs before the call returns. Phases Core
+does not currently permit to finish remain visible with the existing safe
+error. Command-Q remains process termination and does not fabricate completion.
+
+## Consequences
+
+Window frame, split position, transcript scroll position, and live SwiftUI
+state survive compact presentation because the full tree is hidden rather
+than rebuilt. The coordinator centralizes identity, ordering, focus, close,
+reopen, screen-clamping, and termination rules without adding a Core command,
+provider Adapter, persistence field, or test-only window Seam. Headed release
+verification remains necessary for external-app focus, VoiceOver, Spaces, and
+exact installed-artifact behavior.


### PR DESCRIPTION
## **User description**
Refs #16

## Summary
- create one process-owned room model and deep AppKit presentation coordinator
- retain the full hosting tree while projecting exact existing actions into one nonactivating compact panel
- guard close/end/focus/frame/display lifecycle without adding Core or provider behavior
- add accessibility-aware compact sizing, standard responder menus, ADR 0007, and focused lifecycle/truth-table tests

## Verification
- Swift 6 strict production and focused-test typechecks with warnings as errors
- full changed/new Swift parse
- final Impeccable detector: zero findings
- reliability re-audit: GO
- git diff --check and privacy scan

Hosted Xcode 26.3/Metal CI and headed exact-artifact verification remain the release authority.


___

## **CodeAnt-AI Description**
Keep interviews active while switching between full and compact controls

### What Changed
- Added a compact, nonactivating interview panel with live status and controls for recording, handoff, speech, mute, and returning to the full room.
- Full and compact views share the same interview session, so collapsing and expanding preserves room state, window layout, transcript position, and keyboard focus.
- Closing an unfinished interview now offers Continue compact, End interview, or Cancel; ending closes the room only after the interview is saved successfully.
- Reopening the app returns to the retained room, while display changes keep both presentations within visible screens.
- Added coverage for compact statuses and actions, presentation transitions, close handling, focus restoration, sizing, termination, and standard macOS menus.

### Impact
`✅ Interview continues in compact controls`
`✅ No lost room state when switching views`
`✅ Safer unfinished-interview closing`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
