### PR TITLE
Close final System Design mockup fidelity gaps

### DIFF
--- a/Sources/InterviewArcLive/InterviewRoomPresentationCoordinator.swift
+++ b/Sources/InterviewArcLive/InterviewRoomPresentationCoordinator.swift
@@ -48,6 +48,17 @@ enum CompactPanelLayout {
     }
 }
 
+enum InterviewRoomWindowLayout {
+    static let fullDefaultContentSize = NSSize(
+        width: FullRoomLayout.defaultWindowWidth,
+        height: 760
+    )
+    static let fullMinimumContentSize = NSSize(
+        width: FullRoomLayout.minimumWindowWidth,
+        height: FullRoomLayout.minimumWindowHeight
+    )
+}
+
 final class PresentationFrameAdjustmentGuard {
     private(set) var isActive = false
 
@@ -347,7 +358,10 @@ final class InterviewRoomPresentationCoordinator: NSObject, NSWindowDelegate {
         )
 
         let full = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 1_180, height: 760),
+            contentRect: NSRect(
+                origin: .zero,
+                size: InterviewRoomWindowLayout.fullDefaultContentSize
+            ),
             styleMask: [
                 .titled,
                 .closable,
@@ -362,7 +376,7 @@ final class InterviewRoomPresentationCoordinator: NSObject, NSWindowDelegate {
         full.titleVisibility = .hidden
         full.titlebarAppearsTransparent = true
         full.isReleasedWhenClosed = false
-        full.contentMinSize = NSSize(width: 1_080, height: 700)
+        full.contentMinSize = InterviewRoomWindowLayout.fullMinimumContentSize
         full.animationBehavior = .none
         full.contentViewController = fullContainerController
         full.delegate = self

--- a/Sources/InterviewArcLive/SystemDesignBoardView.swift
+++ b/Sources/InterviewArcLive/SystemDesignBoardView.swift
@@ -74,29 +74,44 @@ struct SystemDesignBoardView: View {
     }
 
     private func revisionRailContent(compact: Bool) -> some View {
-        HStack(spacing: compact
-            ? BoardRailWidthBudget.compactRevisionSpacing
-            : 18
-        ) {
+        let sizing = BoardRailWidthBudget.revisionSizing(
+            compact: compact,
+            actionCount: compactRevisionActionCount
+        )
+
+        return HStack(spacing: compact ? BoardRailWidthBudget.compactRevisionSpacing : 0) {
             if compact {
                 tab("Board", isSelected: true)
                     .frame(width: BoardRailWidthBudget.compactTabWidth)
                     .accessibilityHint("Brief and Notes are not available in this version")
+                revisionStatus(compact: true)
+                Spacer(minLength: BoardRailWidthBudget.compactRevisionSpacerWidth)
+                revisionPrimaryAction(compact: true)
+                revisionMenu(compact: true)
+                attachRevisionButton(compact: true)
+                exportRevisionButton(compact: true)
             } else {
                 HStack(spacing: 30) {
                     tab("Board", isSelected: true)
                     tab("Brief", isSelected: false)
                     tab("Notes", isSelected: false)
                 }
-            }
+                .fixedSize()
 
-            revisionStatus(compact: compact)
-            Spacer(minLength: compact ? 4 : 12)
-            revisionPrimaryAction(compact: compact)
-            revisionMenu(compact: compact)
-            if !compact { railDivider }
-            attachRevisionButton(compact: compact)
-            exportRevisionButton(compact: compact)
+                Spacer(
+                    minLength: BoardRailWidthBudget.wideRevisionGroupGapMinimum
+                )
+
+                HStack(spacing: 18) {
+                    revisionStatus(compact: false)
+                    revisionPrimaryAction(compact: false)
+                    revisionMenu(compact: false)
+                    railDivider
+                    attachRevisionButton(compact: false)
+                    exportRevisionButton(compact: false)
+                }
+                .fixedSize()
+            }
         }
         .font(.system(.callout, design: .rounded))
         .padding(.horizontal, compact
@@ -104,14 +119,11 @@ struct SystemDesignBoardView: View {
             : 20
         )
         .frame(
-            minWidth: compact
-                ? BoardRailWidthBudget.compactRevisionRequiredWidth(
-                    actionCount: compactRevisionActionCount
-                )
-                : BoardRailWidthBudget.wideRevisionRequiredWidth,
+            minWidth: sizing.requiredWidth,
+            maxWidth: sizing.maximumWidth,
             minHeight: BoardLayoutMetrics.revisionRailHeight
         )
-        .fixedSize(horizontal: true, vertical: false)
+        .fixedSize(horizontal: sizing.fixesHorizontalSize, vertical: false)
     }
 
     private var compactRevisionActionCount: Int {
@@ -374,7 +386,9 @@ struct SystemDesignBoardView: View {
     }
 
     private func toolRailContent(compact: Bool) -> some View {
-        HStack(spacing: compact
+        let sizing = BoardRailWidthBudget.toolbarSizing(compact: compact)
+
+        return HStack(spacing: compact
             ? BoardRailWidthBudget.compactToolbarSpacing
             : 8
         ) {
@@ -397,7 +411,7 @@ struct SystemDesignBoardView: View {
                 icon: "textformat",
                 compact: compact
             )
-            railDivider
+            toolRailSeparator(compact: compact)
             toolButton(
                 .pen,
                 title: "Pen",
@@ -410,10 +424,10 @@ struct SystemDesignBoardView: View {
                 icon: "eraser",
                 compact: compact
             )
-            railDivider
+            toolRailSeparator(compact: compact)
             historyButton(isUndo: true, compact: compact)
             historyButton(isUndo: false, compact: compact)
-            railDivider
+            toolRailSeparator(compact: compact)
             zoomMenu(compact: compact)
         }
         .buttonStyle(.plain)
@@ -423,12 +437,22 @@ struct SystemDesignBoardView: View {
             : 20
         )
         .frame(
-            minWidth: compact
-                ? BoardRailWidthBudget.compactToolbarRequiredWidth
-                : BoardRailWidthBudget.wideToolbarRequiredWidth,
+            minWidth: sizing.requiredWidth,
+            maxWidth: sizing.maximumWidth,
             minHeight: BoardLayoutMetrics.toolRailHeight
         )
-        .fixedSize(horizontal: true, vertical: false)
+        .fixedSize(horizontal: sizing.fixesHorizontalSize, vertical: false)
+    }
+
+    @ViewBuilder
+    private func toolRailSeparator(compact: Bool) -> some View {
+        if compact {
+            railDivider
+        } else {
+            Spacer(minLength: BoardRailWidthBudget.wideToolbarGroupGapMinimum)
+            railDivider
+            Spacer(minLength: BoardRailWidthBudget.wideToolbarGroupGapMinimum)
+        }
     }
 
     private func boxToolMenu(compact: Bool) -> some View {
@@ -719,6 +743,7 @@ struct SystemDesignBoardView: View {
             }
             .overlay(alignment: .bottomLeading) {
                 boardFooter
+                    .padding(12)
             }
         }
     }
@@ -745,39 +770,31 @@ struct SystemDesignBoardView: View {
     }
 
     private var boardFooter: some View {
-        HStack(spacing: 7) {
-            Image(
-                systemName: model.boardErrorMessage == nil
-                    ? "checkmark.circle"
-                    : "exclamationmark.triangle"
-            )
-            Text(boardStatusText)
+        let presentation = BoardFooterPresentation.make(
+            errorMessage: model.boardErrorMessage,
+            exportMessage: model.boardExportMessage,
+            interactionFeedback: interactionFeedback
+        )
+
+        return HStack(spacing: 7) {
+            Image(systemName: presentation.systemImage)
+            Text(presentation.text)
                 .lineLimit(2)
-            Spacer()
         }
         .font(.system(.caption, design: .rounded))
         .foregroundStyle(
-            model.boardErrorMessage == nil ? BoardPalette.muted : BoardPalette.errorText
+            presentation.tone == .error
+                ? BoardPalette.errorText
+                : BoardPalette.muted
         )
-        .padding(.horizontal, 16)
-        .padding(.vertical, 9)
-        .background(BoardPalette.paper.opacity(0.94))
+        .frame(
+            maxWidth: BoardCanvasVisualMetrics.footerMaximumWidth,
+            alignment: .leading
+        )
+        .fixedSize(horizontal: false, vertical: true)
         .accessibilityElement(children: .combine)
         .accessibilityLabel("Board status")
-        .accessibilityValue(boardStatusText)
-    }
-
-    private var boardStatusText: String {
-        if let boardErrorMessage = model.boardErrorMessage {
-            return boardErrorMessage
-        }
-        if let boardExportMessage = model.boardExportMessage {
-            return boardExportMessage
-        }
-        if let interactionFeedback {
-            return "\(interactionFeedback) · \(model.boardRevisionStatus)"
-        }
-        return model.boardRevisionStatus
+        .accessibilityValue(presentation.text)
     }
 
     private func boxLayer(_ document: BoardDocument) -> some View {
@@ -1220,16 +1237,13 @@ struct SystemDesignBoardView: View {
                     select(nil)
                     interactionFeedback = "Selection cleared"
                 case .box:
-                    let origin = BoardPoint(
-                        x: max(0, min(point.x - 80, model.boardEditor.document.canvas.size.width - 160)),
-                        y: max(0, min(point.y - 45, model.boardEditor.document.canvas.size.height - 90))
+                    let frame = BoardNodeCreationDefaults.frame(
+                        centeredAt: point,
+                        in: model.boardEditor.document.canvas.size
                     )
                     model.applyBoardAction(
                         .createBox(
-                            frame: BoardRect(
-                                origin: origin,
-                                size: BoardSize(width: 160, height: 90)
-                            ),
+                            frame: frame,
                             label: newBoxKind.displayName,
                             kind: newBoxKind
                         )
@@ -1875,6 +1889,88 @@ enum BoardLayoutMetrics {
     static let emptyStateMaximumWidth: CGFloat = 360
 }
 
+enum BoardCanvasVisualMetrics {
+    static let gridSpacing: CGFloat = 20
+    static let gridDotDiameter: CGFloat = 1.6
+    static let gridDotOpacity = 0.22
+    static let footerMaximumWidth: CGFloat = 420
+}
+
+struct BoardFooterPresentation: Equatable {
+    enum Tone: Equatable {
+        case neutral
+        case confirmation
+        case feedback
+        case error
+    }
+
+    let text: String
+    let systemImage: String
+    let tone: Tone
+
+    static func make(
+        errorMessage: String?,
+        exportMessage: String?,
+        interactionFeedback: String?
+    ) -> Self {
+        if let errorMessage {
+            return Self(
+                text: errorMessage,
+                systemImage: "exclamationmark.triangle",
+                tone: .error
+            )
+        }
+        if let exportMessage {
+            return Self(
+                text: exportMessage,
+                systemImage: "checkmark.circle",
+                tone: .confirmation
+            )
+        }
+        if let interactionFeedback {
+            return Self(
+                text: interactionFeedback,
+                systemImage: "info.circle",
+                tone: .feedback
+            )
+        }
+        return Self(
+            text: "Editable source autosaves locally",
+            systemImage: "internaldrive",
+            tone: .neutral
+        )
+    }
+}
+
+enum BoardRailVariant: Equatable {
+    case wide
+    case compact
+}
+
+struct BoardRailWidthResolution: Equatable {
+    let variant: BoardRailVariant
+    let renderedWidth: CGFloat
+}
+
+struct BoardRailSizing: Equatable {
+    let requiredWidth: CGFloat
+    let expandsToAvailableWidth: Bool
+
+    var maximumWidth: CGFloat? {
+        expandsToAvailableWidth ? .infinity : nil
+    }
+
+    var fixesHorizontalSize: Bool {
+        !expandsToAvailableWidth
+    }
+
+    func renderedWidth(in availableWidth: CGFloat) -> CGFloat {
+        expandsToAvailableWidth
+            ? max(requiredWidth, availableWidth)
+            : requiredWidth
+    }
+}
+
 enum BoardRailWidthBudget {
     static let supportedBoardWidth: CGFloat = 680
     static let compactHorizontalPadding: CGFloat = 8
@@ -1887,6 +1983,8 @@ enum BoardRailWidthBudget {
     static let dividerWidth: CGFloat = 1
     static let wideRevisionRequiredWidth: CGFloat = 820
     static let wideToolbarRequiredWidth: CGFloat = 780
+    static let wideRevisionGroupGapMinimum: CGFloat = 32
+    static let wideToolbarGroupGapMinimum: CGFloat = 12
 
     static func compactRevisionRequiredWidth(actionCount: Int) -> CGFloat {
         let actions = max(0, actionCount)
@@ -1908,6 +2006,65 @@ enum BoardRailWidthBudget {
             + CGFloat(dividerCount) * dividerWidth
             + compactZoomWidth
             + CGFloat(itemCount - 1) * compactToolbarSpacing
+    }
+
+    static func revisionSizing(
+        compact: Bool,
+        actionCount: Int
+    ) -> BoardRailSizing {
+        BoardRailSizing(
+            requiredWidth: compact
+                ? compactRevisionRequiredWidth(actionCount: actionCount)
+                : wideRevisionRequiredWidth,
+            expandsToAvailableWidth: !compact
+        )
+    }
+
+    static func toolbarSizing(compact: Bool) -> BoardRailSizing {
+        BoardRailSizing(
+            requiredWidth: compact
+                ? compactToolbarRequiredWidth
+                : wideToolbarRequiredWidth,
+            expandsToAvailableWidth: !compact
+        )
+    }
+
+    static func revisionResolution(
+        availableWidth: CGFloat,
+        actionCount: Int
+    ) -> BoardRailWidthResolution {
+        resolution(
+            availableWidth: availableWidth,
+            wide: revisionSizing(compact: false, actionCount: actionCount),
+            compact: revisionSizing(compact: true, actionCount: actionCount)
+        )
+    }
+
+    static func toolbarResolution(
+        availableWidth: CGFloat
+    ) -> BoardRailWidthResolution {
+        resolution(
+            availableWidth: availableWidth,
+            wide: toolbarSizing(compact: false),
+            compact: toolbarSizing(compact: true)
+        )
+    }
+
+    private static func resolution(
+        availableWidth: CGFloat,
+        wide: BoardRailSizing,
+        compact: BoardRailSizing
+    ) -> BoardRailWidthResolution {
+        if availableWidth >= wide.requiredWidth {
+            return BoardRailWidthResolution(
+                variant: .wide,
+                renderedWidth: wide.renderedWidth(in: availableWidth)
+            )
+        }
+        return BoardRailWidthResolution(
+            variant: .compact,
+            renderedWidth: compact.renderedWidth(in: availableWidth)
+        )
     }
 }
 
@@ -1989,11 +2146,32 @@ private struct BoardNodeVisualLayer: View {
 private struct BoardDotGrid: View {
     var body: some View {
         Canvas { context, size in
-            for x in stride(from: 10.0, through: size.width, by: 20) {
-                for y in stride(from: 10.0, through: size.height, by: 20) {
+            let diameter = BoardCanvasVisualMetrics.gridDotDiameter
+            let offset = diameter / 2
+            for x in stride(
+                from: BoardCanvasVisualMetrics.gridSpacing / 2,
+                through: size.width,
+                by: BoardCanvasVisualMetrics.gridSpacing
+            ) {
+                for y in stride(
+                    from: BoardCanvasVisualMetrics.gridSpacing / 2,
+                    through: size.height,
+                    by: BoardCanvasVisualMetrics.gridSpacing
+                ) {
                     context.fill(
-                        Path(ellipseIn: CGRect(x: x, y: y, width: 1.5, height: 1.5)),
-                        with: .color(BoardPalette.line.opacity(0.9))
+                        Path(
+                            ellipseIn: CGRect(
+                                x: x - offset,
+                                y: y - offset,
+                                width: diameter,
+                                height: diameter
+                            )
+                        ),
+                        with: .color(
+                            BoardPalette.violet.opacity(
+                                BoardCanvasVisualMetrics.gridDotOpacity
+                            )
+                        )
                     )
                 }
             }
@@ -2196,11 +2374,43 @@ enum BoardKeyboardCreationOutcome {
     }
 }
 
+enum BoardNodeCreationDefaults {
+    static let defaultSize = BoardSize(width: 120, height: 112)
+
+    static func fittedSize(in canvas: BoardSize) -> BoardSize {
+        BoardSize(
+            width: min(defaultSize.width, canvas.width),
+            height: min(defaultSize.height, canvas.height)
+        )
+    }
+
+    static func frame(
+        centeredAt point: BoardPoint,
+        in canvas: BoardSize
+    ) -> BoardRect {
+        let size = fittedSize(in: canvas)
+        return BoardRect(
+            origin: BoardPoint(
+                x: max(
+                    0,
+                    min(point.x - size.width / 2, canvas.width - size.width)
+                ),
+                y: max(
+                    0,
+                    min(point.y - size.height / 2, canvas.height - size.height)
+                )
+            ),
+            size: size
+        )
+    }
+}
+
 enum BoardKeyboardPlacement {
     static func nextBoxFrame(in document: BoardDocument) -> BoardRect {
         let canvas = document.canvas.size
-        let width = min(160, canvas.width)
-        let height = min(90, canvas.height)
+        let size = BoardNodeCreationDefaults.fittedSize(in: canvas)
+        let width = size.width
+        let height = size.height
         let horizontalMargin = min(40, max(0, (canvas.width - width) / 2))
         let verticalMargin = min(40, max(0, (canvas.height - height) / 2))
         let horizontalStep = width + 24

--- a/Sources/InterviewArcLive/SystemDesignBoardView.swift
+++ b/Sources/InterviewArcLive/SystemDesignBoardView.swift
@@ -1920,18 +1920,18 @@ struct BoardFooterPresentation: Equatable {
                 tone: .error
             )
         }
-        if let exportMessage {
-            return Self(
-                text: exportMessage,
-                systemImage: "checkmark.circle",
-                tone: .confirmation
-            )
-        }
         if let interactionFeedback {
             return Self(
                 text: interactionFeedback,
                 systemImage: "info.circle",
                 tone: .feedback
+            )
+        }
+        if let exportMessage {
+            return Self(
+                text: exportMessage,
+                systemImage: "checkmark.circle",
+                tone: .confirmation
             )
         }
         return Self(

--- a/Sources/InterviewArcLive/SystemDesignRoomView.swift
+++ b/Sources/InterviewArcLive/SystemDesignRoomView.swift
@@ -859,9 +859,7 @@ struct SystemDesignRoomView: View {
 enum FullRoomLayout {
     static let minimumWindowWidth: CGFloat = 1_080
     static let defaultWindowWidth: CGFloat = 1_180
-    static let minimumWindowHeight: CGFloat = 700
     static let headerHeight: CGFloat = 70
-    static let questionBandMinimumHeight: CGFloat = 148
     static let questionTitleSize: CGFloat = 40
     static let questionHorizontalPadding: CGFloat = 56
     static let questionTopPadding: CGFloat = 48
@@ -869,6 +867,11 @@ enum FullRoomLayout {
     static let questionStackSpacing: CGFloat = 24
     static let questionLineLimit = 2
     static let questionMinimumScaleFactor: CGFloat = 0.82
+    /// Keeps the approved single-line mockup band unchanged.
+    static let questionBandOneLineHeight: CGFloat = 148
+    /// Reserves one full rounded 40-point title line without clipping.
+    static let questionAdditionalLineHeight: CGFloat = 48
+    static let questionBandMinimumHeight = questionBandOneLineHeight
     static let turnlineHeaderHeight: CGFloat = 58
     static let turnlineWidthFraction: CGFloat = 0.37
     static let turnlineMinimumWidth: CGFloat = 380
@@ -881,6 +884,15 @@ enum FullRoomLayout {
     static let floorContentHorizontalPadding: CGFloat = 48
     static let floorOutlineHorizontalInset: CGFloat = 24
     static let minimumActionHitTarget: CGFloat = 44
+    static let requiredWorkspaceHeight: CGFloat = 380
+    static let minimumWindowHeight = headerHeight
+        + questionBandMaximumHeight
+        + floorRailHeight
+        + requiredWorkspaceHeight
+
+    static var questionBandMaximumHeight: CGFloat {
+        questionBandHeight(forLineCount: questionLineLimit)
+    }
 
     /// The full-size-content window draws into the titlebar. This keeps the
     /// brand beyond the standard close/minimize/zoom group while the custom
@@ -902,8 +914,23 @@ enum FullRoomLayout {
         max(boardMinimumWidth, workspaceWidth - turnlineIdealWidth(for: workspaceWidth))
     }
 
-    static func minimumWorkspaceHeight(for windowHeight: CGFloat) -> CGFloat {
-        max(0, windowHeight - headerHeight - questionBandMinimumHeight - floorRailHeight)
+    static func questionBandHeight(forLineCount lineCount: Int) -> CGFloat {
+        let boundedLineCount = min(max(lineCount, 1), questionLineLimit)
+        return questionBandOneLineHeight
+            + CGFloat(boundedLineCount - 1) * questionAdditionalLineHeight
+    }
+
+    static func minimumWorkspaceHeight(
+        for windowHeight: CGFloat,
+        questionLineCount: Int = questionLineLimit
+    ) -> CGFloat {
+        max(
+            0,
+            windowHeight
+                - headerHeight
+                - questionBandHeight(forLineCount: questionLineCount)
+                - floorRailHeight
+        )
     }
 }
 

--- a/Sources/InterviewArcLive/SystemDesignRoomView.swift
+++ b/Sources/InterviewArcLive/SystemDesignRoomView.swift
@@ -33,8 +33,7 @@ struct SystemDesignRoomView: View {
                             minWidth: FullRoomLayout.turnlineMinimumWidth,
                             idealWidth: FullRoomLayout.turnlineIdealWidth(
                                 for: workspace.size.width
-                            ),
-                            maxWidth: FullRoomLayout.turnlineMaximumWidth
+                            )
                         )
                     board
                         .frame(minWidth: FullRoomLayout.boardMinimumWidth)
@@ -79,14 +78,10 @@ struct SystemDesignRoomView: View {
             )
 
             Group {
-                if state.usesAttentionCompactHeader {
+                if state.presentation == .compact {
                     compactHeaderContent
                 } else {
-                    ViewThatFits(in: .horizontal) {
-                        fullHeaderContent
-                            .fixedSize(horizontal: true, vertical: false)
-                        compactHeaderContent
-                    }
+                    fullHeaderContent
                 }
             }
             .font(.system(.body, design: .rounded))
@@ -117,6 +112,7 @@ struct SystemDesignRoomView: View {
             privacyStatus(isCompact: false)
             collapseButton
         }
+        .frame(maxWidth: .infinity)
     }
 
     private var compactHeaderContent: some View {
@@ -130,6 +126,7 @@ struct SystemDesignRoomView: View {
             privacyStatus(isCompact: true)
             collapseButton
         }
+        .frame(maxWidth: .infinity)
     }
 
     private var headerBrand: some View {
@@ -313,25 +310,32 @@ struct SystemDesignRoomView: View {
     }
 
     private var question: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: FullRoomLayout.questionStackSpacing) {
             Text("QUESTION")
                 .font(.system(.callout, design: .monospaced, weight: .semibold))
                 .tracking(1.4)
                 .foregroundStyle(LivePalette.navy)
             Text(model.question)
-                .font(.system(size: 35, weight: .semibold, design: .rounded))
+                .font(
+                    .system(
+                        size: FullRoomLayout.questionTitleSize,
+                        weight: .semibold,
+                        design: .rounded
+                    )
+                )
                 .tracking(-0.35)
                 .lineLimit(FullRoomLayout.questionLineLimit)
                 .minimumScaleFactor(FullRoomLayout.questionMinimumScaleFactor)
                 .fixedSize(horizontal: false, vertical: true)
                 .accessibilityAddTraits(.isHeader)
         }
-        .padding(.horizontal, 40)
-        .padding(.vertical, 20)
+        .padding(.horizontal, FullRoomLayout.questionHorizontalPadding)
+        .padding(.top, FullRoomLayout.questionTopPadding)
+        .padding(.bottom, FullRoomLayout.questionBottomPadding)
         .frame(
             maxWidth: .infinity,
             minHeight: FullRoomLayout.questionBandMinimumHeight,
-            alignment: .leading
+            alignment: .topLeading
         )
         .background(LivePalette.paper)
         .accessibilityElement(children: .contain)
@@ -414,7 +418,7 @@ struct SystemDesignRoomView: View {
     }
 
     private var candidateFloorEntry: some View {
-        HStack(alignment: .top, spacing: 18) {
+        HStack(alignment: .top, spacing: FullRoomLayout.turnlineEntryGap) {
             VStack(spacing: 0) {
                 Circle()
                     .fill(LivePalette.candidateText)
@@ -441,7 +445,13 @@ struct SystemDesignRoomView: View {
                 if model.segments.isEmpty {
                     VStack(alignment: .leading, spacing: 10) {
                         Text("Ready for your next answer.")
-                            .font(.system(size: 21, weight: .semibold, design: .rounded))
+                            .font(
+                                .system(
+                                    size: FullRoomLayout.turnlineBodyFontSize,
+                                    weight: .semibold,
+                                    design: .rounded
+                                )
+                            )
                         Text("Record one or more segments here. Working pauses stay in this Candidate Turn until you choose Hand off.")
                             .font(.system(.body, design: .rounded))
                             .foregroundStyle(LivePalette.muted)
@@ -470,7 +480,7 @@ struct SystemDesignRoomView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.bottom, 30)
         }
-        .padding(.horizontal, 30)
+        .padding(.horizontal, FullRoomLayout.turnlineHorizontalPadding)
     }
 
     private func turnlineEntry(_ turn: InterviewTurn, isLast: Bool) -> some View {
@@ -502,7 +512,10 @@ struct SystemDesignRoomView: View {
             boardRevisionID = nil
         }
 
-        return HStack(alignment: .top, spacing: 18) {
+        return HStack(
+            alignment: .top,
+            spacing: FullRoomLayout.turnlineEntryGap
+        ) {
             VStack(spacing: 0) {
                 Circle()
                     .fill(color)
@@ -526,7 +539,13 @@ struct SystemDesignRoomView: View {
                         Text(body)
                     }
                 }
-                    .font(.system(size: 21, weight: .medium, design: .rounded))
+                    .font(
+                        .system(
+                            size: FullRoomLayout.turnlineBodyFontSize,
+                            weight: .medium,
+                            design: .rounded
+                        )
+                    )
                     .lineSpacing(4)
                     .textSelection(.enabled)
                     .fixedSize(horizontal: false, vertical: true)
@@ -556,7 +575,7 @@ struct SystemDesignRoomView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.bottom, 30)
         }
-        .padding(.horizontal, 30)
+        .padding(.horizontal, FullRoomLayout.turnlineHorizontalPadding)
         .accessibilityElement(children: .contain)
     }
 
@@ -682,7 +701,7 @@ struct SystemDesignRoomView: View {
                     .foregroundStyle(LivePalette.muted)
                     .lineLimit(1)
             }
-            .frame(width: 164, alignment: .leading)
+            .frame(width: FullRoomLayout.floorStatusWidth, alignment: .leading)
 
             LiveWaveform(isActive: model.canStopRecording)
                 .frame(minWidth: 140, maxWidth: .infinity)
@@ -750,7 +769,7 @@ struct SystemDesignRoomView: View {
             .accessibilityIdentifier(FullRoomAccessibility.endAction)
         }
         .foregroundStyle(LivePalette.navy)
-        .padding(.horizontal, 24)
+        .padding(.horizontal, FullRoomLayout.floorContentHorizontalPadding)
         .frame(minHeight: FullRoomLayout.floorRailHeight)
         .background(LivePalette.paper)
         .accessibilityElement(children: .contain)
@@ -758,7 +777,10 @@ struct SystemDesignRoomView: View {
         .overlay {
             RoundedRectangle(cornerRadius: 13, style: .continuous)
                 .stroke(LivePalette.line, lineWidth: 1)
-                .padding(.horizontal, 14)
+                .padding(
+                    .horizontal,
+                    FullRoomLayout.floorOutlineHorizontalInset
+                )
                 .padding(.vertical, 8)
         }
     }
@@ -839,15 +861,25 @@ enum FullRoomLayout {
     static let defaultWindowWidth: CGFloat = 1_180
     static let minimumWindowHeight: CGFloat = 700
     static let headerHeight: CGFloat = 70
-    static let questionBandMinimumHeight: CGFloat = 120
+    static let questionBandMinimumHeight: CGFloat = 148
+    static let questionTitleSize: CGFloat = 40
+    static let questionHorizontalPadding: CGFloat = 56
+    static let questionTopPadding: CGFloat = 48
+    static let questionBottomPadding: CGFloat = 12
+    static let questionStackSpacing: CGFloat = 24
     static let questionLineLimit = 2
     static let questionMinimumScaleFactor: CGFloat = 0.82
     static let turnlineHeaderHeight: CGFloat = 58
     static let turnlineWidthFraction: CGFloat = 0.37
     static let turnlineMinimumWidth: CGFloat = 380
-    static let turnlineMaximumWidth: CGFloat = 480
+    static let turnlineHorizontalPadding: CGFloat = 64
+    static let turnlineEntryGap: CGFloat = 42
+    static let turnlineBodyFontSize: CGFloat = 24
     static let boardMinimumWidth: CGFloat = 620
-    static let floorRailHeight: CGFloat = 88
+    static let floorRailHeight: CGFloat = 96
+    static let floorStatusWidth: CGFloat = 184
+    static let floorContentHorizontalPadding: CGFloat = 48
+    static let floorOutlineHorizontalInset: CGFloat = 24
     static let minimumActionHitTarget: CGFloat = 44
 
     /// The full-size-content window draws into the titlebar. This keeps the
@@ -856,9 +888,13 @@ enum FullRoomLayout {
     static let trafficLightClearance: CGFloat = 84
 
     static func turnlineIdealWidth(for workspaceWidth: CGFloat) -> CGFloat {
-        min(
+        let availableTurnlineWidth = max(
+            turnlineMinimumWidth,
+            workspaceWidth - boardMinimumWidth
+        )
+        return min(
             max(workspaceWidth * turnlineWidthFraction, turnlineMinimumWidth),
-            turnlineMaximumWidth
+            availableTurnlineWidth
         )
     }
 
@@ -882,10 +918,22 @@ struct FullRoomHeaderLayoutState: Equatable {
     let windowWidth: CGFloat
     let attention: FullRoomHeaderAttention
 
-    var usesAttentionCompactHeader: Bool {
-        attention != .none
-            && windowWidth <= FullRoomHeaderLayout.attentionCompactMaximumWidth
+    var presentation: FullRoomHeaderPresentation {
+        if attention != .none,
+           windowWidth <= FullRoomHeaderLayout.attentionCompactMaximumWidth {
+            return .compact
+        }
+        return .wide
     }
+
+    var usesAttentionCompactHeader: Bool {
+        presentation == .compact
+    }
+}
+
+enum FullRoomHeaderPresentation: Equatable {
+    case wide
+    case compact
 }
 
 enum FullRoomHeaderLayout {
@@ -1014,9 +1062,11 @@ private struct LiveWaveform: View {
                 lineWidth: 1
             )
 
-            let spacing = min(7.0, size.width / Double(levels.count + 2))
-            for (index, level) in levels.enumerated() {
-                let x = 10 + Double(index) * spacing
+            let barPositions = FullRoomWaveformLayout.barXPositions(
+                width: size.width,
+                levelCount: levels.count
+            )
+            for (level, x) in zip(levels, barPositions) {
                 let height = max(3, level * size.height * (isActive ? 0.88 : 0.55))
                 var bar = Path()
                 bar.move(to: CGPoint(x: x, y: center - height / 2))
@@ -1029,6 +1079,34 @@ private struct LiveWaveform: View {
             }
         }
         .accessibilityHidden(true)
+    }
+}
+
+enum FullRoomWaveformLayout {
+    static let traceCoverageFraction: CGFloat = 0.58
+    static let horizontalInset: CGFloat = 10
+
+    static func barXPositions(
+        width: CGFloat,
+        levelCount: Int
+    ) -> [CGFloat] {
+        guard width > 0, levelCount > 0 else { return [] }
+        guard levelCount > 1 else {
+            return [min(width, horizontalInset)]
+        }
+
+        let first = min(width, horizontalInset)
+        let last = max(
+            first,
+            min(
+                width,
+                width * traceCoverageFraction - horizontalInset
+            )
+        )
+        let spacing = (last - first) / CGFloat(levelCount - 1)
+        return (0..<levelCount).map { index in
+            first + CGFloat(index) * spacing
+        }
     }
 }
 

--- a/Sources/InterviewArcLiveCore/BoardDomain.swift
+++ b/Sources/InterviewArcLiveCore/BoardDomain.swift
@@ -76,6 +76,7 @@ public struct BoardColor: RawRepresentable, Codable, Hashable, Sendable, CustomS
     public static let ink = BoardColor(hexRGB: "1f2937")
     public static let surface = BoardColor(hexRGB: "f8fafc")
     public static let accent = BoardColor(hexRGB: "2563eb")
+    public static let nodeOutline = BoardColor(hexRGB: "4b3abf")
     public static let white = BoardColor(hexRGB: "ffffff")
 }
 
@@ -101,8 +102,8 @@ public struct BoardBox: Codable, Sendable, Equatable {
         frame: BoardRect,
         label: String,
         kind: BoardNodeKind = .generic,
-        fill: BoardColor = .surface,
-        stroke: BoardColor = .ink
+        fill: BoardColor = .white,
+        stroke: BoardColor = .nodeOutline
     ) {
         self.id = id
         self.frame = frame

--- a/Tests/InterviewArcLiveTests/BoardEditorTests.swift
+++ b/Tests/InterviewArcLiveTests/BoardEditorTests.swift
@@ -899,7 +899,7 @@ final class BoardEditorTests: XCTestCase {
         var document = BoardDocument.empty
         let first = BoardKeyboardPlacement.nextBoxFrame(in: document)
         XCTAssertEqual(first.origin, BoardPoint(x: 40, y: 40))
-        XCTAssertEqual(first.size, BoardSize(width: 160, height: 90))
+        XCTAssertEqual(first.size, BoardSize(width: 120, height: 112))
 
         document = try BoardDocument(
             canvas: document.canvas,
@@ -914,10 +914,35 @@ final class BoardEditorTests: XCTestCase {
             ]
         )
         let second = BoardKeyboardPlacement.nextBoxFrame(in: document)
-        XCTAssertEqual(second.origin, BoardPoint(x: 224, y: 40))
+        XCTAssertEqual(second.origin, BoardPoint(x: 184, y: 40))
         XCTAssertLessThanOrEqual(
             second.origin.x + second.size.width,
             document.canvas.size.width
+        )
+    }
+
+    func testPointerPlacementCentersNearSquareDefaultNodeAndClampsItsExtent() {
+        let canvas = BoardSize(width: 300, height: 220)
+
+        XCTAssertEqual(
+            BoardNodeCreationDefaults.frame(
+                centeredAt: BoardPoint(x: 150, y: 110),
+                in: canvas
+            ),
+            BoardRect(
+                origin: BoardPoint(x: 90, y: 54),
+                size: BoardSize(width: 120, height: 112)
+            )
+        )
+        XCTAssertEqual(
+            BoardNodeCreationDefaults.frame(
+                centeredAt: BoardPoint(x: 298, y: 218),
+                in: canvas
+            ),
+            BoardRect(
+                origin: BoardPoint(x: 180, y: 108),
+                size: BoardSize(width: 120, height: 112)
+            )
         )
     }
 

--- a/Tests/InterviewArcLiveTests/BoardNodePresentationTests.swift
+++ b/Tests/InterviewArcLiveTests/BoardNodePresentationTests.swift
@@ -12,6 +12,10 @@ final class BoardNodePresentationTests: XCTestCase {
         XCTAssertEqual(BoardLayoutMetrics.minimumHitTarget, 44)
         XCTAssertEqual(BoardLayoutMetrics.toolControlHeight, 44)
         XCTAssertEqual(BoardLayoutMetrics.emptyStateMaximumWidth, 360)
+        XCTAssertEqual(BoardCanvasVisualMetrics.gridSpacing, 20)
+        XCTAssertEqual(BoardCanvasVisualMetrics.gridDotDiameter, 1.6)
+        XCTAssertEqual(BoardCanvasVisualMetrics.gridDotOpacity, 0.22)
+        XCTAssertEqual(BoardCanvasVisualMetrics.footerMaximumWidth, 420)
     }
 
     func testCompactBoardRailsFitTheSupported680PointBoardWidth() {
@@ -43,6 +47,130 @@ final class BoardNodePresentationTests: XCTestCase {
             BoardRailWidthBudget.compactZoomWidth,
             BoardLayoutMetrics.minimumHitTarget
         )
+    }
+
+    func testWideRailsConsumeTheRenderedWidthAndCompactRailsStayBounded() {
+        let wideWidth: CGFloat = 960
+        let wideRevision = BoardRailWidthBudget.revisionResolution(
+            availableWidth: wideWidth,
+            actionCount: 4
+        )
+        let wideToolbar = BoardRailWidthBudget.toolbarResolution(
+            availableWidth: wideWidth
+        )
+
+        XCTAssertEqual(wideRevision.variant, .wide)
+        XCTAssertEqual(wideRevision.renderedWidth, wideWidth)
+        XCTAssertEqual(wideToolbar.variant, .wide)
+        XCTAssertEqual(wideToolbar.renderedWidth, wideWidth)
+        XCTAssertGreaterThanOrEqual(
+            BoardRailWidthBudget.wideRevisionGroupGapMinimum,
+            24
+        )
+        XCTAssertGreaterThanOrEqual(
+            BoardRailWidthBudget.wideToolbarGroupGapMinimum,
+            12
+        )
+
+        let compactRevision = BoardRailWidthBudget.revisionResolution(
+            availableWidth: BoardRailWidthBudget.supportedBoardWidth,
+            actionCount: 4
+        )
+        let compactToolbar = BoardRailWidthBudget.toolbarResolution(
+            availableWidth: BoardRailWidthBudget.supportedBoardWidth
+        )
+
+        XCTAssertEqual(compactRevision.variant, .compact)
+        XCTAssertEqual(compactRevision.renderedWidth, 428)
+        XCTAssertLessThanOrEqual(
+            compactRevision.renderedWidth,
+            BoardRailWidthBudget.supportedBoardWidth
+        )
+        XCTAssertEqual(compactToolbar.variant, .compact)
+        XCTAssertEqual(compactToolbar.renderedWidth, 483)
+        XCTAssertLessThanOrEqual(
+            compactToolbar.renderedWidth,
+            BoardRailWidthBudget.supportedBoardWidth
+        )
+    }
+
+    func testDefaultNodeStyleUsesNearSquareBrandGeometryWithoutOverridingAuthoredStyle() throws {
+        XCTAssertEqual(
+            BoardNodeCreationDefaults.defaultSize,
+            BoardSize(width: 120, height: 112)
+        )
+        XCTAssertLessThanOrEqual(
+            BoardNodeCreationDefaults.defaultSize.width
+                / BoardNodeCreationDefaults.defaultSize.height,
+            1.1
+        )
+
+        let created = BoardBox(
+            id: BoardElementID("created"),
+            frame: BoardRect(
+                origin: BoardPoint(x: 40, y: 40),
+                size: BoardNodeCreationDefaults.defaultSize
+            ),
+            label: "Fanout workers",
+            kind: .service
+        )
+        XCTAssertEqual(created.fill, .white)
+        XCTAssertEqual(created.stroke, .nodeOutline)
+        XCTAssertEqual(created.stroke.hexRGB, "4b3abf")
+
+        let authored = BoardBox(
+            id: BoardElementID("authored"),
+            frame: created.frame,
+            label: "Imported service",
+            kind: .service,
+            fill: BoardColor(hexRGB: "f8fafc"),
+            stroke: BoardColor(hexRGB: "1f2937")
+        )
+        let decoded = try JSONDecoder().decode(
+            BoardBox.self,
+            from: JSONEncoder().encode(authored)
+        )
+        XCTAssertEqual(decoded.fill.hexRGB, "f8fafc")
+        XCTAssertEqual(decoded.stroke.hexRGB, "1f2937")
+    }
+
+    func testFooterKeepsCanvasFeedbackDistinctFromRevisionStatus() {
+        XCTAssertEqual(
+            BoardFooterPresentation.make(
+                errorMessage: nil,
+                exportMessage: nil,
+                interactionFeedback: nil
+            ),
+            BoardFooterPresentation(
+                text: "Editable source autosaves locally",
+                systemImage: "internaldrive",
+                tone: .neutral
+            )
+        )
+
+        let feedback = BoardFooterPresentation.make(
+            errorMessage: nil,
+            exportMessage: nil,
+            interactionFeedback: "Service node added and selected"
+        )
+        XCTAssertEqual(feedback.text, "Service node added and selected")
+        XCTAssertFalse(feedback.text.localizedCaseInsensitiveContains("unsaved"))
+
+        let exported = BoardFooterPresentation.make(
+            errorMessage: nil,
+            exportMessage: "Editable source · SVG + PNG available",
+            interactionFeedback: "Selection cleared"
+        )
+        XCTAssertEqual(exported.tone, .confirmation)
+        XCTAssertEqual(exported.text, "Editable source · SVG + PNG available")
+
+        let error = BoardFooterPresentation.make(
+            errorMessage: "Return to the draft before editing.",
+            exportMessage: "Editable source · SVG + PNG available",
+            interactionFeedback: nil
+        )
+        XCTAssertEqual(error.tone, .error)
+        XCTAssertEqual(error.text, "Return to the draft before editing.")
     }
 
     func testCompactRevisionStatusPreservesEveryCanonicalLifecycleState() {

--- a/Tests/InterviewArcLiveTests/BoardNodePresentationTests.swift
+++ b/Tests/InterviewArcLiveTests/BoardNodePresentationTests.swift
@@ -135,42 +135,68 @@ final class BoardNodePresentationTests: XCTestCase {
     }
 
     func testFooterKeepsCanvasFeedbackDistinctFromRevisionStatus() {
-        XCTAssertEqual(
-            BoardFooterPresentation.make(
-                errorMessage: nil,
-                exportMessage: nil,
-                interactionFeedback: nil
-            ),
-            BoardFooterPresentation(
+        let error = "Return to the draft before editing."
+        let feedback = "Service node added and selected"
+        let export = "Editable source · SVG + PNG available"
+        let cases: [(
+            error: String?,
+            export: String?,
+            feedback: String?,
+            expected: BoardFooterPresentation
+        )] = [
+            (nil, nil, nil, BoardFooterPresentation(
                 text: "Editable source autosaves locally",
                 systemImage: "internaldrive",
                 tone: .neutral
+            )),
+            (nil, export, nil, BoardFooterPresentation(
+                text: export,
+                systemImage: "checkmark.circle",
+                tone: .confirmation
+            )),
+            (nil, nil, feedback, BoardFooterPresentation(
+                text: feedback,
+                systemImage: "info.circle",
+                tone: .feedback
+            )),
+            (nil, export, feedback, BoardFooterPresentation(
+                text: feedback,
+                systemImage: "info.circle",
+                tone: .feedback
+            )),
+            (error, nil, nil, BoardFooterPresentation(
+                text: error,
+                systemImage: "exclamationmark.triangle",
+                tone: .error
+            )),
+            (error, export, nil, BoardFooterPresentation(
+                text: error,
+                systemImage: "exclamationmark.triangle",
+                tone: .error
+            )),
+            (error, nil, feedback, BoardFooterPresentation(
+                text: error,
+                systemImage: "exclamationmark.triangle",
+                tone: .error
+            )),
+            (error, export, feedback, BoardFooterPresentation(
+                text: error,
+                systemImage: "exclamationmark.triangle",
+                tone: .error
+            )),
+        ]
+
+        for value in cases {
+            XCTAssertEqual(
+                BoardFooterPresentation.make(
+                    errorMessage: value.error,
+                    exportMessage: value.export,
+                    interactionFeedback: value.feedback
+                ),
+                value.expected
             )
-        )
-
-        let feedback = BoardFooterPresentation.make(
-            errorMessage: nil,
-            exportMessage: nil,
-            interactionFeedback: "Service node added and selected"
-        )
-        XCTAssertEqual(feedback.text, "Service node added and selected")
-        XCTAssertFalse(feedback.text.localizedCaseInsensitiveContains("unsaved"))
-
-        let exported = BoardFooterPresentation.make(
-            errorMessage: nil,
-            exportMessage: "Editable source · SVG + PNG available",
-            interactionFeedback: "Selection cleared"
-        )
-        XCTAssertEqual(exported.tone, .confirmation)
-        XCTAssertEqual(exported.text, "Editable source · SVG + PNG available")
-
-        let error = BoardFooterPresentation.make(
-            errorMessage: "Return to the draft before editing.",
-            exportMessage: "Editable source · SVG + PNG available",
-            interactionFeedback: nil
-        )
-        XCTAssertEqual(error.tone, .error)
-        XCTAssertEqual(error.text, "Return to the draft before editing.")
+        }
+        XCTAssertFalse(feedback.localizedCaseInsensitiveContains("unsaved"))
     }
 
     func testCompactRevisionStatusPreservesEveryCanonicalLifecycleState() {

--- a/Tests/InterviewArcLiveTests/InterviewRoomPresentationCoordinatorTests.swift
+++ b/Tests/InterviewArcLiveTests/InterviewRoomPresentationCoordinatorTests.swift
@@ -12,6 +12,28 @@ final class InterviewRoomPresentationCoordinatorTests: XCTestCase {
         XCTAssertEqual(CompactPanelLayout.maximumContentHeight, 180)
     }
 
+    func testFullWindowMinimumSizeUsesTheTwoLineQuestionBudget() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.prepareForTermination() }
+
+        XCTAssertEqual(
+            coordinator.fullWindow.contentMinSize,
+            InterviewRoomWindowLayout.fullMinimumContentSize
+        )
+        XCTAssertEqual(
+            coordinator.fullWindow.contentMinSize.width,
+            FullRoomLayout.minimumWindowWidth
+        )
+        XCTAssertEqual(coordinator.fullWindow.contentMinSize.height, 742)
+        XCTAssertEqual(
+            FullRoomLayout.minimumWorkspaceHeight(
+                for: coordinator.fullWindow.contentMinSize.height,
+                questionLineCount: FullRoomLayout.questionLineLimit
+            ),
+            FullRoomLayout.requiredWorkspaceHeight
+        )
+    }
+
     func testCoordinatorOwnsOneFullWindowAndOneNonactivatingPanelWithSharedModel() {
         let model = SystemDesignRoomModel()
         let coordinator = makeCoordinator(model: model)

--- a/Tests/InterviewArcLiveTests/SystemDesignRoomLayoutTests.swift
+++ b/Tests/InterviewArcLiveTests/SystemDesignRoomLayoutTests.swift
@@ -1,12 +1,10 @@
+import CoreGraphics
 import XCTest
 @testable import InterviewArcLive
 
 final class SystemDesignRoomLayoutTests: XCTestCase {
-    func testMinimumAndDefaultWidthsKeepTheApprovedTurnlineBoardBalance() {
-        for width in [
-            FullRoomLayout.minimumWindowWidth,
-            FullRoomLayout.defaultWindowWidth,
-        ] {
+    func testSupportedWidthsKeepTheApprovedTurnlineBoardBalance() {
+        for width: CGFloat in [1_080, 1_197, 1_600] {
             let turnline = FullRoomLayout.turnlineIdealWidth(for: width)
             let board = FullRoomLayout.boardIdealWidth(for: width)
 
@@ -21,12 +19,27 @@ final class SystemDesignRoomLayoutTests: XCTestCase {
         }
     }
 
+    func testWideWindowDoesNotCapTheTurnlineBelowTheApprovedFraction() {
+        let width: CGFloat = 1_600
+
+        XCTAssertEqual(
+            FullRoomLayout.turnlineIdealWidth(for: width),
+            592,
+            accuracy: 0.001
+        )
+        XCTAssertEqual(
+            FullRoomLayout.boardIdealWidth(for: width),
+            1_008,
+            accuracy: 0.001
+        )
+    }
+
     func testMinimumWindowRetainsAUsableWorkspaceAndActionTargets() {
         XCTAssertGreaterThanOrEqual(
             FullRoomLayout.minimumWorkspaceHeight(
                 for: FullRoomLayout.minimumWindowHeight
             ),
-            420
+            380
         )
         XCTAssertGreaterThanOrEqual(FullRoomLayout.minimumActionHitTarget, 44)
         XCTAssertGreaterThanOrEqual(
@@ -34,6 +47,14 @@ final class SystemDesignRoomLayoutTests: XCTestCase {
             FullRoomLayout.minimumActionHitTarget
         )
         XCTAssertGreaterThanOrEqual(FullRoomLayout.questionLineLimit, 2)
+        XCTAssertEqual(FullRoomLayout.questionBandMinimumHeight, 148)
+        XCTAssertEqual(FullRoomLayout.questionTitleSize, 40)
+        XCTAssertEqual(FullRoomLayout.turnlineHorizontalPadding, 64)
+        XCTAssertEqual(FullRoomLayout.turnlineEntryGap, 42)
+        XCTAssertEqual(FullRoomLayout.turnlineBodyFontSize, 24)
+        XCTAssertEqual(FullRoomLayout.floorRailHeight, 96)
+        XCTAssertEqual(FullRoomLayout.floorContentHorizontalPadding, 48)
+        XCTAssertEqual(FullRoomLayout.floorOutlineHorizontalInset, 24)
     }
 
     func testCandidateTextMeetsWCAGBodyContrastAcrossRoomSurfaces() {
@@ -85,7 +106,7 @@ final class SystemDesignRoomLayoutTests: XCTestCase {
         XCTAssertTrue(combined.usesAttentionCompactHeader)
     }
 
-    func testDefaultWidthStillLetsViewThatFitsChooseTheHeader() {
+    func testDefaultWidthKeepsWideHeaderUnderAttention() {
         let state = FullRoomHeaderLayout.state(
             windowWidth: FullRoomLayout.defaultWindowWidth,
             hasSpeechAttention: true,
@@ -93,6 +114,77 @@ final class SystemDesignRoomLayoutTests: XCTestCase {
         )
         XCTAssertEqual(state.attention, .speechAndRoom)
         XCTAssertFalse(state.usesAttentionCompactHeader)
+    }
+
+    func testHeaderPresentationIsWideAt1197And1600ForEveryAttentionState() {
+        for width: CGFloat in [1_197, 1_600] {
+            for (speech, room) in [
+                (false, false),
+                (true, false),
+                (false, true),
+                (true, true),
+            ] {
+                let state = FullRoomHeaderLayout.state(
+                    windowWidth: width,
+                    hasSpeechAttention: speech,
+                    hasRoomAttention: room
+                )
+
+                XCTAssertEqual(state.presentation, .wide)
+            }
+        }
+    }
+
+    func testMinimumWidthKeepsWideHeaderWithoutAttentionAndCompactWithIt() {
+        let normal = FullRoomHeaderLayout.state(
+            windowWidth: 1_080,
+            hasSpeechAttention: false,
+            hasRoomAttention: false
+        )
+        let attention = FullRoomHeaderLayout.state(
+            windowWidth: 1_080,
+            hasSpeechAttention: true,
+            hasRoomAttention: true
+        )
+
+        XCTAssertEqual(normal.presentation, .wide)
+        XCTAssertEqual(attention.presentation, .compact)
+        XCTAssertTrue(
+            FullRoomHeaderAccessibility.personaLabel.contains("Staff Engineer")
+        )
+        XCTAssertEqual(
+            FullRoomHeaderAccessibility.privacyLabel,
+            "Private local session"
+        )
+    }
+
+    func testWaveformUsesTheRailWithoutPretendingToBeRecordedAudio() {
+        for width: CGFloat in [140, 600, 900] {
+            let positions = FullRoomWaveformLayout.barXPositions(
+                width: width,
+                levelCount: 30
+            )
+
+            XCTAssertEqual(positions.count, 30)
+            XCTAssertEqual(
+                positions.first ?? .nan,
+                FullRoomWaveformLayout.horizontalInset,
+                accuracy: 0.001
+            )
+            XCTAssertEqual(
+                positions.last ?? .nan,
+                width * FullRoomWaveformLayout.traceCoverageFraction
+                    - FullRoomWaveformLayout.horizontalInset,
+                accuracy: 0.001
+            )
+            XCTAssertTrue(
+                zip(positions, positions.dropFirst()).allSatisfy { lhs, rhs in
+                    lhs < rhs
+                }
+            )
+            XCTAssertGreaterThanOrEqual(positions.first ?? -1, 0)
+            XCTAssertLessThanOrEqual(positions.last ?? .infinity, width)
+        }
     }
 
     func testFullRoomAccessibilityIdentifiersAreStableAndUnique() {

--- a/Tests/InterviewArcLiveTests/SystemDesignRoomLayoutTests.swift
+++ b/Tests/InterviewArcLiveTests/SystemDesignRoomLayoutTests.swift
@@ -35,11 +35,29 @@ final class SystemDesignRoomLayoutTests: XCTestCase {
     }
 
     func testMinimumWindowRetainsAUsableWorkspaceAndActionTargets() {
+        XCTAssertEqual(
+            FullRoomLayout.questionBandHeight(forLineCount: 1),
+            148
+        )
+        XCTAssertEqual(
+            FullRoomLayout.questionBandHeight(forLineCount: 2),
+            196
+        )
+        XCTAssertEqual(FullRoomLayout.questionBandMaximumHeight, 196)
+        XCTAssertEqual(FullRoomLayout.minimumWindowHeight, 742)
+        XCTAssertEqual(
+            FullRoomLayout.minimumWorkspaceHeight(
+                for: FullRoomLayout.minimumWindowHeight,
+                questionLineCount: FullRoomLayout.questionLineLimit
+            ),
+            FullRoomLayout.requiredWorkspaceHeight
+        )
         XCTAssertGreaterThanOrEqual(
             FullRoomLayout.minimumWorkspaceHeight(
-                for: FullRoomLayout.minimumWindowHeight
+                for: FullRoomLayout.minimumWindowHeight,
+                questionLineCount: 1
             ),
-            380
+            FullRoomLayout.requiredWorkspaceHeight
         )
         XCTAssertGreaterThanOrEqual(FullRoomLayout.minimumActionHitTarget, 44)
         XCTAssertGreaterThanOrEqual(
@@ -47,7 +65,10 @@ final class SystemDesignRoomLayoutTests: XCTestCase {
             FullRoomLayout.minimumActionHitTarget
         )
         XCTAssertGreaterThanOrEqual(FullRoomLayout.questionLineLimit, 2)
-        XCTAssertEqual(FullRoomLayout.questionBandMinimumHeight, 148)
+        XCTAssertEqual(
+            FullRoomLayout.questionBandMinimumHeight,
+            FullRoomLayout.questionBandHeight(forLineCount: 1)
+        )
         XCTAssertEqual(FullRoomLayout.questionTitleSize, 40)
         XCTAssertEqual(FullRoomLayout.turnlineHorizontalPadding, 64)
         XCTAssertEqual(FullRoomLayout.turnlineEntryGap, 42)


### PR DESCRIPTION
## **User description**
Refs #17

## Summary

- make the full room header consume the available width and retain the Staff Engineer, privacy, save, and collapse hierarchy in wide presentation
- preserve the approved 37/63 Turnline/Board balance at 1080, 1197, and 1600 points without the former 480-point Turnline cap
- align the question anchor, Turnline spacing, floor rail, and waveform coverage with the issue #1 System Design mockup
- make wide Board rails distribute across the Board while retaining compact overflow-safe rails at supported narrow widths
- give newly created nodes near-square 120x112 geometry, white fill, and the canonical brand-violet outline while preserving all authored/imported styles
- strengthen the canvas grid and keep one truthful, accessible bottom status without duplicating revision state

## Acceptance evidence

- exact source comparison against the approved issue #1 mockup identified and closed the header, split, rail, question, Turnline, floor, waveform, node-default, grid, and status gaps
- one bounded headed smoke of the prior merged artifact proved create/label/connect, resize, undo/redo, zoom, revision save/inspect, Draw.io+SVG+PNG export, collapse, and expand; that artifact was rejected and not installed because its visual layout was still wrong
- the app remained closed throughout this correction; a new headed pass is reserved for the exact merged-main artifact

## Local verification

- strict Swift 6 Core emit with complete concurrency and warnings as errors
- strict full application emit and link
- changed test target typecheck
- 84/84 exact-source runtime contracts: room layout/header/waveform, Board visual/editor/presentation, and Draw.io/SVG/PNG export
- changed-source parse and diff check
- Impeccable layout detector: no findings on either isolated UI slice
- public-safety added-line scan: no findings
- independent combined source audit: GO

## Reliability and limits

- no Session, persistence, recording, transcription, Codex, speech, artifact-store, renderer, or Draw.io codec behavior changed
- saved/imported nodes retain their authored geometry and colors; this PR changes only defaults for newly created nodes and does not silently migrate evidence
- timers and hosted state remain intentionally absent until their authoritative contract exists; no mock session content is fabricated
- merge requires clean exact-head hosted CI and zero unresolved actionable review threads
- after merge, package exact `main`, verify manifest/signature, and run one bounded headed visual/interaction pass before installation or issue closure

## Rollback

Revert this PR. Existing Board documents remain readable because persisted node geometry and colors are unchanged.


___

## **CodeAnt-AI Description**
Align the interview room and Board with the approved mockup

### What Changed
- Wide interview rooms now preserve the approved 37/63 Turnline-to-Board balance instead of capping the Turnline at 480 points.
- The room header stays wide at supported window sizes, switches to compact only when attention content cannot fit, and keeps the Staff Engineer and privacy information visible.
- Two-line questions receive dedicated space, with updated Turnline typography, spacing, floor controls, and waveform coverage.
- Board rails fill wide canvases while retaining compact layouts at narrower widths.
- New Board nodes use 120×112 near-square geometry, white fill, and a violet outline; imported or authored node styles remain unchanged.
- The canvas grid and footer now provide clearer visual feedback, with errors, actions, exports, and autosave status shown without duplicating revision state.
- Added coverage for supported room sizes, header behavior, node creation, Board rails, waveform placement, footer messages, and minimum window sizing.

### Impact
`✅ Consistent mockup layout at 1080–1600 point windows`
`✅ Clearer Board node styling and placement`
`✅ More readable room questions and Turnline content`
`✅ Distinct Board errors, actions, and autosave feedback`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
