### PR TITLE
Make the compact capsule hug its content

### DIFF
--- a/Sources/InterviewArcLive/CompactSystemDesignRoomView.swift
+++ b/Sources/InterviewArcLive/CompactSystemDesignRoomView.swift
@@ -3,8 +3,20 @@ import SwiftUI
 struct CompactSystemDesignRoomView: View {
   @ObservedObject var model: SystemDesignRoomModel
   let onExpand: () -> Void
+  let dynamicTypeSizeOverride: DynamicTypeSize?
 
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+  init(
+    model: SystemDesignRoomModel,
+    onExpand: @escaping () -> Void,
+    dynamicTypeSizeOverride: DynamicTypeSize? = nil
+  ) {
+    self.model = model
+    self.onExpand = onExpand
+    self.dynamicTypeSizeOverride = dynamicTypeSizeOverride
+  }
 
   private var presentation: CompactRoomPresentation {
     model.compactPresentation
@@ -45,13 +57,23 @@ struct CompactSystemDesignRoomView: View {
   }
 
   private var capsuleContent: some View {
-    ViewThatFits(in: .horizontal) {
-      horizontalCapsule
-      stackedCapsule
+    Group {
+      if effectiveDynamicTypeSize.isAccessibilitySize {
+        stackedCapsule
+      } else {
+        ViewThatFits(in: .horizontal) {
+          horizontalCapsule
+          stackedCapsule
+        }
+      }
     }
     .padding(7)
     .frame(maxWidth: .infinity, alignment: .leading)
     .fixedSize(horizontal: false, vertical: true)
+  }
+
+  private var effectiveDynamicTypeSize: DynamicTypeSize {
+    dynamicTypeSizeOverride ?? dynamicTypeSize
   }
 
   private var horizontalCapsule: some View {

--- a/Sources/InterviewArcLive/InterviewRoomPresentationCoordinator.swift
+++ b/Sources/InterviewArcLive/InterviewRoomPresentationCoordinator.swift
@@ -75,6 +75,7 @@ final class InterviewRoomPresentationCoordinator: NSObject, NSWindowDelegate {
     private var compactHostingController: CompactRoomHostingController!
     private var fullContainerController: FullRoomContainerController!
     private let frameAutosaveName: String
+    private let compactDynamicTypeSizeOverride: DynamicTypeSize?
 
     private var didStart = false
     private var didRegisterObservers = false
@@ -91,10 +92,12 @@ final class InterviewRoomPresentationCoordinator: NSObject, NSWindowDelegate {
 
     init(
         model: SystemDesignRoomModel,
-        frameAutosaveName: String = "InterviewArcLive.SystemDesignRoom"
+        frameAutosaveName: String = "InterviewArcLive.SystemDesignRoom",
+        compactDynamicTypeSizeOverride: DynamicTypeSize? = nil
     ) {
         self.model = model
         self.frameAutosaveName = frameAutosaveName
+        self.compactDynamicTypeSizeOverride = compactDynamicTypeSizeOverride
         super.init()
         installPresentations()
         registerLifecycleObservers()
@@ -376,7 +379,8 @@ final class InterviewRoomPresentationCoordinator: NSObject, NSWindowDelegate {
 
         let compactRoot = CompactSystemDesignRoomView(
             model: model,
-            onExpand: { [weak self] in self?.expand() }
+            onExpand: { [weak self] in self?.expand() },
+            dynamicTypeSizeOverride: compactDynamicTypeSizeOverride
         )
         compactHostingController = CompactRoomHostingController(
             rootView: compactRoot
@@ -590,15 +594,11 @@ final class InterviewRoomPresentationCoordinator: NSObject, NSWindowDelegate {
               presentationState != .terminated else {
             return
         }
-        let measuredSize = compactHostingController.sizeThatFits(
-            in: NSSize(
-                width: CompactPanelLayout.contentWidth,
-                height: CompactPanelLayout.maximumContentHeight
-            )
-        )
+        let hostedView = compactHostingController.view
+        hostedView.layoutSubtreeIfNeeded()
         let resized = CompactPanelLayout.framePreservingTopEdge(
             compactPanel.frame,
-            measuredContentHeight: measuredSize.height
+            measuredContentHeight: hostedView.fittingSize.height
         )
         let clamped = Self.clampedFrame(
             resized,

--- a/Sources/InterviewArcLive/InterviewRoomPresentationCoordinator.swift
+++ b/Sources/InterviewArcLive/InterviewRoomPresentationCoordinator.swift
@@ -403,14 +403,6 @@ final class InterviewRoomPresentationCoordinator: NSObject, NSWindowDelegate {
         )
         panel.title = "Interview Arc Live compact interview controls"
         panel.contentViewController = compactHostingController
-        panel.contentMinSize = NSSize(
-            width: CompactPanelLayout.contentWidth,
-            height: CompactPanelLayout.minimumContentHeight
-        )
-        panel.contentMaxSize = NSSize(
-            width: CompactPanelLayout.contentWidth,
-            height: CompactPanelLayout.maximumContentHeight
-        )
         panel.isReleasedWhenClosed = false
         panel.isOpaque = false
         panel.backgroundColor = .clear

--- a/Tests/InterviewArcLiveTests/InterviewRoomPresentationCoordinatorTests.swift
+++ b/Tests/InterviewArcLiveTests/InterviewRoomPresentationCoordinatorTests.swift
@@ -44,20 +44,6 @@ final class InterviewRoomPresentationCoordinatorTests: XCTestCase {
         XCTAssertTrue(
             coordinator.compactPanel.collectionBehavior.contains(.fullScreenNone)
         )
-        XCTAssertEqual(
-            coordinator.compactPanel.contentMinSize,
-            NSSize(
-                width: CompactPanelLayout.contentWidth,
-                height: CompactPanelLayout.minimumContentHeight
-            )
-        )
-        XCTAssertEqual(
-            coordinator.compactPanel.contentMaxSize,
-            NSSize(
-                width: CompactPanelLayout.contentWidth,
-                height: CompactPanelLayout.maximumContentHeight
-            )
-        )
     }
 
     func testScreenChangeCallbackCannotReenterAnActiveFrameAdjustment() {

--- a/Tests/InterviewArcLiveTests/InterviewRoomPresentationCoordinatorTests.swift
+++ b/Tests/InterviewArcLiveTests/InterviewRoomPresentationCoordinatorTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import SwiftUI
 import XCTest
 
 @testable import InterviewArcLive
@@ -278,6 +279,59 @@ final class InterviewRoomPresentationCoordinatorTests: XCTestCase {
         XCTAssertEqual(resized.maxY, original.maxY)
     }
 
+    func testCollapsedCompactPanelHugsHorizontalHostedContent() throws {
+        let coordinator = makeCoordinator()
+        defer { coordinator.prepareForTermination() }
+
+        coordinator.collapse()
+
+        let contentView = try XCTUnwrap(coordinator.compactPanel.contentView)
+        contentView.layoutSubtreeIfNeeded()
+        let hostedContentHeight = CompactPanelLayout.boundedContentHeight(
+            contentView.fittingSize.height
+        )
+
+        XCTAssertTrue(coordinator.compactPanel.isVisible)
+        XCTAssertEqual(
+            hostedContentHeight,
+            CompactPanelLayout.minimumContentHeight
+        )
+        XCTAssertTrue(
+            abs(coordinator.compactPanel.frame.height - hostedContentHeight) <= 0.5
+        )
+        XCTAssertTrue(
+            abs(contentView.frame.height - hostedContentHeight) <= 0.5
+        )
+    }
+
+    func testCollapsedCompactPanelGrowsForStackedAccessibilityContent() throws {
+        let coordinator = makeCoordinator(
+            compactDynamicTypeSizeOverride: .accessibility1
+        )
+        defer { coordinator.prepareForTermination() }
+
+        coordinator.collapse()
+
+        let contentView = try XCTUnwrap(coordinator.compactPanel.contentView)
+        contentView.layoutSubtreeIfNeeded()
+        let hostedContentHeight = CompactPanelLayout.boundedContentHeight(
+            contentView.fittingSize.height
+        )
+
+        XCTAssertTrue(coordinator.compactPanel.isVisible)
+        XCTAssertTrue(
+            coordinator.compactPanel.frame.height
+                > CompactPanelLayout.minimumContentHeight
+        )
+        XCTAssertTrue(
+            coordinator.compactPanel.frame.height
+                <= CompactPanelLayout.maximumContentHeight
+        )
+        XCTAssertTrue(
+            abs(coordinator.compactPanel.frame.height - hostedContentHeight) <= 0.5
+        )
+    }
+
     func testGrowingCompactPanelRemainsInsideVisibleScreen() {
         let visibleFrame = NSRect(x: 0, y: 0, width: 1_440, height: 900)
         let panelNearBottom = NSRect(x: 780, y: 20, width: 580, height: 82)
@@ -299,12 +353,14 @@ final class InterviewRoomPresentationCoordinatorTests: XCTestCase {
     }
 
     private func makeCoordinator(
-        model: SystemDesignRoomModel = SystemDesignRoomModel()
+        model: SystemDesignRoomModel? = nil,
+        compactDynamicTypeSizeOverride: DynamicTypeSize? = nil
     ) -> InterviewRoomPresentationCoordinator {
         _ = NSApplication.shared
         return InterviewRoomPresentationCoordinator(
-            model: model,
-            frameAutosaveName: "InterviewArcLiveTests.TransientFrame"
+            model: model ?? SystemDesignRoomModel(),
+            frameAutosaveName: "InterviewArcLiveTests.TransientFrame",
+            compactDynamicTypeSizeOverride: compactDynamicTypeSizeOverride
         )
     }
 }


### PR DESCRIPTION
## **User description**
Refs #16

## Summary

- size the compact panel from the laid-out hosted view's real fitting height instead of the maximum `sizeThatFits` proposal
- keep the ordinary horizontal capsule exactly `580×82`, eliminating the headed-smoke blank area
- force the stacked capsule only for accessibility Dynamic Type and bound its fitted height to 180pt
- retain startup frame-reentrancy, display clamping, model identity, focus, and nonactivating-panel behavior

## Root cause

`NSHostingController.sizeThatFits(in: 580×180)` returned the proposal ceiling for this root view. The coordinator therefore kept an 180pt panel around content whose real intrinsic height was 82pt. Laying out the hosted view and reading `view.fittingSize.height` measures the content rather than the proposal.

## Verification

- full app module strict emit: zero diagnostics
- focused presentation plus Board/model test typecheck: zero diagnostics
- current-source AppKit harness: screen-change reentrancy, horizontal `580×82` panel/content equality, and bounded accessibility-stacked growth passed
- Swift parse and `git diff --check`
- hosted Xcode 26.3/Metal CI required on this exact head

## Scope

Exactly the compact view, presentation coordinator, and focused coordinator tests change. Board, Core session, recording, transcription, Codex runtime, speech, credentials, and packaging are unchanged.


___

## **CodeAnt-AI Description**
Make the compact interview panel fit its content and accessibility text

### What Changed
- The compact panel now matches the hosted controls’ actual height instead of retaining unused space from a sizing limit.
- Standard text sizes keep the horizontal capsule at its compact height.
- Accessibility text sizes use the stacked layout and allow the panel to grow up to its supported maximum.
- Added coverage confirming content-sized panels and accessibility-driven growth.

### Impact
`✅ Removes blank space from the compact panel`
`✅ Keeps accessibility text and controls readable`
`✅ Keeps the panel aligned with its visible content`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
