### PR TITLE
Make Codex child-process exit waiting deterministic

### DIFF
--- a/Sources/InterviewArcLiveCodexAdapter/CodexAppServerProcess.swift
+++ b/Sources/InterviewArcLiveCodexAdapter/CodexAppServerProcess.swift
@@ -123,6 +123,15 @@ struct FoundationCodexAppServerProcessLauncher: CodexAppServerProcessLaunching {
         // retains it; a zero-byte buffer is the strictest possible memory bound.
         process.standardError = FileHandle.nullDevice
 
+        // `waitUntilExit()` polls the current thread's run loop, which is not a
+        // safe assumption on Swift concurrency's detached worker threads. Install
+        // the completion observer before launch so even an immediate exit is
+        // retained for every current or future waiter.
+        let exitWaiter = ProcessExitWaiter()
+        process.terminationHandler = { [exitWaiter] process in
+            exitWaiter.finish(with: process.terminationStatus)
+        }
+
         // A concurrent cancellation closes stdin while a detached writer may be
         // blocked. Convert the resulting broken pipe into a Swift error instead of
         // allowing SIGPIPE to terminate the Live app process.
@@ -145,7 +154,8 @@ struct FoundationCodexAppServerProcessLauncher: CodexAppServerProcessLaunching {
             inputPipe: input,
             outputPipe: output,
             lineLimit: lineLimit,
-            totalOutputLimit: totalOutputLimit
+            totalOutputLimit: totalOutputLimit,
+            exitWaiter: exitWaiter
         )
     }
 }
@@ -155,6 +165,41 @@ private final class SendableProcessBox: @unchecked Sendable {
 
     init(_ process: Process) {
         self.process = process
+    }
+}
+
+private final class ProcessExitWaiter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var exitCode: Int32?
+    private var waiters: [CheckedContinuation<Int32, Never>] = []
+
+    func wait() async -> Int32 {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            if let exitCode {
+                lock.unlock()
+                continuation.resume(returning: exitCode)
+            } else {
+                waiters.append(continuation)
+                lock.unlock()
+            }
+        }
+    }
+
+    func finish(with exitCode: Int32) {
+        lock.lock()
+        guard self.exitCode == nil else {
+            lock.unlock()
+            return
+        }
+        self.exitCode = exitCode
+        let waiters = waiters
+        self.waiters.removeAll(keepingCapacity: false)
+        lock.unlock()
+
+        for waiter in waiters {
+            waiter.resume(returning: exitCode)
+        }
     }
 }
 
@@ -262,6 +307,7 @@ private actor FoundationCodexAppServerConnection: CodexAppServerProcessConnectio
     private let outputPipe: Pipe
     private let writer: BlockingWriter
     private let reader: BlockingLineReader
+    private let exitWaiter: ProcessExitWaiter
     private var didTerminate = false
     private var terminationCompleted = false
     private var terminationWaiters: [CheckedContinuation<Void, Never>] = []
@@ -271,7 +317,8 @@ private actor FoundationCodexAppServerConnection: CodexAppServerProcessConnectio
         inputPipe: Pipe,
         outputPipe: Pipe,
         lineLimit: Int,
-        totalOutputLimit: Int
+        totalOutputLimit: Int,
+        exitWaiter: ProcessExitWaiter
     ) {
         processBox = SendableProcessBox(process)
         self.inputPipe = inputPipe
@@ -282,6 +329,7 @@ private actor FoundationCodexAppServerConnection: CodexAppServerProcessConnectio
             lineLimit: lineLimit,
             totalOutputLimit: totalOutputLimit
         )
