### PR TITLE
Prevent presentation frame restoration crash

### DIFF
--- a/Sources/InterviewArcLive/InterviewRoomPresentationCoordinator.swift
+++ b/Sources/InterviewArcLive/InterviewRoomPresentationCoordinator.swift
@@ -48,6 +48,17 @@ enum CompactPanelLayout {
     }
 }
 
+final class PresentationFrameAdjustmentGuard {
+    private(set) var isActive = false
+
+    func perform(_ adjustment: () -> Void) {
+        guard !isActive else { return }
+        isActive = true
+        defer { isActive = false }
+        adjustment()
+    }
+}
+
 /// Owns the two process-level Presentations while the interview model remains
 /// the single interaction writer. Hiding a Presentation never tears down its
 /// hosting tree or creates session/provider state.
@@ -69,7 +80,7 @@ final class InterviewRoomPresentationCoordinator: NSObject, NSWindowDelegate {
     private var didRegisterObservers = false
     private var isAllowingFullWindowClose = false
     private(set) var isResolvingCloseChoice = false
-    private var isAdjustingFrames = false
+    private let frameAdjustmentGuard = PresentationFrameAdjustmentGuard()
     private var closeAlert: NSAlert?
     private var modelOpenTask: Task<Void, Never>?
     private var compactSizeReconciliationTask: Task<Void, Never>?
@@ -257,7 +268,7 @@ final class InterviewRoomPresentationCoordinator: NSObject, NSWindowDelegate {
     }
 
     func windowDidMove(_ notification: Notification) {
-        guard !isAdjustingFrames,
+        guard !frameAdjustmentGuard.isActive,
               let window = notification.object as? NSWindow else {
             return
         }
@@ -269,7 +280,7 @@ final class InterviewRoomPresentationCoordinator: NSObject, NSWindowDelegate {
     }
 
     func windowDidResize(_ notification: Notification) {
-        guard !isAdjustingFrames,
+        guard !frameAdjustmentGuard.isActive,
               let window = notification.object as? NSWindow,
               window === fullWindow,
               !fullWindow.isMiniaturized else {
@@ -531,19 +542,24 @@ final class InterviewRoomPresentationCoordinator: NSObject, NSWindowDelegate {
     }
 
     private func clampPresentationFramesToVisibleScreens() {
+        guard fullWindow != nil,
+              compactPanel != nil,
+              !frameAdjustmentGuard.isActive else {
+            return
+        }
         clampFullWindowToVisibleScreens()
         clampCompactPanelToVisibleScreens()
     }
 
     private func clampFullWindowToVisibleScreens(source: NSRect? = nil) {
-        let visibleFrames = NSScreen.screens.map(\.visibleFrame)
-        guard !visibleFrames.isEmpty else { return }
-        let frame = source ?? savedFullFrame ?? fullWindow.frame
-        let clamped = Self.clampedFrame(frame, to: visibleFrames)
-        isAdjustingFrames = true
-        fullWindow.setFrame(clamped, display: fullWindow.isVisible)
-        isAdjustingFrames = false
-        savedFullFrame = fullWindow.frame
+        frameAdjustmentGuard.perform { [self] in
+            let visibleFrames = NSScreen.screens.map(\.visibleFrame)
+            guard !visibleFrames.isEmpty else { return }
+            let frame = source ?? savedFullFrame ?? fullWindow.frame
+            let clamped = Self.clampedFrame(frame, to: visibleFrames)
+            fullWindow.setFrame(clamped, display: fullWindow.isVisible)
+            savedFullFrame = fullWindow.frame
+        }
     }
 
     private func clampCompactPanelToVisibleScreens() {
@@ -597,10 +613,10 @@ final class InterviewRoomPresentationCoordinator: NSObject, NSWindowDelegate {
     }
 
     private func setCompactPanelFrame(_ frame: NSRect) {
-        isAdjustingFrames = true
-        compactPanel.setFrame(frame, display: compactPanel.isVisible)
-        isAdjustingFrames = false
-        savedCompactOrigin = compactPanel.frame.origin
+        frameAdjustmentGuard.perform { [self] in
+            compactPanel.setFrame(frame, display: compactPanel.isVisible)
+            savedCompactOrigin = compactPanel.frame.origin
+        }
     }
 
     @objc

--- a/Tests/InterviewArcLiveTests/InterviewRoomPresentationCoordinatorTests.swift
+++ b/Tests/InterviewArcLiveTests/InterviewRoomPresentationCoordinatorTests.swift
@@ -59,6 +59,27 @@ final class InterviewRoomPresentationCoordinatorTests: XCTestCase {
         )
     }
 
+    func testScreenChangeCallbackCannotReenterAnActiveFrameAdjustment() {
+        let frameAdjustmentGuard = PresentationFrameAdjustmentGuard()
+        var adjustmentCount = 0
+        var screenChangeCallback: (() -> Void)!
+
+        screenChangeCallback = {
+            guard !frameAdjustmentGuard.isActive else { return }
+            frameAdjustmentGuard.perform {
+                adjustmentCount += 1
+                // NSWindow frame restoration can synchronously send the same
+                // screen-change callback before setFrame returns.
+                screenChangeCallback()
+            }
+        }
+
+        screenChangeCallback()
+
+        XCTAssertEqual(adjustmentCount, 1)
+        XCTAssertFalse(frameAdjustmentGuard.isActive)
+    }
+
     func testCollapseAndExpandRetainWindowsHostingTreesFrameAndFocus() throws {
         let coordinator = makeCoordinator()
         defer { coordinator.prepareForTermination() }


### PR DESCRIPTION
## **User description**
## Summary

- prevent synchronous `windowDidChangeScreen` callbacks from re-entering retained-presentation frame adjustment
- defer display clamping until both retained presentations finish installation, so frame restoration cannot access a partially constructed window graph
- add a deterministic regression that simulates AppKit sending the same screen-change callback from inside an active frame adjustment

Refs #16

## Root cause

`setFrameUsingName` can synchronously send `windowDidChangeScreen` while `installPresentations` is still constructing the full and compact windows. The callback attempted composite clamping before both windows existed. A subsequent `setFrame` could synchronously send the callback again because screen changes did not participate in the coordinator's existing frame-adjustment exclusion.

## Verification

- `swiftc -frontend -parse Sources/InterviewArcLive/InterviewRoomPresentationCoordinator.swift`
- `swiftc -frontend -parse Tests/InterviewArcLiveTests/InterviewRoomPresentationCoordinatorTests.swift`
- `git diff --check`
- Focused local `swift test --filter InterviewRoomPresentationCoordinatorTests` could not compile the package manifest because this Mac currently exposes a Swift 6.3.3 command-line compiler with a Swift 6.3.2 SDK. Required hosted CI remains the clean package/typecheck/XCTest gate.

## Reliability and rollback

- The change is limited to presentation frame orchestration; it does not touch session, recording, transcript, provider, or persistence state.
- Full and compact frames still use the same clamping calculations and saved-frame behavior. Only partial-installation and reentrant callback work is rejected.
- Rollback is this single commit, `69668055d921ad1b9ada6e7e62377bf90a2710bb`.

## Execution ledger

| Pacific time | Work |
| --- | --- |
| unknown–2026-08-10 03:56:30 PDT | Reviewed the repeated launch-crash stack and issue #16 presentation contract; implemented the installation/reentrancy invariant and focused regression; completed parser and diff checks; recorded the local compiler/SDK blocker. |
| 2026-08-10 03:56:30 PDT | Created commit `69668055d921ad1b9ada6e7e62377bf90a2710bb` and pushed the scoped branch. |

Request time, active engineering duration, external cost, and provider usage are unavailable.


___

## **CodeAnt-AI Description**
Prevent presentation windows from crashing during screen changes

### What Changed
- Prevents screen-change callbacks from restarting an active window frame adjustment
- Defers frame clamping when either presentation window is not yet available
- Adds regression coverage for synchronous callback recursion during frame restoration

### Impact
`✅ Fewer launch crashes during presentation restoration`
`✅ Stable window placement across display changes`
`✅ Safer full-window and compact-panel setup`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
