### PR TITLE
Match compact room to the canonical mockup

### DIFF
--- a/Sources/InterviewArcLive/CompactSystemDesignRoomView.swift
+++ b/Sources/InterviewArcLive/CompactSystemDesignRoomView.swift
@@ -1,233 +1,423 @@
 import SwiftUI
 
 struct CompactSystemDesignRoomView: View {
-    @ObservedObject var model: SystemDesignRoomModel
-    let onExpand: () -> Void
+  @ObservedObject var model: SystemDesignRoomModel
+  let onExpand: () -> Void
 
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-    private var presentation: CompactRoomPresentation {
-        model.compactPresentation
+  private var presentation: CompactRoomPresentation {
+    model.compactPresentation
+  }
+
+  var body: some View {
+    ViewThatFits(in: .vertical) {
+      capsuleContent
+
+      ScrollView(.vertical) {
+        capsuleContent
+      }
+      .scrollIndicators(.visible)
+      .frame(height: CompactPanelLayout.maximumContentHeight)
     }
-
-    var body: some View {
-        ViewThatFits(in: .vertical) {
-            capsuleContent
-
-            ScrollView(.vertical) {
-                capsuleContent
-            }
-            .scrollIndicators(.visible)
-            .frame(height: CompactPanelLayout.maximumContentHeight)
-        }
-        .frame(width: CompactPanelLayout.contentWidth)
-        .frame(
-            minHeight: CompactPanelLayout.minimumContentHeight,
-            maxHeight: CompactPanelLayout.maximumContentHeight,
-            alignment: .topLeading
-        )
-        .background(
-            LivePalette.shell,
-            in: RoundedRectangle(cornerRadius: 22, style: .continuous)
-        )
-        .foregroundStyle(LivePalette.paper)
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel("Interview Arc Live compact interview controls")
-        .animation(
-            reduceMotion ? nil : .easeOut(duration: 0.16),
-            value: presentation.statusKind
-        )
+    .frame(width: CompactPanelLayout.contentWidth)
+    .frame(
+      minHeight: CompactPanelLayout.minimumContentHeight,
+      maxHeight: CompactPanelLayout.maximumContentHeight,
+      alignment: .topLeading
+    )
+    .background(
+      CompactMockupPalette.outerShell,
+      in: RoundedRectangle(cornerRadius: 28, style: .continuous)
+    )
+    .overlay {
+      RoundedRectangle(cornerRadius: 28, style: .continuous)
+        .stroke(CompactMockupPalette.outerLine, lineWidth: 1)
+        .accessibilityHidden(true)
     }
+    .foregroundStyle(CompactMockupPalette.ink)
+    .accessibilityElement(children: .contain)
+    .accessibilityLabel("Interview Arc Live compact interview controls")
+    .animation(
+      reduceMotion ? nil : .easeOut(duration: 0.16),
+      value: presentation.statusKind
+    )
+  }
 
-    private var capsuleContent: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            status
-
-            Rectangle()
-                .fill(LivePalette.line.opacity(0.42))
-                .frame(height: 1)
-                .accessibilityHidden(true)
-
-            if !conversationControls.isEmpty {
-                controlRow(conversationControls)
-            }
-            bottomControlRow
-        }
-        .padding(18)
-        .frame(maxWidth: .infinity, alignment: .topLeading)
-        .fixedSize(horizontal: false, vertical: true)
+  private var capsuleContent: some View {
+    ViewThatFits(in: .horizontal) {
+      horizontalCapsule
+      stackedCapsule
     }
+    .padding(7)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .fixedSize(horizontal: false, vertical: true)
+  }
 
-    private var status: some View {
-        HStack(alignment: .top, spacing: 13) {
-            Image(systemName: presentation.systemImage)
-                .font(.system(size: 22, weight: .semibold))
-                .foregroundStyle(statusColor)
-                .frame(width: 30, height: 30)
-                .accessibilityHidden(true)
-
-            VStack(alignment: .leading, spacing: 4) {
-                Text(presentation.floorTitle)
-                    .font(.system(.headline, design: .rounded, weight: .semibold))
-                Text(presentation.statusValue)
-                    .font(.system(.body, design: .rounded))
-                    .foregroundStyle(LivePalette.line)
-                    .lineLimit(3)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .help(presentation.statusValue)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-        }
-        .accessibilityElement(children: .combine)
-        .accessibilityIdentifier("compact-room-status")
-        .accessibilityLabel("Current interview status")
-        .accessibilityValue(
-            "\(presentation.floorTitle). \(presentation.statusValue)"
-        )
-        .accessibilitySortPriority(60)
+  private var horizontalCapsule: some View {
+    HStack(spacing: 12) {
+      expandMarkButton
+      status
+      signalTrace
+      Spacer(minLength: 4)
+      utilityControls
+      conversationControls
     }
-
-    private var conversationControls: [CompactRoomControl] {
-        [presentation.candidateControl, presentation.phaseControl]
-            .compactMap { $0 }
+    .padding(.horizontal, 12)
+    .padding(.vertical, 10)
+    .background(
+      CompactMockupPalette.paper,
+      in: RoundedRectangle(cornerRadius: 22, style: .continuous)
+    )
+    .overlay {
+      RoundedRectangle(cornerRadius: 22, style: .continuous)
+        .stroke(CompactMockupPalette.innerLine, lineWidth: 1)
+        .accessibilityHidden(true)
     }
+  }
 
-    private func controlRow(
-        _ controls: [CompactRoomControl]
-    ) -> some View {
-        ViewThatFits(in: .horizontal) {
-            HStack(spacing: 10) {
-                ForEach(controls) { control in
-                    controlButton(control)
-                }
-                Spacer(minLength: 0)
-            }
+  private var stackedCapsule: some View {
+    VStack(spacing: 10) {
+      HStack(spacing: 12) {
+        expandMarkButton
+        status
+        signalTrace
+        Spacer(minLength: 0)
+      }
 
-            VStack(alignment: .leading, spacing: 8) {
-                ForEach(controls) { control in
-                    controlButton(control)
-                }
-            }
-        }
+      Rectangle()
+        .fill(CompactMockupPalette.innerLine)
+        .frame(height: 1)
+        .accessibilityHidden(true)
+
+      HStack(spacing: 8) {
+        Spacer(minLength: 0)
+        utilityControls
+        conversationControls
+      }
     }
-
-    private var bottomControlRow: some View {
-        ViewThatFits(in: .horizontal) {
-            HStack(spacing: 10) {
-                ForEach(presentation.speechControls) { control in
-                    controlButton(control)
-                }
-                Spacer(minLength: 12)
-                controlButton(presentation.expandControl)
-            }
-
-            VStack(alignment: .leading, spacing: 8) {
-                ForEach(presentation.speechControls) { control in
-                    controlButton(control)
-                }
-                controlButton(presentation.expandControl)
-            }
-        }
+    .padding(12)
+    .background(
+      CompactMockupPalette.paper,
+      in: RoundedRectangle(cornerRadius: 22, style: .continuous)
+    )
+    .overlay {
+      RoundedRectangle(cornerRadius: 22, style: .continuous)
+        .stroke(CompactMockupPalette.innerLine, lineWidth: 1)
+        .accessibilityHidden(true)
     }
+  }
 
-    @ViewBuilder
-    private func controlButton(
-        _ control: CompactRoomControl
-    ) -> some View {
-        let button = Button {
-            dispatch(control.action)
-        } label: {
-            Label(control.title, systemImage: control.systemImage)
-                .font(.system(.body, design: .rounded, weight: .semibold))
-        }
-        .disabled(!control.isEnabled)
-        .frame(minHeight: 34)
-        .help(control.accessibilityHint)
-        .accessibilityIdentifier("compact-room-\(control.action.rawValue)")
-        .accessibilityHint(control.accessibilityHint)
-        .optionalAccessibilityValue(control.accessibilityValue)
-        .accessibilitySortPriority(accessibilityPriority(for: control.action))
-
-        switch control.action {
-        case .stopRecording, .primaryPhaseAction:
-            button
-                .buttonStyle(.borderedProminent)
-                .tint(LivePalette.handoff)
-        case .recordSegment:
-            button
-                .buttonStyle(.bordered)
-                .tint(LivePalette.paper)
-        case .stopSpeech:
-            button
-                .buttonStyle(.borderedProminent)
-                .tint(LivePalette.interviewer)
-        case .toggleSpeechMute, .expand:
-            button
-                .buttonStyle(.bordered)
-                .tint(LivePalette.paper)
-        }
+  private var status: some View {
+    HStack(spacing: 6) {
+      Text(presentation.floorTitle)
+        .font(.system(size: 13, weight: .semibold, design: .rounded))
+        .foregroundStyle(statusColor)
+        .lineLimit(1)
+      Text("·")
+        .foregroundStyle(CompactMockupPalette.muted)
+        .accessibilityHidden(true)
+      Text(presentation.statusValue)
+        .font(.system(size: 12, weight: .medium, design: .rounded))
+        .foregroundStyle(CompactMockupPalette.muted)
+        .lineLimit(1)
+        .truncationMode(.tail)
+        .help(presentation.statusValue)
     }
+    .accessibilityElement(children: .combine)
+    .accessibilityIdentifier("compact-room-status")
+    .accessibilityLabel("Current interview status")
+    .accessibilityValue(
+      "\(presentation.floorTitle). \(presentation.statusValue)"
+    )
+    .accessibilitySortPriority(60)
+    .frame(maxWidth: 190, alignment: .leading)
+  }
 
-    private var statusColor: Color {
-        switch presentation.tone {
-        case .quiet: return LivePalette.line
-        case .candidate: return LivePalette.liveSignal
-        case .working: return LivePalette.interviewer
-        case .interviewer: return LivePalette.interviewer
-        case .warning: return LivePalette.handoff
-        case .completed: return LivePalette.liveSignal
-        }
+  private var signalTrace: some View {
+    HStack(alignment: .center, spacing: 1.5) {
+      ForEach(Array(Self.signalHeights.enumerated()), id: \.offset) { _, height in
+        Capsule()
+          .fill(statusColor)
+          .frame(width: 1.5, height: height)
+      }
     }
+    .frame(width: 66, height: 22)
+    .accessibilityHidden(true)
+  }
 
-    private func accessibilityPriority(
-        for action: CompactRoomAction
-    ) -> Double {
-        switch action {
-        case .recordSegment, .stopRecording: return 50
-        case .primaryPhaseAction: return 40
-        case .stopSpeech: return 30
-        case .toggleSpeechMute: return 20
-        case .expand: return 10
-        }
+  private var utilityControls: some View {
+    HStack(spacing: 6) {
+      ForEach(presentation.speechControls) { control in
+        utilityButton(control)
+      }
     }
+  }
 
-    private func dispatch(_ action: CompactRoomAction) {
-        switch action {
-        case .recordSegment:
-            Task { await model.recordSegment() }
-        case .stopRecording:
-            Task { await model.stopRecording() }
-        case .primaryPhaseAction:
-            Task { await model.performPrimaryAction() }
-        case .stopSpeech:
-            Task { await model.stopSpeech() }
-        case .toggleSpeechMute:
-            Task { await model.toggleSpeechMute() }
-        case .expand:
-            onExpand()
-        }
+  private var conversationControls: some View {
+    HStack(spacing: 8) {
+      if let candidateControl = presentation.candidateControl {
+        utilityButton(candidateControl)
+      }
+      if let phaseControl = presentation.phaseControl {
+        conversationButton(phaseControl)
+      }
     }
+  }
+
+  private var expandMarkButton: some View {
+    Button {
+      dispatch(.expand)
+    } label: {
+      CompactHandoffMark()
+        .frame(width: 36, height: 36)
+        .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .help(presentation.expandControl.accessibilityHint)
+    .accessibilityIdentifier("compact-room-expand")
+    .accessibilityLabel(presentation.expandControl.title)
+    .accessibilityHint(presentation.expandControl.accessibilityHint)
+    .accessibilitySortPriority(10)
+  }
+
+  private func utilityButton(_ control: CompactRoomControl) -> some View {
+    Button {
+      dispatch(control.action)
+    } label: {
+      CompactUtilityGlyph(action: control.action)
+        .frame(width: 30, height: 30)
+        .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .foregroundStyle(CompactMockupPalette.ink)
+    .disabled(!control.isEnabled)
+    .help(control.accessibilityHint)
+    .accessibilityIdentifier("compact-room-\(control.action.rawValue)")
+    .accessibilityLabel(control.title)
+    .accessibilityHint(control.accessibilityHint)
+    .optionalAccessibilityValue(control.accessibilityValue)
+    .accessibilitySortPriority(accessibilityPriority(for: control.action))
+  }
+
+  @ViewBuilder
+  private func conversationButton(_ control: CompactRoomControl) -> some View {
+    let button = Button {
+      dispatch(control.action)
+    } label: {
+      Label(control.title, systemImage: control.systemImage)
+        .font(.system(size: 13, weight: .semibold, design: .rounded))
+        .lineLimit(1)
+    }
+    .disabled(!control.isEnabled)
+    .controlSize(.large)
+    .help(control.accessibilityHint)
+    .accessibilityIdentifier("compact-room-\(control.action.rawValue)")
+    .accessibilityHint(control.accessibilityHint)
+    .optionalAccessibilityValue(control.accessibilityValue)
+    .accessibilitySortPriority(accessibilityPriority(for: control.action))
+
+    switch control.action {
+    case .stopRecording, .stopSpeech:
+      button
+        .buttonStyle(.borderedProminent)
+        .tint(CompactMockupPalette.stop)
+    case .recordSegment, .primaryPhaseAction:
+      button
+        .buttonStyle(.bordered)
+        .tint(CompactMockupPalette.violet)
+    case .toggleSpeechMute, .expand:
+      EmptyView()
+    }
+  }
+
+  private var statusColor: Color {
+    switch presentation.tone {
+    case .quiet: return CompactMockupPalette.muted
+    case .candidate: return CompactMockupPalette.violet
+    case .working: return CompactMockupPalette.violet
+    case .interviewer: return CompactMockupPalette.violet
+    case .warning: return CompactMockupPalette.stop
+    case .completed: return CompactMockupPalette.violet
+    }
+  }
+
+  private func accessibilityPriority(
+    for action: CompactRoomAction
+  ) -> Double {
+    switch action {
+    case .recordSegment, .stopRecording: return 50
+    case .primaryPhaseAction: return 40
+    case .stopSpeech: return 30
+    case .toggleSpeechMute: return 20
+    case .expand: return 10
+    }
+  }
+
+  private func dispatch(_ action: CompactRoomAction) {
+    switch action {
+    case .recordSegment:
+      Task { await model.recordSegment() }
+    case .stopRecording:
+      Task { await model.stopRecording() }
+    case .primaryPhaseAction:
+      Task { await model.performPrimaryAction() }
+    case .stopSpeech:
+      Task { await model.stopSpeech() }
+    case .toggleSpeechMute:
+      Task { await model.toggleSpeechMute() }
+    case .expand:
+      onExpand()
+    }
+  }
+
+  private static let signalHeights: [CGFloat] = [
+    4, 7, 11, 6, 15, 8, 5, 12, 18, 9, 6, 14, 8, 5, 11, 7,
+    4, 9, 6, 12, 5, 8, 4, 7,
+  ]
 }
 
-private extension View {
-    @ViewBuilder
-    func optionalAccessibilityValue(_ value: String?) -> some View {
-        if let value {
-            accessibilityValue(value)
-        } else {
-            self
-        }
+private struct CompactUtilityGlyph: View {
+  let action: CompactRoomAction
+
+  @ViewBuilder
+  var body: some View {
+    switch action {
+    case .recordSegment:
+      ZStack {
+        RoundedRectangle(cornerRadius: 4, style: .continuous)
+          .stroke(CompactMockupPalette.ink, lineWidth: 1.7)
+          .frame(width: 8, height: 13)
+          .offset(y: -3)
+        CompactMicrophoneStandShape()
+          .stroke(
+            CompactMockupPalette.ink,
+            style: StrokeStyle(lineWidth: 1.7, lineCap: .round)
+          )
+          .frame(width: 18, height: 17)
+          .offset(y: 3)
+      }
+      .accessibilityHidden(true)
+
+    case .toggleSpeechMute:
+      ZStack {
+        CompactSpeakerShape()
+          .stroke(
+            CompactMockupPalette.ink,
+            style: StrokeStyle(lineWidth: 1.7, lineJoin: .round)
+          )
+          .frame(width: 17, height: 17)
+          .offset(x: -2)
+        Capsule()
+          .fill(CompactMockupPalette.ink)
+          .frame(width: 1.8, height: 23)
+          .rotationEffect(.degrees(-42))
+      }
+      .accessibilityHidden(true)
+
+    case .stopRecording, .stopSpeech:
+      RoundedRectangle(cornerRadius: 2, style: .continuous)
+        .fill(CompactMockupPalette.stop)
+        .frame(width: 12, height: 12)
+        .accessibilityHidden(true)
+
+    case .primaryPhaseAction, .expand:
+      Circle()
+        .stroke(CompactMockupPalette.ink, lineWidth: 1.7)
+        .frame(width: 14, height: 14)
+        .accessibilityHidden(true)
     }
+  }
+}
+
+private struct CompactMicrophoneStandShape: Shape {
+  func path(in rect: CGRect) -> Path {
+    var path = Path()
+    path.move(to: CGPoint(x: rect.minX, y: rect.minY))
+    path.addCurve(
+      to: CGPoint(x: rect.maxX, y: rect.minY),
+      control1: CGPoint(x: rect.minX, y: rect.maxY * 0.62),
+      control2: CGPoint(x: rect.maxX, y: rect.maxY * 0.62)
+    )
+    path.move(to: CGPoint(x: rect.midX, y: rect.maxY * 0.55))
+    path.addLine(to: CGPoint(x: rect.midX, y: rect.maxY))
+    path.move(to: CGPoint(x: rect.width * 0.3, y: rect.maxY))
+    path.addLine(to: CGPoint(x: rect.width * 0.7, y: rect.maxY))
+    return path
+  }
+}
+
+private struct CompactSpeakerShape: Shape {
+  func path(in rect: CGRect) -> Path {
+    var path = Path()
+    path.move(to: CGPoint(x: rect.minX, y: rect.height * 0.36))
+    path.addLine(to: CGPoint(x: rect.width * 0.34, y: rect.height * 0.36))
+    path.addLine(to: CGPoint(x: rect.maxX, y: rect.minY))
+    path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
+    path.addLine(to: CGPoint(x: rect.width * 0.34, y: rect.height * 0.64))
+    path.addLine(to: CGPoint(x: rect.minX, y: rect.height * 0.64))
+    path.closeSubpath()
+    return path
+  }
+}
+
+private struct CompactHandoffMark: View {
+  var body: some View {
+    ZStack {
+      Circle()
+        .trim(from: 0.04, to: 0.44)
+        .stroke(
+          CompactMockupPalette.violet,
+          style: StrokeStyle(lineWidth: 2.2, lineCap: .round)
+        )
+        .rotationEffect(.degrees(-24))
+      Circle()
+        .trim(from: 0.54, to: 0.92)
+        .stroke(
+          CompactMockupPalette.ink,
+          style: StrokeStyle(lineWidth: 2.2, lineCap: .round)
+        )
+        .rotationEffect(.degrees(-24))
+      Circle()
+        .fill(CompactMockupPalette.stop)
+        .frame(width: 7, height: 7)
+        .offset(x: 11, y: 10)
+    }
+    .padding(3)
+    .accessibilityHidden(true)
+  }
+}
+
+private enum CompactMockupPalette {
+  static let outerShell = Color(red: 244 / 255, green: 246 / 255, blue: 253 / 255)
+  static let outerLine = Color(red: 218 / 255, green: 222 / 255, blue: 240 / 255)
+  static let innerLine = Color(red: 225 / 255, green: 228 / 255, blue: 241 / 255)
+  static let paper = Color(red: 253 / 255, green: 253 / 255, blue: 1)
+  static let ink = Color(red: 15 / 255, green: 26 / 255, blue: 67 / 255)
+  static let muted = Color(red: 91 / 255, green: 102 / 255, blue: 142 / 255)
+  static let violet = Color(red: 68 / 255, green: 48 / 255, blue: 184 / 255)
+  static let stop = Color(red: 216 / 255, green: 48 / 255, blue: 32 / 255)
+}
+
+extension View {
+  @ViewBuilder
+  fileprivate func optionalAccessibilityValue(_ value: String?) -> some View {
+    if let value {
+      accessibilityValue(value)
+    } else {
+      self
+    }
+  }
 }
 
 private struct CompactSystemDesignRoomViewPreview: PreviewProvider {
-    static var previews: some View {
-        CompactSystemDesignRoomView(
-            model: SystemDesignRoomModel(),
-            onExpand: {}
-        )
-        .padding(30)
-        .background(Color.gray.opacity(0.2))
-        .previewDisplayName("Compact system design room")
-    }
+  static var previews: some View {
+    CompactSystemDesignRoomView(
+      model: SystemDesignRoomModel(),
+      onExpand: {}
+    )
+    .padding(30)
+    .background(Color.gray.opacity(0.2))
+    .previewDisplayName("Compact system design room")
+  }
 }

--- a/Sources/InterviewArcLive/InterviewRoomPresentationCoordinator.swift
+++ b/Sources/InterviewArcLive/InterviewRoomPresentationCoordinator.swift
@@ -17,9 +17,9 @@ enum InterviewRoomCloseChoice: Equatable {
 }
 
 enum CompactPanelLayout {
-    static let contentWidth: CGFloat = 640
-    static let minimumContentHeight: CGFloat = 214
-    static let maximumContentHeight: CGFloat = 420
+    static let contentWidth: CGFloat = 580
+    static let minimumContentHeight: CGFloat = 82
+    static let maximumContentHeight: CGFloat = 180
 
     static func boundedContentHeight(_ measuredHeight: CGFloat) -> CGFloat {
         guard !measuredHeight.isNaN else { return minimumContentHeight }

--- a/Tests/InterviewArcLiveTests/InterviewRoomPresentationCoordinatorTests.swift
+++ b/Tests/InterviewArcLiveTests/InterviewRoomPresentationCoordinatorTests.swift
@@ -5,6 +5,12 @@ import XCTest
 
 @MainActor
 final class InterviewRoomPresentationCoordinatorTests: XCTestCase {
+    func testCompactPanelUsesToolPaletteScale() {
+        XCTAssertEqual(CompactPanelLayout.contentWidth, 580)
+        XCTAssertEqual(CompactPanelLayout.minimumContentHeight, 82)
+        XCTAssertEqual(CompactPanelLayout.maximumContentHeight, 180)
+    }
+
     func testCoordinatorOwnsOneFullWindowAndOneNonactivatingPanelWithSharedModel() {
         let model = SystemDesignRoomModel()
         let coordinator = makeCoordinator(model: model)
@@ -236,24 +242,24 @@ final class InterviewRoomPresentationCoordinatorTests: XCTestCase {
     }
 
     func testCompactPanelSizingIsBoundedAndPreservesTopEdge() {
-        XCTAssertEqual(CompactPanelLayout.boundedContentHeight(180), 214)
-        XCTAssertEqual(CompactPanelLayout.boundedContentHeight(310), 310)
-        XCTAssertEqual(CompactPanelLayout.boundedContentHeight(600), 420)
+        XCTAssertEqual(CompactPanelLayout.boundedContentHeight(50), 82)
+        XCTAssertEqual(CompactPanelLayout.boundedContentHeight(120), 120)
+        XCTAssertEqual(CompactPanelLayout.boundedContentHeight(600), 180)
 
         let original = NSRect(x: 100, y: 200, width: 700, height: 254)
         let resized = CompactPanelLayout.framePreservingTopEdge(
             original,
-            measuredContentHeight: 310
+            measuredContentHeight: 120
         )
 
-        XCTAssertEqual(resized.width, 640)
-        XCTAssertEqual(resized.height, 310)
+        XCTAssertEqual(resized.width, 580)
+        XCTAssertEqual(resized.height, 120)
         XCTAssertEqual(resized.maxY, original.maxY)
     }
 
     func testGrowingCompactPanelRemainsInsideVisibleScreen() {
         let visibleFrame = NSRect(x: 0, y: 0, width: 1_440, height: 900)
-        let panelNearBottom = NSRect(x: 780, y: 20, width: 640, height: 214)
+        let panelNearBottom = NSRect(x: 780, y: 20, width: 580, height: 82)
         let resized = CompactPanelLayout.framePreservingTopEdge(
             panelNearBottom,
             measuredContentHeight: 600
@@ -268,7 +274,7 @@ final class InterviewRoomPresentationCoordinatorTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(clamped.minY, visibleFrame.minY + 12)
         XCTAssertLessThanOrEqual(clamped.maxX, visibleFrame.maxX - 12)
         XCTAssertLessThanOrEqual(clamped.maxY, visibleFrame.maxY - 12)
-        XCTAssertEqual(clamped.size, NSSize(width: 640, height: 420))
+        XCTAssertEqual(clamped.size, NSSize(width: 580, height: 180))
     }
 
     private func makeCoordinator(


### PR DESCRIPTION
## **User description**
Closes #16

## Summary

- rebuild the compact room from issue #1's canonical mockup instead of an improvised palette
- match its white capsule, navy/violet/orange visual language, handoff mark, floor/status line, waveform, and bordered primary action
- retain the required live Record/Stop, Hand off/Retry/Give-floor, speech Stop/Mute, and Expand behavior without creating a second room model
- use a 580-point horizontal capsule with an adaptive stacked fallback for accessibility text

## Visual authority

- `docs/design/system-design-room.png`
- SHA-256: `31b697eb86880f611fca75f644f33e00f578bd4a01fa8b67ee970df091c5b39c`

## Verification

- Swift 6 strict warnings-as-errors typecheck of the exact compact view against signature-equivalent app state
- Swift parser checks for the compact view, coordinator, and focused test
- `git diff --check`

The hosted Xcode build, tests, package path, and headed artifact comparison remain the release authority.


___

## **CodeAnt-AI Description**
Polish the compact interview room to match the canonical tool-palette design

### What Changed
- Reworked the compact room into a smaller capsule with the canonical light palette, handoff mark, status line, waveform, borders, and compact controls
- Replaced text-heavy speech and recording controls with recognizable utility icons while keeping their accessible labels and existing actions
- Added a stacked layout for narrow or constrained spaces, with status and controls remaining usable
- Reduced the compact panel size to 580 points wide and 82–180 points high

### Impact
`✅ Compact interview controls fit in less space`
`✅ Clearer recording, speech, and handoff controls`
`✅ Usable layout on constrained window sizes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