+        self.exitWaiter = exitWaiter
     }
 
     func send(_ data: Data) async throws {
@@ -302,11 +350,7 @@ private actor FoundationCodexAppServerConnection: CodexAppServerProcessConnectio
     }
 
     func waitForExit() async -> Int32 {
-        let processBox = processBox
-        return await Task.detached(priority: .utility) {
-            processBox.process.waitUntilExit()
-            return processBox.process.terminationStatus
-        }.value
+        await exitWaiter.wait()
     }
 
     func terminate() async {

--- a/Tests/InterviewArcLiveCodexAdapterTests/CodexAppServerProcessTests.swift
+++ b/Tests/InterviewArcLiveCodexAdapterTests/CodexAppServerProcessTests.swift
@@ -36,6 +36,29 @@ final class CodexAppServerProcessTests: XCTestCase {
         await connection.terminate()
     }
 
+    func testWaitForNaturalExitCompletesFromDetachedWorkerWithoutRunLoopPolling() async throws {
+        let launcher = FoundationCodexAppServerProcessLauncher()
+        let connection = try await launcher.connect(
+            executableURL: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-c", "exit 23"],
+            environment: [
+                "HOME": "/private/tmp",
+                "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+                "LANG": "en_US.UTF-8",
+                "LC_ALL": "en_US.UTF-8",
+            ],
+            lineLimit: 1_024,
+            totalOutputLimit: 1_024
+        )
+
+        let exitCode = await Task.detached {
+            await connection.waitForExit()
+        }.value
+
+        XCTAssertEqual(exitCode, 23)
+        await connection.terminate()
+    }
+
     func testTerminateEscalatesTermIgnoringChildAndReapsWithinBound() async throws {
         let launcher = FoundationCodexAppServerProcessLauncher()
         let connection = try await launcher.connect(
@@ -53,14 +76,30 @@ final class CodexAppServerProcessTests: XCTestCase {
         let readyLine = try await connection.receiveLine()
         XCTAssertEqual(readyLine, Data("ready".utf8))
 
+        let exitWaiters = (0..<8).map { _ in
+            Task.detached {
+                await connection.waitForExit()
+            }
+        }
         let clock = ContinuousClock()
         let started = clock.now
-        await connection.terminate()
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<8 {
+                group.addTask {
+                    await connection.terminate()
+                }
+            }
+        }
         let elapsed = started.duration(to: clock.now)
 
         XCTAssertLessThan(elapsed, .seconds(3))
-        let exitCode = await connection.waitForExit()
-        XCTAssertEqual(exitCode, SIGKILL)
+        for waiter in exitWaiters {
+            let exitCode = await waiter.value
+            XCTAssertEqual(exitCode, SIGKILL)
+        }
+        let repeatedExitCode = await connection.waitForExit()
+        XCTAssertEqual(repeatedExitCode, SIGKILL)
+        await connection.terminate()
     }
 
     func testLargeWriteToNonReadingChildCanBeCancelledAndReaped() async throws {


### PR DESCRIPTION
## **User description**
Refs #24

## Summary

- replace detached `Process.waitUntilExit()` polling with a process-owned asynchronous exit receipt
- install the termination handler before launch so immediate exits cannot be missed
- make concurrent and repeated exit waits/termination calls return one stable terminal status
- preserve bounded TERM-to-KILL escalation, process reaping, output bounds, and existing adapter behavior

## Verification

- strict Swift 6 complete-concurrency production typecheck with warnings as errors
- focused source/test parse and `git diff --check`
- executable concurrency harness covering immediate natural exit, forced SIGKILL, 32 concurrent waiters and terminators, repeated future waits, normal JSONL streaming, blocked-write cancellation, and output-limit cleanup
- hosted Xcode 26.3/Metal CI required on this exact head

## Scope

Only the Codex subprocess adapter and its focused process tests change. Presentation, Board, Core session, speech, credentials, and packaging are untouched.


___

## **CodeAnt-AI Description**
Make Codex process exit waits deterministic

### What Changed
- Exit waits now complete reliably, including when called from detached workers or immediately after a process exits
- Multiple concurrent and repeated waiters receive the same final exit status
- Termination remains bounded while all callers receive the confirmed result, including forced termination
- Added coverage for natural exits, concurrent termination, repeated waits, and stable exit statuses

### Impact
`✅ Reliable Codex process completion`
`✅ Fewer indefinite exit waits`
`✅ Consistent termination results`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
