### PR TITLE
Implement truthful Cue Only handoff

### DIFF
--- a/Sources/InterviewArcLive/EndpointShadowPresentation.swift
+++ b/Sources/InterviewArcLive/EndpointShadowPresentation.swift
@@ -40,6 +40,14 @@ struct EndpointShadowPresentation: Equatable {
         hasUnresolvedDraft: Bool,
         hasStaleEvaluation: Bool
     ) -> EndpointShadowPresentation {
+        if turnMode == .cueOnly {
+            return EndpointShadowPresentation(
+                title: "Cue Only turn-taking",
+                detail: "A terminal finish, clarification, or hint cue Hands off after its transcript is saved. The Hand off control remains available.",
+                systemImage: "quote.bubble.fill",
+                tone: .neutral
+            )
+        }
         guard turnMode == .patientAuto else {
             return EndpointShadowPresentation(
                 title: "Manual turn-taking",

--- a/Sources/InterviewArcLive/EndpointShadowPresentation.swift
+++ b/Sources/InterviewArcLive/EndpointShadowPresentation.swift
@@ -43,7 +43,7 @@ struct EndpointShadowPresentation: Equatable {
         if turnMode == .cueOnly {
             return EndpointShadowPresentation(
                 title: "Cue Only turn-taking",
-                detail: "A terminal finish, clarification, or hint cue Hands off after its transcript is saved. The Hand off control remains available.",
+                detail: "A terminal finish, direct question, or hint cue triggers Hand off after its transcript is saved. The Hand off control remains available.",
                 systemImage: "quote.bubble.fill",
                 tone: .neutral
             )

--- a/Sources/InterviewArcLive/SystemDesignRoomModel.swift
+++ b/Sources/InterviewArcLive/SystemDesignRoomModel.swift
@@ -273,11 +273,11 @@ final class SystemDesignRoomModel: ObservableObject {
     }
 
     var availableTurnModes: [TurnMode] {
-        [.manual, .patientAuto]
+        [.cueOnly, .manual, .patientAuto]
     }
 
     var turnMode: TurnMode {
-        snapshot?.turnMode ?? .manual
+        snapshot?.turnMode ?? .cueOnly
     }
 
     var canSelectTurnMode: Bool {
@@ -299,7 +299,7 @@ final class SystemDesignRoomModel: ObservableObject {
     var endpointShadowPresentation: EndpointShadowPresentation {
         guard let snapshot else {
             return EndpointShadowPresentation.make(
-                turnMode: .manual,
+                turnMode: .cueOnly,
                 phase: nil,
                 currentEvaluation: nil,
                 hasSelectedDraft: false,
@@ -838,7 +838,7 @@ final class SystemDesignRoomModel: ObservableObject {
                 sessionID: sessionID,
                 activityID: "local-system-design-tracer",
                 activityPrompt: activityPrompt,
-                turnMode: .manual,
+                turnMode: .cueOnly,
                 interviewerRuntime: codexRuntime,
                 recording: VoiceCoreSegmentRecorder(),
                 transcriber: VoiceCoreSegmentTranscriber(),
@@ -944,7 +944,7 @@ final class SystemDesignRoomModel: ObservableObject {
     }
 
     func selectTurnMode(_ mode: TurnMode) async {
-        guard mode == .manual || mode == .patientAuto,
+        guard availableTurnModes.contains(mode),
               mode != turnMode,
               canSelectTurnMode,
               let coordinator else {
@@ -1022,7 +1022,10 @@ final class SystemDesignRoomModel: ObservableObject {
                     segmentID: activeSegment.id,
                     commandID: commandID("initial-transcription")
                 )
-                publish(transcribed)
+                await publishTranscriptionResult(
+                    transcribed,
+                    triggerSegmentID: activeSegment.id
+                )
             }
         } catch {
             publish(coordinator.snapshot)
@@ -1058,11 +1061,40 @@ final class SystemDesignRoomModel: ObservableObject {
                     isInitial ? "initial-transcription" : "retry-transcription"
                 )
             )
-            publish(updated)
+            await publishTranscriptionResult(
+                updated,
+                triggerSegmentID: segment.id
+            )
         } catch {
             publish(coordinator.snapshot)
             handleCredentialFailure(error)
             errorMessage = safeMessage(for: error)
+        }
+    }
+
+    private func publishTranscriptionResult(
+        _ updated: InterviewRoomSnapshot,
+        triggerSegmentID: SegmentID
+    ) async {
+        publish(updated)
+        if updated.phase == .interviewerTurn {
+            await interviewerSpeechCoordinator?
+                .observeNewlyPersistedSnapshot(updated)
+            return
+        }
+        guard updated.phase == .candidateFloor,
+              updated.turnMode == .cueOnly,
+              let trigger = updated.segments.first(where: {
+                  $0.id == triggerSegmentID
+              }),
+              let body = trigger.selectedCandidate?.body,
+              CueOnlyHandoffPolicy.reason(in: body) != nil else {
+            return
+        }
+        if boardAttachmentForHandOff == nil {
+            boardErrorMessage = "Cue detected. Save the displayed Board as a revision, then choose Hand off."
+        } else {
+            statusMessage = "Cue detected · resolve the remaining segment before Hand off"
         }
     }
 

--- a/Sources/InterviewArcLive/SystemDesignRoomModel.swift
+++ b/Sources/InterviewArcLive/SystemDesignRoomModel.swift
@@ -414,22 +414,22 @@ final class SystemDesignRoomModel: ObservableObject {
     }
 
     var boardAttachmentForHandOff: CandidateTurnBoardAttachment? {
+        guard let board = snapshot?.board else { return nil }
         if let inspectedBoardRevisionID {
-            guard snapshot?.board.revisions.contains(where: {
-                $0.id == inspectedBoardRevisionID
-            }) == true else {
-                return nil
-            }
-            return .revision(inspectedBoardRevisionID)
+            return BoardHandoffAttachmentPolicy.explicitAttachment(
+                in: board,
+                inspectedRevisionID: inspectedBoardRevisionID
+            )
         }
-        if boardEditor.document.elements.isEmpty {
-            return .noBoard
-        }
-        guard let latestBoardRevision,
-              latestBoardRevision.document == boardEditor.document else {
-            return nil
-        }
-        return .revision(latestBoardRevision.id)
+        return currentBoardDraftAttachmentForHandOff
+    }
+
+    var currentBoardDraftAttachmentForHandOff: CandidateTurnBoardAttachment? {
+        guard let board = snapshot?.board else { return nil }
+        return BoardHandoffAttachmentPolicy.currentDraftAttachment(
+            draft: boardEditor.document,
+            revisions: board.revisions
+        )
     }
 
     var canSaveBoardRevision: Bool {
@@ -1093,7 +1093,7 @@ final class SystemDesignRoomModel: ObservableObject {
               CueOnlyHandoffPolicy.reason(in: body) != nil else {
             return
         }
-        if boardAttachmentForHandOff == nil {
+        if currentBoardDraftAttachmentForHandOff == nil {
             boardErrorMessage = "Cue detected. Save the displayed Board as a revision, then choose Hand off."
         } else {
             statusMessage = "Cue detected · resolve the remaining segment before Hand off"

--- a/Sources/InterviewArcLive/SystemDesignRoomModel.swift
+++ b/Sources/InterviewArcLive/SystemDesignRoomModel.swift
@@ -1030,6 +1030,7 @@ final class SystemDesignRoomModel: ObservableObject {
         } catch {
             publish(coordinator.snapshot)
             handleCredentialFailure(error)
+            errorWasCodexFailure = applyCodexFailure(error)
             errorMessage = safeMessage(for: error)
         }
     }
@@ -1068,6 +1069,7 @@ final class SystemDesignRoomModel: ObservableObject {
         } catch {
             publish(coordinator.snapshot)
             handleCredentialFailure(error)
+            errorWasCodexFailure = applyCodexFailure(error)
             errorMessage = safeMessage(for: error)
         }
     }

--- a/Sources/InterviewArcLiveCore/BoardDomain.swift
+++ b/Sources/InterviewArcLiveCore/BoardDomain.swift
@@ -507,6 +507,49 @@ public enum CandidateTurnBoardAttachment: Codable, Sendable, Equatable {
     case revision(BoardRevisionID)
 }
 
+/// One source of truth for choosing Board evidence at Hand off.
+/// Automatic flows use only the current draft; the explicit UI may instead
+/// attach a revision the candidate is deliberately inspecting.
+public enum BoardHandoffAttachmentPolicy {
+    public static func currentDraftAttachment(
+        draft: BoardDocument,
+        revisions: [BoardRevision]
+    ) -> CandidateTurnBoardAttachment? {
+        if draft.elements.isEmpty {
+            return .noBoard
+        }
+        guard let latest = revisions.last,
+              latest.document == draft else {
+            return nil
+        }
+        return .revision(latest.id)
+    }
+
+    public static func currentDraftAttachment(
+        in workspace: BoardWorkspace
+    ) -> CandidateTurnBoardAttachment? {
+        currentDraftAttachment(
+            draft: workspace.draft,
+            revisions: workspace.revisions
+        )
+    }
+
+    public static func explicitAttachment(
+        in workspace: BoardWorkspace,
+        inspectedRevisionID: BoardRevisionID?
+    ) -> CandidateTurnBoardAttachment? {
+        if let inspectedRevisionID {
+            guard workspace.revisions.contains(where: {
+                $0.id == inspectedRevisionID
+            }) else {
+                return nil
+            }
+            return .revision(inspectedRevisionID)
+        }
+        return currentDraftAttachment(in: workspace)
+    }
+}
+
 public enum BoardArtifactIdentityValidationError: Error, Sendable, Equatable {
     case invalidRelativeIdentity
 }

--- a/Sources/InterviewArcLiveCore/CueOnlyHandoffPolicy.swift
+++ b/Sources/InterviewArcLiveCore/CueOnlyHandoffPolicy.swift
@@ -1,0 +1,119 @@
+import Foundation
+
+public enum CueOnlyHandoffReason: String, Sendable, Equatable {
+    case explicitCompletion = "explicit_completion"
+    case interviewerClarification = "interviewer_clarification"
+    case hintRequest = "hint_request"
+}
+
+/// Conservative transcript-boundary policy for the Cue Only turn mode.
+///
+/// Matching is deliberately terminal and deterministic. The policy does not
+/// infer semantic completeness, rewrite transcript evidence, or invoke a
+/// provider. Broader endpoint decisions belong to Patient Auto.
+public enum CueOnlyHandoffPolicy {
+    public static func reason(in transcript: String) -> CueOnlyHandoffReason? {
+        let words = canonicalWords(in: transcript)
+        guard !words.isEmpty, !endsWithQuotedExample(transcript) else {
+            return nil
+        }
+
+        if matchesTerminalPhrase(in: words, phrases: completionPhrases) {
+            return .explicitCompletion
+        }
+        if matchesTerminalPhrase(in: words, phrases: clarificationPhrases) {
+            return .interviewerClarification
+        }
+        if matchesTerminalPhrase(in: words, phrases: hintPhrases) {
+            return .hintRequest
+        }
+        return nil
+    }
+
+    private static let completionPhrases = [
+        ["i", "m", "done"],
+        ["i", "am", "done"],
+        ["that", "s", "my", "answer"],
+        ["that", "is", "my", "answer"],
+        ["that", "s", "it"],
+        ["that", "is", "it"],
+        ["hand", "off"],
+        ["your", "turn"],
+        ["i", "ll", "hand", "it", "back"],
+        ["i", "will", "hand", "it", "back"],
+        ["over", "to", "you"],
+    ]
+
+    private static let clarificationPhrases = [
+        ["can", "you", "clarify", "the", "question"],
+        ["could", "you", "clarify", "the", "question"],
+        ["would", "you", "clarify", "the", "question"],
+        ["can", "you", "repeat", "the", "question"],
+        ["could", "you", "repeat", "the", "question"],
+        ["would", "you", "repeat", "the", "question"],
+        ["what", "do", "you", "mean", "by", "that"],
+    ]
+
+    private static let hintPhrases = [
+        ["can", "you", "give", "me", "a", "hint"],
+        ["could", "you", "give", "me", "a", "hint"],
+        ["would", "you", "give", "me", "a", "hint"],
+        ["may", "i", "have", "a", "hint"],
+        ["can", "you", "help", "me"],
+        ["could", "you", "help", "me"],
+        ["what", "should", "i", "consider", "next"],
+    ]
+
+    private static let attributionWords: Set<String> = [
+        "example", "phrase", "quote", "say", "says", "said",
+    ]
+
+    private static func matchesTerminalPhrase(
+        in words: [String],
+        phrases: [[String]]
+    ) -> Bool {
+        for phrase in phrases where words.count >= phrase.count {
+            let start = words.count - phrase.count
+            guard Array(words[start...]) == phrase else { continue }
+            if start > 0, attributionWords.contains(words[start - 1]) {
+                continue
+            }
+            if start >= 2,
+               words[start - 2] == "for",
+               words[start - 1] == "example" {
+                continue
+            }
+            return true
+        }
+        return false
+    }
+
+    private static func canonicalWords(in transcript: String) -> [String] {
+        let folded = transcript
+            .precomposedStringWithCompatibilityMapping
+            .folding(
+                options: [.caseInsensitive, .diacriticInsensitive],
+                locale: Locale(identifier: "en_US_POSIX")
+            )
+        var words: [String] = []
+        var current = String.UnicodeScalarView()
+        for scalar in folded.unicodeScalars {
+            if CharacterSet.alphanumerics.contains(scalar) {
+                current.append(scalar)
+            } else if !current.isEmpty {
+                words.append(String(current))
+                current = String.UnicodeScalarView()
+            }
+        }
+        if !current.isEmpty {
+            words.append(String(current))
+        }
+        return words
+    }
+
+    private static func endsWithQuotedExample(_ transcript: String) -> Bool {
+        let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let last = trimmed.last else { return false }
+        return ["\"", "”", "’", "»"].contains(last)
+    }
+}

--- a/Sources/InterviewArcLiveCore/CueOnlyHandoffPolicy.swift
+++ b/Sources/InterviewArcLiveCore/CueOnlyHandoffPolicy.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public enum CueOnlyHandoffReason: String, Sendable, Equatable {
     case explicitCompletion = "explicit_completion"
-    case interviewerClarification = "interviewer_clarification"
+    case interviewerQuestion = "interviewer_question"
     case hintRequest = "hint_request"
 }
 
@@ -21,11 +21,12 @@ public enum CueOnlyHandoffPolicy {
         if matchesTerminalPhrase(in: words, phrases: completionPhrases) {
             return .explicitCompletion
         }
-        if matchesTerminalPhrase(in: words, phrases: clarificationPhrases) {
-            return .interviewerClarification
-        }
         if matchesTerminalPhrase(in: words, phrases: hintPhrases) {
             return .hintRequest
+        }
+        if isTerminalQuestion(transcript)
+            || matchesTerminalPhrase(in: words, phrases: interviewerQuestionPhrases) {
+            return .interviewerQuestion
         }
         return nil
     }
@@ -44,7 +45,9 @@ public enum CueOnlyHandoffPolicy {
         ["over", "to", "you"],
     ]
 
-    private static let clarificationPhrases = [
+    /// Exact fallbacks cover transcripts whose provider omitted question-mark
+    /// punctuation. A genuine terminal `?` is itself an explicit floor cue.
+    private static let interviewerQuestionPhrases = [
         ["can", "you", "clarify", "the", "question"],
         ["could", "you", "clarify", "the", "question"],
         ["would", "you", "clarify", "the", "question"],
@@ -109,6 +112,15 @@ public enum CueOnlyHandoffPolicy {
             words.append(String(current))
         }
         return words
+    }
+
+    private static func isTerminalQuestion(_ transcript: String) -> Bool {
+        guard let last = transcript
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .last else {
+            return false
+        }
+        return last == "?" || last == "？"
     }
 
     private static func endsWithQuotedExample(_ transcript: String) -> Bool {

--- a/Sources/InterviewArcLiveCore/SegmentSpeechCoordinator.swift
+++ b/Sources/InterviewArcLiveCore/SegmentSpeechCoordinator.swift
@@ -720,28 +720,31 @@ public final class SegmentSpeechCoordinator {
             return snapshot
         }
 
-        return try await applyAndPublish(
-            .handOffSegmentsWithBoard(
-                commandID: InterviewRoomSession.derivedCommandID(
-                    source: sourceCommandID,
-                    operation: "cue-only-hand-off"
-                ),
-                boardAttachment: boardAttachment
-            )
-        ).snapshot
+        do {
+            return try await applyAndPublish(
+                .handOffSegmentsWithBoard(
+                    commandID: InterviewRoomSession.derivedCommandID(
+                        source: sourceCommandID,
+                        operation: "cue-only-hand-off"
+                    ),
+                    boardAttachment: boardAttachment
+                )
+            ).snapshot
+        } catch {
+            // Hand off persists the Candidate Turn before invoking Codex. If
+            // that provider work fails, the transcript succeeded and the
+            // durable room is now explicitly recoverable through Retry.
+            guard snapshot.phase == .interviewerProcessing else {
+                throw error
+            }
+            return snapshot
+        }
     }
 
     private static func cueOnlyBoardAttachment(
         in workspace: BoardWorkspace
     ) -> CandidateTurnBoardAttachment? {
-        if workspace.draft.elements.isEmpty {
-            return .noBoard
-        }
-        guard let latest = workspace.revisions.last,
-              latest.document == workspace.draft else {
-            return nil
-        }
-        return .revision(latest.id)
+        BoardHandoffAttachmentPolicy.currentDraftAttachment(in: workspace)
     }
 
     /// Patient Auto is intentionally a Shadow policy in this slice. It stores

--- a/Sources/InterviewArcLiveCore/SegmentSpeechCoordinator.swift
+++ b/Sources/InterviewArcLiveCore/SegmentSpeechCoordinator.swift
@@ -682,10 +682,66 @@ public final class SegmentSpeechCoordinator {
               recordedSegment.selectedCandidateID != previouslySelectedCandidateID else {
             return recorded
         }
-        return await evaluateEndpointIfNeeded(
-            triggerSegmentID: segmentID,
-            sourceCommandID: commandID
-        )
+        switch snapshot.turnMode {
+        case .cueOnly:
+            return try await handOffCueIfNeeded(
+                triggerSegmentID: segmentID,
+                sourceCommandID: commandID
+            )
+        case .patientAuto:
+            return await evaluateEndpointIfNeeded(
+                triggerSegmentID: segmentID,
+                sourceCommandID: commandID
+            )
+        case .manual:
+            return snapshot
+        }
+    }
+
+    /// Cue Only consumes only a newly selected, durably stored transcript.
+    /// It uses the same idempotent Hand off command as the visible control and
+    /// never invokes the semantic endpoint classifier.
+    private func handOffCueIfNeeded(
+        triggerSegmentID: SegmentID,
+        sourceCommandID: CommandID
+    ) async throws -> InterviewRoomSnapshot {
+        guard snapshot.phase == .candidateFloor,
+              snapshot.turnMode == .cueOnly else {
+            return snapshot
+        }
+        let draftSegments = snapshot.segments.filter { $0.committedTurnID == nil }
+        guard !draftSegments.contains(where: {
+            $0.lifecycle != .excluded && $0.selectedCandidate == nil
+        }),
+        let trigger = draftSegments.first(where: { $0.id == triggerSegmentID }),
+        let body = trigger.selectedCandidate?.body,
+        CueOnlyHandoffPolicy.reason(in: body) != nil,
+        let boardAttachment = Self.cueOnlyBoardAttachment(in: snapshot.board) else {
+            return snapshot
+        }
+
+        return try await applyAndPublish(
+            .handOffSegmentsWithBoard(
+                commandID: InterviewRoomSession.derivedCommandID(
+                    source: sourceCommandID,
+                    operation: "cue-only-hand-off"
+                ),
+                boardAttachment: boardAttachment
+            )
+        ).snapshot
+    }
+
+    private static func cueOnlyBoardAttachment(
+        in workspace: BoardWorkspace
+    ) -> CandidateTurnBoardAttachment? {
+        if workspace.draft.elements.isEmpty {
+            return .noBoard
+        }
+        guard let latest = workspace.revisions.last,
+              latest.document == workspace.draft else {
+            return nil
+        }
+        return .revision(latest.id)
     }
 
     /// Patient Auto is intentionally a Shadow policy in this slice. It stores

--- a/Tests/InterviewArcLiveCoreTests/CueOnlyHandoffPolicyTests.swift
+++ b/Tests/InterviewArcLiveCoreTests/CueOnlyHandoffPolicyTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+@testable import InterviewArcLiveCore
+
+final class CueOnlyHandoffPolicyTests: XCTestCase {
+    func testRecognizesConservativeTerminalCueFamilies() {
+        let fixtures: [(String, CueOnlyHandoffReason)] = [
+            ("The write path is durable. That’s my answer.", .explicitCompletion),
+            ("I would monitor queue age — I’m done!", .explicitCompletion),
+            ("Can you clarify the question?", .interviewerClarification),
+            ("I covered the storage tradeoff. Could you repeat the question?", .interviewerClarification),
+            ("Could you give me a hint?", .hintRequest),
+            ("I am stuck on partitioning; what should I consider next?", .hintRequest),
+        ]
+
+        for (transcript, reason) in fixtures {
+            XCTAssertEqual(
+                CueOnlyHandoffPolicy.reason(in: transcript),
+                reason,
+                transcript
+            )
+        }
+    }
+
+    func testRejectsNonterminalAmbiguousAndQuotedLanguage() {
+        let fixtures = [
+            "I’m done with the cache layer, and next I will cover the database.",
+            "Should the queue be durable?",
+            "A candidate might say “I’m done.”",
+            "For example, hand off.",
+            "The phrase your turn is useful in a protocol.",
+            "I am still thinking through the tradeoff.",
+            "",
+        ]
+
+        for transcript in fixtures {
+            XCTAssertNil(CueOnlyHandoffPolicy.reason(in: transcript), transcript)
+        }
+    }
+}

--- a/Tests/InterviewArcLiveCoreTests/CueOnlyHandoffPolicyTests.swift
+++ b/Tests/InterviewArcLiveCoreTests/CueOnlyHandoffPolicyTests.swift
@@ -6,8 +6,9 @@ final class CueOnlyHandoffPolicyTests: XCTestCase {
         let fixtures: [(String, CueOnlyHandoffReason)] = [
             ("The write path is durable. That’s my answer.", .explicitCompletion),
             ("I would monitor queue age — I’m done!", .explicitCompletion),
-            ("Can you clarify the question?", .interviewerClarification),
-            ("I covered the storage tradeoff. Could you repeat the question?", .interviewerClarification),
+            ("Can you clarify the question?", .interviewerQuestion),
+            ("I covered the storage tradeoff. Could you repeat the question?", .interviewerQuestion),
+            ("How many daily users should I design for?", .interviewerQuestion),
             ("Could you give me a hint?", .hintRequest),
             ("I am stuck on partitioning; what should I consider next?", .hintRequest),
         ]
@@ -24,7 +25,7 @@ final class CueOnlyHandoffPolicyTests: XCTestCase {
     func testRejectsNonterminalAmbiguousAndQuotedLanguage() {
         let fixtures = [
             "I’m done with the cache layer, and next I will cover the database.",
-            "Should the queue be durable?",
+            "I am deciding whether the queue should be durable.",
             "A candidate might say “I’m done.”",
             "For example, hand off.",
             "The phrase your turn is useful in a protocol.",

--- a/Tests/InterviewArcLiveCoreTests/SegmentLifecycleTests.swift
+++ b/Tests/InterviewArcLiveCoreTests/SegmentLifecycleTests.swift
@@ -845,6 +845,184 @@ final class SegmentLifecycleTests: XCTestCase {
         }
     }
 
+    func testCueOnlyTerminalCueHandsOffVerbatimWithoutSemanticClassifier() async throws {
+        let body = "The queue absorbs bursts. That’s my answer."
+        let classifier = RecordingSemanticEndpointClassifier(results: [])
+        let runtime = CountingInterviewerRuntime()
+        let coordinator = try await SegmentSpeechCoordinator.open(
+            sessionID: SessionID("cue-only-handoff"),
+            activityID: "cue-only-activity",
+            activityPrompt: try fixtureActivityPrompt(),
+            turnMode: .cueOnly,
+            manifestStore: InMemorySessionManifestStore(),
+            interviewerRuntime: runtime,
+            recording: StubSegmentRecorder(
+                capture: try capturedAudio(fileName: "cue-only.m4a")
+            ),
+            transcriber: SequencedSegmentTranscriber(
+                results: [
+                    .success(
+                        SegmentTranscriptionResult(
+                            body: body,
+                            quality: .verified
+                        )
+                    )
+                ]
+            ),
+            credentialReader: FixedCredentialReader(value: "credential"),
+            semanticEndpointClassifier: classifier
+        )
+        _ = try await coordinator.giveCandidateFloor(
+            commandID: CommandID("cue-only-floor")
+        )
+        _ = try await coordinator.beginSegment(
+            commandID: CommandID("cue-only-begin")
+        )
+
+        let completed = try await coordinator.finishSegment(
+            commandID: CommandID("cue-only-finish"),
+            transcriptionCommandID: CommandID("cue-only-transcribe")
+        )
+
+        XCTAssertEqual(completed.phase, .interviewerTurn)
+        XCTAssertEqual(completed.turns.count, 2)
+        guard case .candidate(let candidate) = completed.turns.first else {
+            return XCTFail("Expected one Candidate Turn")
+        }
+        XCTAssertEqual(candidate.transcript.body, body)
+        XCTAssertEqual(candidate.boardAttachment, .noBoard)
+        let classifierCalls = await classifier.invocationCount()
+        let runtimeCalls = await runtime.invocationCount()
+        XCTAssertEqual(classifierCalls, 0)
+        XCTAssertEqual(runtimeCalls, 1)
+    }
+
+    func testCueOnlyDoesNotAttachDirtyBoardOrCommitTurn() async throws {
+        let coordinator = try await SegmentSpeechCoordinator.open(
+            sessionID: SessionID("cue-only-dirty-board"),
+            activityID: "cue-only-dirty-board-activity",
+            activityPrompt: try fixtureActivityPrompt(),
+            turnMode: .cueOnly,
+            manifestStore: InMemorySessionManifestStore(),
+            interviewerRuntime: fixtureRuntime(),
+            recording: StubSegmentRecorder(
+                capture: try capturedAudio(fileName: "cue-only-dirty-board.m4a")
+            ),
+            transcriber: SequencedSegmentTranscriber(
+                results: [
+                    .success(
+                        SegmentTranscriptionResult(
+                            body: "That is my answer.",
+                            quality: .verified
+                        )
+                    )
+                ]
+            ),
+            credentialReader: FixedCredentialReader(value: "credential")
+        )
+        _ = try await coordinator.giveCandidateFloor(
+            commandID: CommandID("cue-only-dirty-floor")
+        )
+        let dirtyBoard = try BoardDocument(
+            canvas: BoardCanvas(size: BoardSize(width: 1_200, height: 800)),
+            elements: [
+                .box(
+                    BoardBox(
+                        id: BoardElementID("cue-only-service"),
+                        frame: BoardRect(
+                            origin: BoardPoint(x: 80, y: 80),
+                            size: BoardSize(width: 160, height: 100)
+                        ),
+                        label: "Service"
+                    )
+                )
+            ]
+        )
+        _ = try await coordinator.updateBoardDraft(
+            dirtyBoard,
+            commandID: CommandID("cue-only-dirty-board-update")
+        )
+        _ = try await coordinator.beginSegment(
+            commandID: CommandID("cue-only-dirty-begin")
+        )
+
+        let completed = try await coordinator.finishSegment(
+            commandID: CommandID("cue-only-dirty-finish"),
+            transcriptionCommandID: CommandID("cue-only-dirty-transcribe")
+        )
+
+        XCTAssertEqual(completed.phase, .candidateFloor)
+        XCTAssertTrue(completed.turns.isEmpty)
+        XCTAssertEqual(completed.board.draft, dirtyBoard)
+        XCTAssertTrue(completed.board.revisions.isEmpty)
+    }
+
+    func testCueOnlyAttachesTheExactSavedBoardRevision() async throws {
+        let coordinator = try await SegmentSpeechCoordinator.open(
+            sessionID: SessionID("cue-only-saved-board"),
+            activityID: "cue-only-saved-board-activity",
+            activityPrompt: try fixtureActivityPrompt(),
+            turnMode: .cueOnly,
+            manifestStore: InMemorySessionManifestStore(),
+            interviewerRuntime: fixtureRuntime(),
+            recording: StubSegmentRecorder(
+                capture: try capturedAudio(fileName: "cue-only-saved-board.m4a")
+            ),
+            transcriber: SequencedSegmentTranscriber(
+                results: [
+                    .success(
+                        SegmentTranscriptionResult(
+                            body: "Could you give me a hint?",
+                            quality: .verified
+                        )
+                    )
+                ]
+            ),
+            credentialReader: FixedCredentialReader(value: "credential")
+        )
+        _ = try await coordinator.giveCandidateFloor(
+            commandID: CommandID("cue-only-saved-floor")
+        )
+        let document = try BoardDocument(
+            canvas: BoardCanvas(size: BoardSize(width: 1_200, height: 800)),
+            elements: [
+                .box(
+                    BoardBox(
+                        id: BoardElementID("cue-only-saved-service"),
+                        frame: BoardRect(
+                            origin: BoardPoint(x: 100, y: 100),
+                            size: BoardSize(width: 180, height: 110)
+                        ),
+                        label: "Gateway"
+                    )
+                )
+            ]
+        )
+        _ = try await coordinator.updateBoardDraft(
+            document,
+            commandID: CommandID("cue-only-saved-board-update")
+        )
+        let saved = try await coordinator.saveBoardRevision(
+            commandID: CommandID("cue-only-save-board")
+        )
+        let revision = try XCTUnwrap(saved.board.revisions.last)
+        _ = try await coordinator.beginSegment(
+            commandID: CommandID("cue-only-saved-begin")
+        )
+
+        let completed = try await coordinator.finishSegment(
+            commandID: CommandID("cue-only-saved-finish"),
+            transcriptionCommandID: CommandID("cue-only-saved-transcribe")
+        )
+
+        guard case .candidate(let candidate) = completed.turns.first else {
+            return XCTFail("Expected one Candidate Turn")
+        }
+        XCTAssertEqual(candidate.boardAttachment, .revision(revision.id))
+        XCTAssertEqual(completed.board.revisions, [revision])
+        XCTAssertEqual(completed.phase, .interviewerTurn)
+    }
+
     func testPatientAutoPersistsAuthorizationBeforeExactShadowContextAndProposal() async throws {
         let store = InMemorySessionManifestStore()
         let session = try await makeCandidateFloorSession(

--- a/Tests/InterviewArcLiveCoreTests/SegmentLifecycleTests.swift
+++ b/Tests/InterviewArcLiveCoreTests/SegmentLifecycleTests.swift
@@ -1023,6 +1023,57 @@ final class SegmentLifecycleTests: XCTestCase {
         XCTAssertEqual(completed.phase, .interviewerTurn)
     }
 
+    func testCueOnlyReturnsDurableRetryStateWhenInterviewerFailsAfterHandOff() async throws {
+        let store = InMemorySessionManifestStore()
+        let runtime = FailingCueOnlyInterviewerRuntime()
+        let coordinator = try await SegmentSpeechCoordinator.open(
+            sessionID: SessionID("cue-only-interviewer-retry"),
+            activityID: "cue-only-interviewer-retry-activity",
+            activityPrompt: try fixtureActivityPrompt(),
+            turnMode: .cueOnly,
+            manifestStore: store,
+            interviewerRuntime: runtime,
+            recording: StubSegmentRecorder(
+                capture: try capturedAudio(fileName: "cue-only-interviewer-retry.m4a")
+            ),
+            transcriber: SequencedSegmentTranscriber(
+                results: [
+                    .success(
+                        SegmentTranscriptionResult(
+                            body: "That is my answer.",
+                            quality: .verified
+                        )
+                    )
+                ]
+            ),
+            credentialReader: FixedCredentialReader(value: "credential")
+        )
+        _ = try await coordinator.giveCandidateFloor(
+            commandID: CommandID("cue-only-interviewer-retry-floor")
+        )
+        _ = try await coordinator.beginSegment(
+            commandID: CommandID("cue-only-interviewer-retry-begin")
+        )
+
+        let retryable = try await coordinator.finishSegment(
+            commandID: CommandID("cue-only-interviewer-retry-finish"),
+            transcriptionCommandID: CommandID("cue-only-interviewer-retry-transcribe")
+        )
+
+        XCTAssertEqual(retryable.phase, .interviewerProcessing)
+        XCTAssertEqual(retryable.turns.count, 1)
+        guard case .candidate(let candidate) = retryable.turns.first else {
+            return XCTFail("Expected the durable Candidate Turn")
+        }
+        XCTAssertEqual(candidate.transcript.body, "That is my answer.")
+        XCTAssertEqual(candidate.boardAttachment, .noBoard)
+        let runtimeCalls = await runtime.invocationCount()
+        XCTAssertEqual(runtimeCalls, 1)
+        let durable = await store.load(sessionID: retryable.sessionID)
+        XCTAssertEqual(durable?.phase, .interviewerProcessing)
+        XCTAssertEqual(durable?.turns, retryable.turns)
+    }
+
     func testPatientAutoPersistsAuthorizationBeforeExactShadowContextAndProposal() async throws {
         let store = InMemorySessionManifestStore()
         let session = try await makeCandidateFloorSession(
@@ -2241,6 +2292,23 @@ private actor CountingInterviewerRuntime: InterviewerRuntime {
             displayMarkdown: "What trade-off comes next?",
             spokenText: "What trade-off comes next?"
         )
+    }
+
+    func invocationCount() -> Int { calls }
+}
+
+private enum CueOnlyInterviewerRuntimeError: Error {
+    case unavailable
+}
+
+private actor FailingCueOnlyInterviewerRuntime: InterviewerRuntime {
+    private var calls = 0
+
+    func respond(
+        to request: InterviewerRequest
+    ) throws -> CanonicalInterviewerResponse {
+        calls += 1
+        throw CueOnlyInterviewerRuntimeError.unavailable
     }
 
     func invocationCount() -> Int { calls }

--- a/Tests/InterviewArcLiveTests/SystemDesignBoardModelTests.swift
+++ b/Tests/InterviewArcLiveTests/SystemDesignBoardModelTests.swift
@@ -113,6 +113,10 @@ final class SystemDesignBoardModelTests: XCTestCase {
         XCTAssertEqual(model.boardRevisionStatus, "Viewing revision 1 · read-only")
         XCTAssertNil(model.boardSelectedElementIDForPresentation)
         XCTAssertEqual(model.boardAttachmentForHandOff, .revision(revision.id))
+        XCTAssertEqual(
+            model.currentBoardDraftAttachmentForHandOff,
+            .revision(latest.id)
+        )
 
         await model.returnToBoardDraft()
         XCTAssertFalse(model.isInspectingBoardRevision)
@@ -123,6 +127,10 @@ final class SystemDesignBoardModelTests: XCTestCase {
         model.applyBoardAction(.updateLabel(id: boxID, text: "Dirty gateway"))
         await model.waitForBoardPersistence()
         XCTAssertNil(model.boardAttachmentForHandOff)
+
+        await model.inspectBoardRevision(revision.id)
+        XCTAssertEqual(model.boardAttachmentForHandOff, .revision(revision.id))
+        XCTAssertNil(model.currentBoardDraftAttachmentForHandOff)
     }
 
     func testExplicitExportRecordsOnlyACompletePrivateBundle() async throws {

--- a/Tests/InterviewArcLiveTests/SystemDesignRoomModelTests.swift
+++ b/Tests/InterviewArcLiveTests/SystemDesignRoomModelTests.swift
@@ -94,19 +94,19 @@ final class SystemDesignRoomModelTests: XCTestCase {
         }
     }
 
-    func testTurnModeSurfaceOffersOnlyManualAndPatientAutoShadow() {
+    func testTurnModeSurfaceOffersCueOnlyAsTheNewSessionDefault() {
         let model = SystemDesignRoomModel(
             codexRuntime: CodexRuntimeFixture(readiness: .ready)
         )
 
-        XCTAssertEqual(model.availableTurnModes, [.manual, .patientAuto])
-        XCTAssertFalse(model.availableTurnModes.contains(.cueOnly))
-        XCTAssertEqual(model.turnMode, .manual)
+        XCTAssertEqual(model.availableTurnModes, [.cueOnly, .manual, .patientAuto])
+        XCTAssertEqual(model.turnMode, .cueOnly)
+        XCTAssertEqual(model.turnModeTitle(.cueOnly), "Cue Only")
         XCTAssertEqual(model.turnModeTitle(.manual), "Manual")
         XCTAssertEqual(model.turnModeTitle(.patientAuto), "Patient Auto · Shadow")
         XCTAssertEqual(
             model.endpointShadowPresentation.detail,
-            "Semantic endpoint calls are off. Hand off remains explicit."
+            "A terminal finish, clarification, or hint cue Hands off after its transcript is saved. The Hand off control remains available."
         )
     }
 

--- a/Tests/InterviewArcLiveTests/SystemDesignRoomModelTests.swift
+++ b/Tests/InterviewArcLiveTests/SystemDesignRoomModelTests.swift
@@ -106,7 +106,7 @@ final class SystemDesignRoomModelTests: XCTestCase {
         XCTAssertEqual(model.turnModeTitle(.patientAuto), "Patient Auto · Shadow")
         XCTAssertEqual(
             model.endpointShadowPresentation.detail,
-            "A terminal finish, clarification, or hint cue Hands off after its transcript is saved. The Hand off control remains available."
+            "A terminal finish, direct question, or hint cue triggers Hand off after its transcript is saved. The Hand off control remains available."
         )
     }
 


### PR DESCRIPTION
## **User description**
Closes #32

## Summary

- add a conservative deterministic Cue Only policy for terminal completion,
  clarification, and hint cues
- make Cue Only the default for new local sessions while preserving restored
  Turn Mode selections
- route recognized cues through the existing durable, idempotent Hand off
  operation without semantic-classifier calls
- preserve exact transcript and Board evidence, blocking on a dirty nonempty
  Board until the candidate saves a revision
- publish truthful Cue Only copy and forward a successful automatic turn to
  the existing interviewer-speech observer

## Verification

- strict Swift 6 Core emit/link with complete concurrency and warnings as errors
- strict Swift 6 full-app emit/link against actual Core, Codex, and speech-output
  modules plus compile-only external-adapter seams
- changed Core/model tests typecheck with warnings as errors
- direct runtime harness: recognition, quoted/ambiguous rejection, exact
  transcript handoff, zero classifier calls, and dirty-Board refusal
- changed Swift parse and `git diff --check`

Local SwiftPM cannot compile its manifest on this host because the selected
Command Line Tools compiler and default SDK revisions differ. Hosted macOS CI
remains the authoritative complete package/XCTest gate.


___

## **CodeAnt-AI Description**
Enable truthful automatic handoff for Cue Only sessions

### What Changed
- New sessions use Cue Only by default, with Manual and Patient Auto still available.
- Saved transcripts ending in a clear completion, direct question, or hint request automatically hand off the turn without semantic analysis.
- Quoted, example, or ambiguous phrases do not trigger an automatic handoff.
- Automatic handoff preserves the exact transcript and attaches only an empty Board or the latest matching saved revision; unsaved Board changes keep the session on the candidate floor with guidance.
- If the interviewer response fails after handoff, the candidate turn remains saved in a retryable state.
- Cue Only status text explains when a cue is detected and when the Board or remaining segments still require action.

### Impact
`✅ Faster handoff after clear completion cues`
`✅ Fewer accidental handoffs from quoted or ambiguous phrases`
`✅ Preserved transcript and saved Board evidence`
`✅ Recoverable interviewer failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
