### PR TITLE
Make final System Design room layout deterministic

### DIFF
--- a/Sources/InterviewArcLive/SystemDesignRoomView.swift
+++ b/Sources/InterviewArcLive/SystemDesignRoomView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import InterviewArcLiveCore
 import SwiftUI
@@ -93,12 +94,21 @@ struct SystemDesignRoomView: View {
                 hasRoomAttention: model.errorMessage != nil
                     || model.codexAttentionMessage != nil
             )
+            let statusPresentation = FullRoomHeaderStatusLayout.presentation(
+                headerPresentation: state.presentation,
+                windowWidth: geometry.size.width,
+                statusMessage: model.statusMessage
+            )
 
             Group {
                 if state.presentation == .compact {
-                    compactHeaderContent
+                    compactHeaderContent(
+                        statusPresentation: statusPresentation
+                    )
                 } else {
-                    fullHeaderContent
+                    fullHeaderContent(
+                        statusPresentation: statusPresentation
+                    )
                 }
             }
             .font(.system(.body, design: .rounded))
@@ -118,11 +128,13 @@ struct SystemDesignRoomView: View {
         }
     }
 
-    private var fullHeaderContent: some View {
+    private func fullHeaderContent(
+        statusPresentation: FullRoomHeaderStatusPresentation
+    ) -> some View {
         HStack(spacing: 16) {
             headerBrand
             Spacer(minLength: 22)
-            roomStatusMenu(isCompact: false)
+            roomStatusMenu(presentation: statusPresentation)
             headerDivider
             personaMenu(isCompact: false)
             Spacer(minLength: 22)
@@ -132,11 +144,13 @@ struct SystemDesignRoomView: View {
         .frame(maxWidth: .infinity)
     }
 
-    private var compactHeaderContent: some View {
+    private func compactHeaderContent(
+        statusPresentation: FullRoomHeaderStatusPresentation
+    ) -> some View {
         HStack(spacing: 12) {
             headerBrand
             Spacer(minLength: 12)
-            roomStatusMenu(isCompact: true)
+            roomStatusMenu(presentation: statusPresentation)
             headerDivider
             personaMenu(isCompact: true)
             Spacer(minLength: 12)
@@ -157,7 +171,9 @@ struct SystemDesignRoomView: View {
         .accessibilityElement(children: .combine)
     }
 
-    private func roomStatusMenu(isCompact: Bool) -> some View {
+    private func roomStatusMenu(
+        presentation: FullRoomHeaderStatusPresentation
+    ) -> some View {
         Menu {
             Picker("Turn-taking", selection: turnModeRawSelection) {
                 ForEach(model.availableTurnModes, id: \.rawValue) { mode in
@@ -172,30 +188,39 @@ struct SystemDesignRoomView: View {
             }
             Button("Check Codex") { Task { await model.checkCodex() } }
         } label: {
-            if isCompact {
+            switch presentation.style {
+            case .compact:
                 HStack(spacing: 7) {
-                    Text(FullRoomHeaderLabels.compactRoom)
+                    Text(presentation.visibleText)
                         .fontWeight(.semibold)
                     Circle()
                         .fill(headerRoomStatusColor)
                         .frame(width: 8, height: 8)
                         .accessibilityHidden(true)
                 }
-                .help("System design · \(model.statusMessage)")
-            } else {
-                Text(
-                    FullRoomHeaderLabels.roomStatus(
-                        statusMessage: model.statusMessage
+            case .wideInline:
+                Text(presentation.visibleText)
+                    .fontWeight(.semibold)
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
+            case .wideWrapped:
+                Text(presentation.visibleText)
+                    .fontWeight(.semibold)
+                    .lineLimit(presentation.lineLimit)
+                    .multilineTextAlignment(.leading)
+                    .allowsTightening(true)
+                    .minimumScaleFactor(0.92)
+                    .frame(
+                        width: presentation.frameWidth,
+                        alignment: .leading
                     )
-                )
-                .fontWeight(.semibold)
-                .lineLimit(1)
-                .help(model.statusMessage)
+                    .fixedSize(horizontal: false, vertical: true)
             }
         }
         .menuStyle(.borderlessButton)
+        .help(presentation.helpText)
         .accessibilityLabel(FullRoomHeaderAccessibility.roomStatusLabel)
-        .accessibilityValue(model.statusMessage)
+        .accessibilityValue(presentation.accessibilityValue)
     }
 
     private func personaMenu(isCompact: Bool) -> some View {
@@ -997,7 +1022,8 @@ enum FullRoomHeaderPresentation: Equatable {
 }
 
 enum FullRoomHeaderLayout {
-    static let attentionCompactMaximumWidth: CGFloat = 1_100
+    static let attentionCompactMaximumWidth =
+        FullRoomHeaderStatusLayout.minimumWideHeaderWidth
 
     static func state(
         windowWidth: CGFloat,
@@ -1023,6 +1049,109 @@ enum FullRoomHeaderAccessibility {
     static let personaLabel = "Interviewer: Mara, Staff Engineer"
     static let privacyLabel = "Private local session"
     static let collapseLabel = "Collapse interview room"
+}
+
+enum FullRoomHeaderStatusStyle: Equatable {
+    case compact
+    case wideInline
+    case wideWrapped
+}
+
+struct FullRoomHeaderStatusPresentation: Equatable {
+    let style: FullRoomHeaderStatusStyle
+    let visibleText: String
+    let accessibilityValue: String
+    let helpText: String
+    let frameWidth: CGFloat?
+    let lineLimit: Int
+}
+
+enum FullRoomHeaderStatusLayout {
+    /// Brand, the worst-case local-voice attention badge, persona, privacy,
+    /// collapse, padding, gaps, and both flexible spacers keep this much of a
+    /// wide header before status text is added.
+    static let wideReservedWidth: CGFloat = 940
+    static let minimumWrappedWidth: CGFloat = 220
+    static let minimumWideHeaderWidth = wideReservedWidth + minimumWrappedWidth
+    static let wrappedLineLimit = 2
+    static let maximumWrappedTextHeight: CGFloat = 40
+    static let inlineMeasurementSafetyMargin: CGFloat = 8
+
+    static func presentation(
+        headerPresentation: FullRoomHeaderPresentation,
+        windowWidth: CGFloat,
+        statusMessage: String
+    ) -> FullRoomHeaderStatusPresentation {
+        let fullText = FullRoomHeaderLabels.roomStatus(
+            statusMessage: statusMessage
+        )
+        if headerPresentation == .compact {
+            return FullRoomHeaderStatusPresentation(
+                style: .compact,
+                visibleText: FullRoomHeaderLabels.compactRoom,
+                accessibilityValue: statusMessage,
+                helpText: fullText,
+                frameWidth: nil,
+                lineLimit: 1
+            )
+        }
+
+        let availableWidth = wideStatusWidth(for: windowWidth)
+        if measuredWidth(of: fullText)
+            + inlineMeasurementSafetyMargin <= availableWidth {
+            return FullRoomHeaderStatusPresentation(
+                style: .wideInline,
+                visibleText: fullText,
+                accessibilityValue: statusMessage,
+                helpText: fullText,
+                frameWidth: nil,
+                lineLimit: 1
+            )
+        }
+        return FullRoomHeaderStatusPresentation(
+            style: .wideWrapped,
+            visibleText: statusMessage,
+            accessibilityValue: statusMessage,
+            helpText: fullText,
+            frameWidth: availableWidth,
+            lineLimit: wrappedLineLimit
+        )
+    }
+
+    static func wideStatusWidth(for windowWidth: CGFloat) -> CGFloat {
+        max(minimumWrappedWidth, windowWidth - wideReservedWidth)
+    }
+
+    static func measuredWidth(of text: String) -> CGFloat {
+        ceil(
+            (text as NSString).size(
+                withAttributes: [.font: statusFont]
+            ).width
+        )
+    }
+
+    static func wrappedTextHeight(
+        of text: String,
+        width: CGFloat
+    ) -> CGFloat {
+        ceil(
+            (text as NSString).boundingRect(
+                with: NSSize(
+                    width: width,
+                    height: CGFloat.greatestFiniteMagnitude
+                ),
+                options: [.usesLineFragmentOrigin, .usesFontLeading],
+                attributes: [.font: statusFont]
+            ).height
+        )
+    }
+
+    private static var statusFont: NSFont {
+        NSFont.systemFont(
+            ofSize: NSFont.systemFontSize,
+            weight: .semibold
+        )
+    }
 }
 
 enum FullRoomHeaderLabels {

--- a/Sources/InterviewArcLive/SystemDesignRoomView.swift
+++ b/Sources/InterviewArcLive/SystemDesignRoomView.swift
@@ -27,18 +27,35 @@ struct SystemDesignRoomView: View {
             }
 
             GeometryReader { workspace in
-                HSplitView {
+                let widths = FullRoomLayout.workspaceWidths(
+                    for: workspace.size.width
+                )
+
+                HStack(spacing: 0) {
                     transcript
                         .frame(
-                            minWidth: FullRoomLayout.turnlineMinimumWidth,
-                            idealWidth: FullRoomLayout.turnlineIdealWidth(
-                                for: workspace.size.width
-                            )
+                            width: widths.turnlineWidth,
+                            height: workspace.size.height
                         )
+                        .overlay(alignment: .trailing) {
+                            Rectangle()
+                                .fill(LivePalette.line)
+                                .frame(width: widths.visualDividerWidth)
+                                .allowsHitTesting(false)
+                                .accessibilityHidden(true)
+                        }
                     board
-                        .frame(minWidth: FullRoomLayout.boardMinimumWidth)
+                        .frame(
+                            width: widths.boardWidth,
+                            height: workspace.size.height
+                        )
                         .accessibilityIdentifier(FullRoomAccessibility.board)
                 }
+                .frame(
+                    width: widths.totalWidth,
+                    height: workspace.size.height,
+                    alignment: .leading
+                )
             }
 
             floorRail
@@ -157,7 +174,7 @@ struct SystemDesignRoomView: View {
         } label: {
             if isCompact {
                 HStack(spacing: 7) {
-                    Text("System design")
+                    Text(FullRoomHeaderLabels.compactRoom)
                         .fontWeight(.semibold)
                     Circle()
                         .fill(headerRoomStatusColor)
@@ -166,17 +183,14 @@ struct SystemDesignRoomView: View {
                 }
                 .help("System design · \(model.statusMessage)")
             } else {
-                HStack(spacing: 7) {
-                    Text("System design")
-                        .fontWeight(.semibold)
-                    Text("·")
-                        .foregroundStyle(LivePalette.muted)
-                    Text(model.statusMessage)
-                        .foregroundStyle(LivePalette.ink)
-                        .lineLimit(1)
-                        .frame(width: 86, alignment: .leading)
-                        .help(model.statusMessage)
-                }
+                Text(
+                    FullRoomHeaderLabels.roomStatus(
+                        statusMessage: model.statusMessage
+                    )
+                )
+                .fontWeight(.semibold)
+                .lineLimit(1)
+                .help(model.statusMessage)
             }
         }
         .menuStyle(.borderlessButton)
@@ -212,12 +226,12 @@ struct SystemDesignRoomView: View {
             }
         } label: {
             HStack(spacing: 7) {
-                Text("Mara")
+                Text(
+                    isCompact
+                        ? FullRoomHeaderLabels.compactPersona
+                        : FullRoomHeaderLabels.widePersona
+                )
                     .fontWeight(.semibold)
-                if !isCompact {
-                    Text("·")
-                    Text("Staff Engineer")
-                }
                 if !model.isSpeechReady {
                     speechAttentionBadge
                 }
@@ -856,6 +870,17 @@ struct SystemDesignRoomView: View {
     }
 }
 
+struct FullRoomWorkspaceWidths: Equatable {
+    let totalWidth: CGFloat
+    let turnlineWidth: CGFloat
+    let boardWidth: CGFloat
+    let visualDividerWidth: CGFloat
+
+    var composedWidth: CGFloat {
+        turnlineWidth + boardWidth
+    }
+}
+
 enum FullRoomLayout {
     static let minimumWindowWidth: CGFloat = 1_080
     static let defaultWindowWidth: CGFloat = 1_180
@@ -874,6 +899,8 @@ enum FullRoomLayout {
     static let questionBandMinimumHeight = questionBandOneLineHeight
     static let turnlineHeaderHeight: CGFloat = 58
     static let turnlineWidthFraction: CGFloat = 0.37
+    static let boardWidthFraction: CGFloat = 1 - turnlineWidthFraction
+    static let workspaceVisualDividerWidth: CGFloat = 1
     static let turnlineMinimumWidth: CGFloat = 380
     static let turnlineHorizontalPadding: CGFloat = 64
     static let turnlineEntryGap: CGFloat = 42
@@ -899,19 +926,25 @@ enum FullRoomLayout {
     /// header occupies that same row instead of leaving a blank strip.
     static let trafficLightClearance: CGFloat = 84
 
-    static func turnlineIdealWidth(for workspaceWidth: CGFloat) -> CGFloat {
-        let availableTurnlineWidth = max(
-            turnlineMinimumWidth,
-            workspaceWidth - boardMinimumWidth
-        )
-        return min(
-            max(workspaceWidth * turnlineWidthFraction, turnlineMinimumWidth),
-            availableTurnlineWidth
+    static func workspaceWidths(
+        for workspaceWidth: CGFloat
+    ) -> FullRoomWorkspaceWidths {
+        let totalWidth = max(0, workspaceWidth)
+        let turnlineWidth = totalWidth * turnlineWidthFraction
+        return FullRoomWorkspaceWidths(
+            totalWidth: totalWidth,
+            turnlineWidth: turnlineWidth,
+            boardWidth: totalWidth - turnlineWidth,
+            visualDividerWidth: workspaceVisualDividerWidth
         )
     }
 
+    static func turnlineIdealWidth(for workspaceWidth: CGFloat) -> CGFloat {
+        workspaceWidths(for: workspaceWidth).turnlineWidth
+    }
+
     static func boardIdealWidth(for workspaceWidth: CGFloat) -> CGFloat {
-        max(boardMinimumWidth, workspaceWidth - turnlineIdealWidth(for: workspaceWidth))
+        workspaceWidths(for: workspaceWidth).boardWidth
     }
 
     static func questionBandHeight(forLineCount lineCount: Int) -> CGFloat {
@@ -990,6 +1023,16 @@ enum FullRoomHeaderAccessibility {
     static let personaLabel = "Interviewer: Mara, Staff Engineer"
     static let privacyLabel = "Private local session"
     static let collapseLabel = "Collapse interview room"
+}
+
+enum FullRoomHeaderLabels {
+    static let compactRoom = "System design"
+    static let compactPersona = "Mara"
+    static let widePersona = "Mara · Staff Engineer"
+
+    static func roomStatus(statusMessage: String) -> String {
+        "\(compactRoom) · \(statusMessage)"
+    }
 }
 
 enum FullRoomAccessibility {

--- a/Tests/InterviewArcLiveTests/SystemDesignRoomLayoutTests.swift
+++ b/Tests/InterviewArcLiveTests/SystemDesignRoomLayoutTests.swift
@@ -163,6 +163,20 @@ final class SystemDesignRoomLayoutTests: XCTestCase {
         )
         XCTAssertEqual(combined.attention, .speechAndRoom)
         XCTAssertTrue(combined.usesAttentionCompactHeader)
+
+        let boundedAttention = FullRoomHeaderLayout.state(
+            windowWidth: FullRoomHeaderStatusLayout.minimumWideHeaderWidth,
+            hasSpeechAttention: true,
+            hasRoomAttention: true
+        )
+        XCTAssertEqual(boundedAttention.presentation, .compact)
+
+        let fittingWideAttention = FullRoomHeaderLayout.state(
+            windowWidth: FullRoomHeaderStatusLayout.minimumWideHeaderWidth + 1,
+            hasSpeechAttention: true,
+            hasRoomAttention: true
+        )
+        XCTAssertEqual(fittingWideAttention.presentation, .wide)
     }
 
     func testDefaultWidthKeepsWideHeaderUnderAttention() {
@@ -227,6 +241,78 @@ final class SystemDesignRoomLayoutTests: XCTestCase {
         XCTAssertEqual(FullRoomHeaderLabels.compactRoom, "System design")
         XCTAssertEqual(FullRoomHeaderLabels.widePersona, "Mara · Staff Engineer")
         XCTAssertEqual(FullRoomHeaderLabels.compactPersona, "Mara")
+
+        for width: CGFloat in [1_080, 1_180] {
+            let status = FullRoomHeaderStatusLayout.presentation(
+                headerPresentation: .wide,
+                windowWidth: width,
+                statusMessage: "Ready to record"
+            )
+            XCTAssertEqual(status.style, .wideInline)
+            XCTAssertEqual(status.visibleText, "System design · Ready to record")
+            XCTAssertEqual(status.accessibilityValue, "Ready to record")
+            XCTAssertEqual(status.lineLimit, 1)
+            XCTAssertNil(status.frameWidth)
+        }
+    }
+
+    func testLongestOperationalStatusUsesBoundedReadableWideFallback() {
+        let longestStatus = "Groq key available until quit · transcribe the affected segment"
+
+        for width: CGFloat in [1_080, 1_180] {
+            let availableWidth = FullRoomHeaderStatusLayout.wideStatusWidth(
+                for: width
+            )
+            let status = FullRoomHeaderStatusLayout.presentation(
+                headerPresentation: .wide,
+                windowWidth: width,
+                statusMessage: longestStatus
+            )
+
+            XCTAssertEqual(status.style, .wideWrapped)
+            XCTAssertEqual(status.visibleText, longestStatus)
+            XCTAssertEqual(status.accessibilityValue, longestStatus)
+            XCTAssertEqual(
+                status.helpText,
+                "System design · \(longestStatus)"
+            )
+            XCTAssertEqual(status.frameWidth, availableWidth)
+            XCTAssertEqual(
+                status.lineLimit,
+                FullRoomHeaderStatusLayout.wrappedLineLimit
+            )
+            XCTAssertLessThanOrEqual(
+                FullRoomHeaderStatusLayout.wrappedTextHeight(
+                    of: longestStatus,
+                    width: availableWidth
+                ),
+                FullRoomHeaderStatusLayout.maximumWrappedTextHeight
+            )
+        }
+
+        let spacious = FullRoomHeaderStatusLayout.presentation(
+            headerPresentation: .wide,
+            windowWidth: 1_600,
+            statusMessage: longestStatus
+        )
+        XCTAssertEqual(spacious.style, .wideInline)
+        XCTAssertEqual(
+            spacious.visibleText,
+            "System design · \(longestStatus)"
+        )
+
+        let compact = FullRoomHeaderStatusLayout.presentation(
+            headerPresentation: .compact,
+            windowWidth: 1_080,
+            statusMessage: longestStatus
+        )
+        XCTAssertEqual(compact.style, .compact)
+        XCTAssertEqual(compact.visibleText, "System design")
+        XCTAssertEqual(compact.accessibilityValue, longestStatus)
+        XCTAssertEqual(
+            compact.helpText,
+            "System design · \(longestStatus)"
+        )
     }
 
     func testWaveformUsesTheRailWithoutPretendingToBeRecordedAudio() {

--- a/Tests/InterviewArcLiveTests/SystemDesignRoomLayoutTests.swift
+++ b/Tests/InterviewArcLiveTests/SystemDesignRoomLayoutTests.swift
@@ -3,20 +3,58 @@ import XCTest
 @testable import InterviewArcLive
 
 final class SystemDesignRoomLayoutTests: XCTestCase {
-    func testSupportedWidthsKeepTheApprovedTurnlineBoardBalance() {
-        for width: CGFloat in [1_080, 1_197, 1_600] {
-            let turnline = FullRoomLayout.turnlineIdealWidth(for: width)
-            let board = FullRoomLayout.boardIdealWidth(for: width)
+    func testSupportedWidthsUseTheDeterministicTurnlineBoardComposition() {
+        let contracts: [(
+            total: CGFloat,
+            turnline: CGFloat,
+            board: CGFloat
+        )] = [
+            (1_080, 399.6, 680.4),
+            (1_180, 436.6, 743.4),
+            (1_600, 592, 1_008),
+        ]
+
+        for contract in contracts {
+            let width = contract.total
+            let widths = FullRoomLayout.workspaceWidths(for: width)
 
             XCTAssertEqual(
-                turnline / width,
+                widths.turnlineWidth,
+                contract.turnline,
+                accuracy: 0.001
+            )
+            XCTAssertEqual(
+                widths.boardWidth,
+                contract.board,
+                accuracy: 0.001
+            )
+            XCTAssertEqual(
+                widths.turnlineWidth / width,
                 FullRoomLayout.turnlineWidthFraction,
                 accuracy: 0.001
             )
-            XCTAssertGreaterThanOrEqual(turnline, FullRoomLayout.turnlineMinimumWidth)
-            XCTAssertGreaterThanOrEqual(board, FullRoomLayout.boardMinimumWidth)
-            XCTAssertEqual(turnline + board, width, accuracy: 0.001)
+            XCTAssertEqual(
+                widths.boardWidth / width,
+                FullRoomLayout.boardWidthFraction,
+                accuracy: 0.001
+            )
+            XCTAssertGreaterThanOrEqual(
+                widths.turnlineWidth,
+                FullRoomLayout.turnlineMinimumWidth
+            )
+            XCTAssertGreaterThanOrEqual(
+                widths.boardWidth,
+                FullRoomLayout.boardMinimumWidth
+            )
+            XCTAssertEqual(widths.composedWidth, width, accuracy: 0.001)
+            XCTAssertEqual(widths.totalWidth, width)
+            XCTAssertEqual(widths.visualDividerWidth, 1)
         }
+        XCTAssertEqual(
+            FullRoomLayout.boardWidthFraction,
+            0.63,
+            accuracy: 0.001
+        )
     }
 
     func testWideWindowDoesNotCapTheTurnlineBelowTheApprovedFraction() {
@@ -177,6 +215,18 @@ final class SystemDesignRoomLayoutTests: XCTestCase {
             FullRoomHeaderAccessibility.privacyLabel,
             "Private local session"
         )
+    }
+
+    func testHeaderVisualLabelsAreAtomicAndTruthful() {
+        XCTAssertEqual(
+            FullRoomHeaderLabels.roomStatus(
+                statusMessage: "Restoring local session…"
+            ),
+            "System design · Restoring local session…"
+        )
+        XCTAssertEqual(FullRoomHeaderLabels.compactRoom, "System design")
+        XCTAssertEqual(FullRoomHeaderLabels.widePersona, "Mara · Staff Engineer")
+        XCTAssertEqual(FullRoomHeaderLabels.compactPersona, "Mara")
     }
 
     func testWaveformUsesTheRailWithoutPretendingToBeRecordedAudio() {


### PR DESCRIPTION
## **User description**
Refs #17

## Summary

- replace the adjustable `HSplitView` with one deterministic, non-resizable 37/63 Turnline/Board composition
- overlay the one-point divider without consuming workspace width
- render wide room status and persona labels atomically so `System design · <status>` and `Mara · Staff Engineer` remain visible as designed
- preserve the existing compact header and compact Board rails at supported narrower widths

## Root cause

The prior merged artifact treated the approved 37/63 split as an ideal width inside `HSplitView`. AppKit restored/rendered that split near 50/50, so the Board stayed narrow and the runtime artifact did not match the checked-in issue #1 mockup even though source-level width calculations passed.

## Verification

- strict Swift 6 Core emit/link with complete concurrency and warnings as errors
- strict full-app emit/link with complete concurrency and warnings as errors
- changed layout-test typecheck
- 11/11 deterministic layout/header runtime contracts
- exact widths: 1080 → 399.6/680.4, 1180 → 436.6/743.4, 1600 → 592/1008
- exact composed-width and one-point overlay-divider contracts
- Swift frontend parse and `git diff --check`
- Impeccable layout detector: zero findings
- independent issue #1 source-vs-mockup audit: zero blocker/high/medium findings
- public-safety scan: zero findings

## Release gate

This PR is not visual release evidence. After merge, the exact merged-main signed artifact must receive one bounded headed staged inspection proving the live 37/63 split and wide header at the mockup width. Only those accepted bytes may be installed and used to close issue #17.

## Known behavior

- At 1080 and the 1180 default, the Board uses its bounded compact rails; at 1600 it uses the full wide rails shown by the issue #1 mockup.
- No Board document, revision, export, session, recording, provider, or persistence behavior changes.


___

## **CodeAnt-AI Description**
Make the System Design room layout deterministic and keep status information readable

### What Changed
- The Turnline and Board now always use a precise 37/63 layout with a one-point divider, instead of allowing the workspace split to move.
- Wide headers show the complete room status and persona name when space allows.
- Long status messages wrap within a bounded area at narrower supported widths, while compact headers retain concise labels and full accessibility details.
- Added coverage for exact workspace proportions, header transitions, readable status text, and accessibility values.

### Impact
`✅ Consistent Turnline and Board proportions`
`✅ Readable room status at supported widths`
`✅ Clearer header labels and accessibility text`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
