### PR TITLE
Make Brief and Notes real work surfaces

### DIFF
--- a/Sources/InterviewArcLive/InterviewArcLiveApp.swift
+++ b/Sources/InterviewArcLive/InterviewArcLiveApp.swift
@@ -1,5 +1,35 @@
 import AppKit
 
+@MainActor
+final class InterviewArcLiveTerminationGate {
+    typealias Preparation = @MainActor () async -> Bool
+    typealias Reply = @MainActor (Bool) -> Void
+
+    private let preparation: Preparation
+    private var preparationTask: Task<Void, Never>?
+    private var pendingReplies: [Reply] = []
+
+    init(preparation: @escaping Preparation) {
+        self.preparation = preparation
+    }
+
+    func requestTermination(
+        reply: @escaping Reply
+    ) -> NSApplication.TerminateReply {
+        pendingReplies.append(reply)
+        guard preparationTask == nil else { return .terminateLater }
+        preparationTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            let shouldTerminate = await preparation()
+            preparationTask = nil
+            let replies = pendingReplies
+            pendingReplies.removeAll()
+            replies.forEach { $0(shouldTerminate) }
+        }
+        return .terminateLater
+    }
+}
+
 @main
 @MainActor
 final class InterviewArcLiveApp: NSObject, NSApplicationDelegate {
@@ -7,6 +37,7 @@ final class InterviewArcLiveApp: NSObject, NSApplicationDelegate {
 
     private let model = SystemDesignRoomModel()
     private var presentationCoordinator: InterviewRoomPresentationCoordinator?
+    private var terminationGate: InterviewArcLiveTerminationGate?
 
     static func main() {
         let application = NSApplication.shared
@@ -20,6 +51,9 @@ final class InterviewArcLiveApp: NSObject, NSApplicationDelegate {
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         installMainMenu()
+        terminationGate = InterviewArcLiveTerminationGate { [weak model] in
+            await model?.prepareLocalPersistenceForTermination() ?? true
+        }
         let coordinator = InterviewRoomPresentationCoordinator(model: model)
         presentationCoordinator = coordinator
         coordinator.start()
@@ -37,6 +71,15 @@ final class InterviewArcLiveApp: NSObject, NSApplicationDelegate {
         _ sender: NSApplication
     ) -> Bool {
         false
+    }
+
+    func applicationShouldTerminate(
+        _ sender: NSApplication
+    ) -> NSApplication.TerminateReply {
+        guard let terminationGate else { return .terminateNow }
+        return terminationGate.requestTermination { [weak sender] shouldTerminate in
+            sender?.reply(toApplicationShouldTerminate: shouldTerminate)
+        }
     }
 
     func applicationWillTerminate(_ notification: Notification) {

--- a/Sources/InterviewArcLive/SystemDesignBoardView.swift
+++ b/Sources/InterviewArcLive/SystemDesignBoardView.swift
@@ -20,9 +20,7 @@ struct SystemDesignBoardView: View {
         VStack(spacing: 0) {
             revisionRail
             Divider().overlay(BoardPalette.line)
-            toolRail
-            Divider().overlay(BoardPalette.line)
-            canvas
+            workSurfaceContent
         }
         .background(BoardPalette.canvas)
         .foregroundStyle(BoardPalette.navy)
@@ -30,11 +28,13 @@ struct SystemDesignBoardView: View {
             revisionHistoryBrowser
         }
         .onDeleteCommand {
-            guard !model.isInspectingBoardRevision else { return }
+            guard model.selectedWorkSurface == .board,
+                  !model.isInspectingBoardRevision else { return }
             model.applyBoardAction(.deleteSelection)
         }
         .onExitCommand {
-            guard !model.isInspectingBoardRevision else { return }
+            guard model.selectedWorkSurface == .board,
+                  !model.isInspectingBoardRevision else { return }
             if editingElementID != nil {
                 cancelEditing()
             } else {
@@ -43,20 +43,37 @@ struct SystemDesignBoardView: View {
                 model.applyBoardAction(.setTool(.select))
             }
         }
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel("System design board")
-        .accessibilityValue(boardAccessibilityValue)
-        .boardRootAccessibilityActions(
-            isReadOnly: model.isInspectingBoardRevision,
-            addTitle: "Add \(newBoxKind.displayName) node",
-            add: addBoxFromKeyboard,
-            next: { selectRelativeElement(forward: true) },
-            previous: { selectRelativeElement(forward: false) }
-        )
         .task(id: interactionFeedback) {
             guard interactionFeedback != nil else { return }
             try? await Task.sleep(for: .seconds(2))
             interactionFeedback = nil
+        }
+    }
+
+    @ViewBuilder
+    private var workSurfaceContent: some View {
+        switch model.selectedWorkSurface {
+        case .board:
+            VStack(spacing: 0) {
+                toolRail
+                Divider().overlay(BoardPalette.line)
+                canvas
+            }
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel("System design board")
+            .accessibilityValue(boardAccessibilityValue)
+            .accessibilityIdentifier("work-surface-panel-board")
+            .boardRootAccessibilityActions(
+                isReadOnly: model.isInspectingBoardRevision,
+                addTitle: "Add \(newBoxKind.displayName) node",
+                add: addBoxFromKeyboard,
+                next: { selectRelativeElement(forward: true) },
+                previous: { selectRelativeElement(forward: false) }
+            )
+        case .brief:
+            briefSurface
+        case .notes:
+            notesSurface
         }
     }
 
@@ -80,37 +97,38 @@ struct SystemDesignBoardView: View {
         )
 
         return HStack(spacing: compact ? BoardRailWidthBudget.compactRevisionSpacing : 0) {
+            workSurfaceSwitcher(compact: compact)
             if compact {
-                tab("Board", isSelected: true)
-                    .frame(width: BoardRailWidthBudget.compactTabWidth)
-                    .accessibilityHint("Brief and Notes are not available in this version")
-                revisionStatus(compact: true)
-                Spacer(minLength: BoardRailWidthBudget.compactRevisionSpacerWidth)
-                revisionPrimaryAction(compact: true)
-                revisionMenu(compact: true)
-                attachRevisionButton(compact: true)
-                exportRevisionButton(compact: true)
-            } else {
-                HStack(spacing: 30) {
-                    tab("Board", isSelected: true)
-                    tab("Brief", isSelected: false)
-                    tab("Notes", isSelected: false)
+                if model.selectedWorkSurface == .board {
+                    revisionStatus(compact: true)
+                } else {
+                    workSurfaceStatus(compact: true)
                 }
-                .fixedSize()
-
+                Spacer(minLength: BoardRailWidthBudget.compactRevisionSpacerWidth)
+                if model.selectedWorkSurface == .board {
+                    revisionPrimaryAction(compact: true)
+                    revisionMenu(compact: true)
+                    attachRevisionButton(compact: true)
+                    exportRevisionButton(compact: true)
+                }
+            } else {
                 Spacer(
                     minLength: BoardRailWidthBudget.wideRevisionGroupGapMinimum
                 )
 
-                HStack(spacing: 18) {
-                    revisionStatus(compact: false)
-                    revisionPrimaryAction(compact: false)
-                    revisionMenu(compact: false)
-                    railDivider
-                    attachRevisionButton(compact: false)
-                    exportRevisionButton(compact: false)
+                if model.selectedWorkSurface == .board {
+                    HStack(spacing: 18) {
+                        revisionStatus(compact: false)
+                        revisionPrimaryAction(compact: false)
+                        revisionMenu(compact: false)
+                        railDivider
+                        attachRevisionButton(compact: false)
+                        exportRevisionButton(compact: false)
+                    }
+                    .fixedSize()
+                } else {
+                    workSurfaceStatus(compact: false)
                 }
-                .fixedSize()
             }
         }
         .font(.system(.callout, design: .rounded))
@@ -135,6 +153,59 @@ struct SystemDesignBoardView: View {
             count += 1
         }
         return count
+    }
+
+    private func workSurfaceSwitcher(compact: Bool) -> some View {
+        HStack(spacing: compact ? 4 : 22) {
+            ForEach(SystemDesignWorkSurfacePane.allCases) { pane in
+                WorkSurfaceTab(
+                    pane: pane,
+                    isSelected: model.selectedWorkSurface == pane,
+                    compact: compact,
+                    isEnabled: model.snapshot != nil
+                ) {
+                    model.selectWorkSurface(pane)
+                }
+            }
+        }
+        .fixedSize()
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Work surfaces")
+    }
+
+    private func workSurfaceStatus(compact: Bool) -> some View {
+        let text: String
+        let icon: String
+        let isError: Bool
+        switch model.selectedWorkSurface {
+        case .board:
+            text = model.boardRevisionStatus
+            icon = revisionStatusIcon
+            isError = model.boardErrorMessage != nil
+        case .brief:
+            text = compact ? "Activity brief" : "Activity brief · read-only"
+            icon = "doc.text"
+            isError = false
+        case .notes:
+            text = model.candidateNotesSavePresentation.text
+            icon = model.candidateNotesSavePresentation == .saving
+                ? "arrow.triangle.2.circlepath"
+                : "checkmark.circle"
+            if case .error = model.candidateNotesSavePresentation {
+                isError = true
+            } else {
+                isError = false
+            }
+        }
+        return Label(text, systemImage: icon)
+            .font(.system(.callout, design: .rounded))
+            .foregroundStyle(isError ? BoardPalette.errorText : BoardPalette.muted)
+            .lineLimit(compact ? 1 : 2)
+            .frame(minHeight: BoardLayoutMetrics.minimumHitTarget)
+            .help(text)
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("\(model.selectedWorkSurface.title) status")
+            .accessibilityValue(text)
     }
 
     private func revisionStatus(compact: Bool) -> some View {
@@ -353,23 +424,159 @@ struct SystemDesignBoardView: View {
         }
     }
 
-    private func tab(_ title: String, isSelected: Bool) -> some View {
-        Text(title)
-            .font(.system(.body, design: .rounded, weight: isSelected ? .semibold : .regular))
-            .foregroundStyle(isSelected ? BoardPalette.ink : BoardPalette.muted)
-            .frame(minHeight: BoardLayoutMetrics.sectionLabelHeight)
-            .overlay(alignment: .bottom) {
-                if isSelected {
-                    Rectangle()
-                        .fill(BoardPalette.violet)
-                        .frame(height: 3)
+    private var briefSurface: some View {
+        let prompt = model.activityPromptForPresentation
+        return ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Label("System design · \(prompt.stage)", systemImage: "scope")
+                        .font(.system(.callout, design: .rounded, weight: .semibold))
+                        .foregroundStyle(BoardPalette.violet)
+                    Text(prompt.question)
+                        .font(.system(size: 30, weight: .semibold, design: .rounded))
+                        .foregroundStyle(BoardPalette.ink)
+                        .textSelection(.enabled)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Divider().overlay(BoardPalette.line)
+
+                if prompt.requestedParts.isEmpty {
+                    Text("No additional requested parts were provided for this activity.")
+                        .font(.system(.body, design: .rounded))
+                        .foregroundStyle(BoardPalette.muted)
+                } else {
+                    VStack(alignment: .leading, spacing: 14) {
+                        Text("Requested parts")
+                            .font(.system(.headline, design: .rounded, weight: .semibold))
+                        ForEach(Array(prompt.requestedParts.enumerated()), id: \.offset) { index, part in
+                            HStack(alignment: .firstTextBaseline, spacing: 12) {
+                                Text("\(index + 1)")
+                                    .font(.system(.caption, design: .rounded, weight: .bold))
+                                    .foregroundStyle(BoardPalette.violet)
+                                    .frame(width: 22, height: 22)
+                                    .background(
+                                        BoardPalette.violet.opacity(0.10),
+                                        in: Circle()
+                                    )
+                                Text(part)
+                                    .font(.system(.body, design: .rounded))
+                                    .foregroundStyle(BoardPalette.navy)
+                                    .textSelection(.enabled)
+                                    .fixedSize(horizontal: false, vertical: true)
+                            }
+                        }
+                    }
                 }
             }
-            .accessibilityLabel(
-                isSelected
-                    ? "Board, current section"
-                    : "\(title), not available in this version"
-            )
+            .frame(maxWidth: 760, alignment: .leading)
+            .padding(.horizontal, 32)
+            .padding(.vertical, 28)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .background(BoardPalette.paper)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Activity brief")
+        .accessibilityIdentifier("work-surface-panel-brief")
+    }
+
+    private var notesSurface: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: 5) {
+                Text("Private notes")
+                    .font(.system(.title2, design: .rounded, weight: .semibold))
+                    .foregroundStyle(BoardPalette.ink)
+                Text("Scratch space for you. Notes are saved locally and never sent to Mara.")
+                    .font(.system(.callout, design: .rounded))
+                    .foregroundStyle(BoardPalette.muted)
+            }
+            .padding(.horizontal, 24)
+            .padding(.top, 22)
+            .padding(.bottom, 14)
+
+            ZStack(alignment: .topLeading) {
+                if model.candidateNotesDraft.isEmpty {
+                    Text("Capture assumptions, trade-offs, or questions to revisit…")
+                        .font(.system(.body, design: .rounded))
+                        .foregroundStyle(BoardPalette.muted.opacity(0.8))
+                        .padding(.horizontal, 19)
+                        .padding(.vertical, 17)
+                        .allowsHitTesting(false)
+                }
+                TextEditor(
+                    text: Binding(
+                        get: { model.candidateNotesDraft },
+                        set: { newValue in
+                            model.updateCandidateNotesDraft(newValue)
+                        }
+                    )
+                )
+                .font(.system(.body, design: .rounded))
+                .foregroundStyle(BoardPalette.navy)
+                .scrollContentBackground(.hidden)
+                .padding(12)
+                .disabled(!model.canEditCandidateNotes)
+                .accessibilityLabel("Candidate notes")
+                .accessibilityHint(
+                    "Private local scratch notes. These are not included in the transcript or spoken by Mara."
+                )
+            }
+            .background(BoardPalette.canvas)
+            .overlay {
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .stroke(BoardPalette.line, lineWidth: 1)
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+            .padding(.horizontal, 24)
+
+            HStack(spacing: 12) {
+                Label(
+                    model.candidateNotesSavePresentation.text,
+                    systemImage: notesStatusIcon
+                )
+                .foregroundStyle(notesStatusColor)
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel("Notes status")
+                .accessibilityValue(model.candidateNotesSavePresentation.text)
+
+                if case .error = model.candidateNotesSavePresentation {
+                    Button("Retry") {
+                        model.retryCandidateNotesSave()
+                    }
+                    .buttonStyle(.borderless)
+                    .foregroundStyle(BoardPalette.violet)
+                }
+
+                Spacer()
+
+                Text("\(model.candidateNotesDraft.utf8.count.formatted()) / \(CandidateNotes.maximumBodyUTF8Bytes.formatted()) bytes")
+                    .foregroundStyle(BoardPalette.muted)
+                    .accessibilityLabel("Notes size")
+            }
+            .font(.system(.caption, design: .rounded))
+            .padding(.horizontal, 28)
+            .frame(minHeight: 44)
+        }
+        .padding(.bottom, 12)
+        .background(BoardPalette.paper)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Private notes")
+        .accessibilityIdentifier("work-surface-panel-notes")
+    }
+
+    private var notesStatusIcon: String {
+        switch model.candidateNotesSavePresentation {
+        case .saved: "checkmark.circle.fill"
+        case .saving: "arrow.triangle.2.circlepath"
+        case .error: "exclamationmark.triangle.fill"
+        }
+    }
+
+    private var notesStatusColor: Color {
+        if case .error = model.candidateNotesSavePresentation {
+            return BoardPalette.errorText
+        }
+        return BoardPalette.muted
     }
 
     private var toolRail: some View {
@@ -2434,5 +2641,83 @@ enum BoardKeyboardPlacement {
             origin: BoardPoint(x: x, y: y),
             size: BoardSize(width: width, height: height)
         )
+    }
+}
+
+private struct WorkSurfaceTab: View {
+    let pane: SystemDesignWorkSurfacePane
+    let isSelected: Bool
+    let compact: Bool
+    let isEnabled: Bool
+    let action: () -> Void
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var isHovered = false
+
+    var body: some View {
+        Button {
+            action()
+        } label: {
+            Group {
+                if compact {
+                    Image(systemName: pane.systemImage)
+                        .accessibilityHidden(true)
+                } else {
+                    Text(pane.title)
+                }
+            }
+            .font(.system(.body, design: .rounded, weight: isSelected ? .semibold : .regular))
+            .foregroundStyle(isSelected ? BoardPalette.ink : BoardPalette.muted)
+            .frame(minWidth: compact ? 44 : nil, minHeight: 44)
+            .padding(.horizontal, compact ? 0 : 4)
+            .contentShape(Rectangle())
+            .background(
+                isSelected
+                    ? BoardPalette.violet.opacity(0.08)
+                    : (isHovered && isEnabled ? BoardPalette.violet.opacity(0.05) : .clear),
+                in: RoundedRectangle(cornerRadius: 8, style: .continuous)
+            )
+            .overlay(alignment: .bottom) {
+                if isSelected {
+                    Capsule()
+                        .fill(BoardPalette.violet)
+                        .frame(height: 3)
+                }
+            }
+        }
+        .buttonStyle(
+            WorkSurfacePressStyle(
+                isEnabled: isEnabled,
+                reduceMotion: reduceMotion
+            )
+        )
+        .disabled(!isEnabled)
+        .onHover { hovering in
+            isHovered = hovering && isEnabled
+        }
+        .animation(
+            reduceMotion ? nil : .easeOut(duration: 0.14),
+            value: isHovered
+        )
+        .help(pane.title)
+        .accessibilityLabel(pane.title)
+        .accessibilityHint("Shows the \(pane.title) work surface")
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+        .accessibilityIdentifier("work-surface-tab-\(pane.rawValue)")
+    }
+}
+
+private struct WorkSurfacePressStyle: ButtonStyle {
+    let isEnabled: Bool
+    let reduceMotion: Bool
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed && isEnabled ? 0.97 : 1)
+            .opacity(configuration.isPressed && isEnabled ? 0.82 : 1)
+            .animation(
+                reduceMotion ? nil : .easeOut(duration: 0.10),
+                value: configuration.isPressed
+            )
     }
 }

--- a/Sources/InterviewArcLive/SystemDesignRoomModel.swift
+++ b/Sources/InterviewArcLive/SystemDesignRoomModel.swift
@@ -66,11 +66,55 @@ enum BoardRevisionStatusPresentation: Equatable, Sendable {
     }
 }
 
+enum SystemDesignWorkSurfacePane: String, CaseIterable, Identifiable, Sendable {
+    case board
+    case brief
+    case notes
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .board: "Board"
+        case .brief: "Brief"
+        case .notes: "Notes"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .board: "square.grid.2x2"
+        case .brief: "doc.text"
+        case .notes: "note.text"
+        }
+    }
+}
+
+enum CandidateNotesSavePresentation: Equatable, Sendable {
+    case saved
+    case saving
+    case error(String)
+
+    var text: String {
+        switch self {
+        case .saved: "Saved locally"
+        case .saving: "Saving notes…"
+        case .error(let message): message
+        }
+    }
+}
+
 @MainActor
 final class SystemDesignRoomModel: ObservableObject {
     @Published private(set) var snapshot: InterviewRoomSnapshot?
     @Published private(set) var segments: [CandidateSegmentPresentation] = []
-    @Published private(set) var isWorking = false
+    @Published private(set) var isWorking = false {
+        didSet {
+            if !isWorking {
+                startCandidateNotesPersistenceIfNeeded()
+            }
+        }
+    }
     @Published private(set) var statusMessage = "Restoring local session…"
     @Published private(set) var errorMessage: String?
     @Published private(set) var codexReadiness: CodexAppServerReadiness?
@@ -88,6 +132,10 @@ final class SystemDesignRoomModel: ObservableObject {
     @Published private(set) var boardErrorMessage: String?
     @Published private(set) var boardExportMessage: String?
     @Published private(set) var inspectedBoardRevisionID: BoardRevisionID?
+    @Published private(set) var selectedWorkSurface: SystemDesignWorkSurfacePane = .board
+    @Published private(set) var candidateNotesDraft = ""
+    @Published private(set) var candidateNotesSavePresentation: CandidateNotesSavePresentation = .saved
+    @Published private(set) var isFinishingInterview = false
 
     @Published var isCredentialSetupPresented = false
     @Published private(set) var isSavingCredential = false
@@ -134,12 +182,18 @@ final class SystemDesignRoomModel: ObservableObject {
     private var interviewerSpeechCoordinator: InterviewerSpeechCoordinator?
     private var speechPreparationTask: Task<Void, Never>?
     private var audioPlayer: AVAudioPlayer?
-    private var boardPersistenceTail: Task<Void, Never>?
+    private var localPersistenceTail: Task<Void, Never>?
+    private var localPersistenceGeneration = 0
     private var pendingBoardWriteCount = 0
     private var didLoadInitialBoard = false
+    private var candidateNotesPersistenceTask: Task<Void, Never>?
+    private var pendingCandidateNotes: CandidateNotes?
+    private var didLoadInitialCandidateNotes = false
 
     private static let speechMutedPreferenceKey =
         "interviewArcLive.interviewerSpeechMuted"
+    private static let workSurfacePreferenceKey =
+        "interviewArcLive.systemDesignWorkSurface"
 
     init(
         credentialStore: LiveGroqCredentialStore = LiveGroqCredentialStore(),
@@ -165,6 +219,9 @@ final class SystemDesignRoomModel: ObservableObject {
         isSpeechMuted = preferences.bool(
             forKey: Self.speechMutedPreferenceKey
         )
+        selectedWorkSurface = SystemDesignWorkSurfacePane(
+            rawValue: preferences.string(forKey: Self.workSurfacePreferenceKey) ?? ""
+        ) ?? .board
         if let initialCoordinator {
             publish(initialCoordinator.snapshot)
         }
@@ -172,6 +229,56 @@ final class SystemDesignRoomModel: ObservableObject {
 
     var question: String {
         snapshot?.activityPrompt.question ?? activityPrompt.question
+    }
+
+    var activityPromptForPresentation: ActivityPrompt {
+        snapshot?.activityPrompt ?? activityPrompt
+    }
+
+    var canEditCandidateNotes: Bool {
+        guard let snapshot else { return false }
+        return snapshot.phase != .completed && !isFinishingInterview
+    }
+
+    private var hasPendingLocalPersistence: Bool {
+        isBoardSaving
+            || candidateNotesPersistenceTask != nil
+            || pendingCandidateNotes != nil
+    }
+
+    func selectWorkSurface(_ pane: SystemDesignWorkSurfacePane) {
+        guard snapshot != nil else { return }
+        selectedWorkSurface = pane
+        preferences.set(pane.rawValue, forKey: Self.workSurfacePreferenceKey)
+    }
+
+    func updateCandidateNotesDraft(_ body: String) {
+        guard canEditCandidateNotes else { return }
+        do {
+            let notes = try CandidateNotes(body: body)
+            candidateNotesDraft = body
+            pendingCandidateNotes = notes
+            candidateNotesSavePresentation = .saving
+            startCandidateNotesPersistenceIfNeeded()
+        } catch {
+            candidateNotesSavePresentation = .error(
+                "Notes are limited to 16 KB. Shorten the text to continue saving."
+            )
+        }
+    }
+
+    func retryCandidateNotesSave() {
+        guard canEditCandidateNotes else { return }
+        guard let notes = try? CandidateNotes(body: candidateNotesDraft) else {
+            return
+        }
+        pendingCandidateNotes = notes
+        candidateNotesSavePresentation = .saving
+        startCandidateNotesPersistenceIfNeeded()
+    }
+
+    func waitForCandidateNotesPersistence() async {
+        await waitForLocalPersistence()
     }
 
     var isCodexReady: Bool {
@@ -281,7 +388,9 @@ final class SystemDesignRoomModel: ObservableObject {
     }
 
     var canSelectTurnMode: Bool {
-        guard !isWorking, let snapshot else { return false }
+        guard !isWorking,
+              !hasPendingLocalPersistence,
+              let snapshot else { return false }
         return snapshot.phase != .completed
     }
 
@@ -438,7 +547,7 @@ final class SystemDesignRoomModel: ObservableObject {
             phase: snapshot?.phase,
             isWorking: isWorking,
             isInspectingRevision: isInspectingBoardRevision,
-            isSaving: isBoardSaving,
+            isSaving: hasPendingLocalPersistence,
             isExporting: isBoardExporting
         )
     }
@@ -507,11 +616,44 @@ final class SystemDesignRoomModel: ObservableObject {
     }
 
     func waitForBoardPersistence() async {
-        await boardPersistenceTail?.value
+        await waitForLocalPersistence()
+    }
+
+    func prepareLocalPersistenceForTermination() async -> Bool {
+        guard !isWorking else {
+            candidateNotesSavePresentation = .error(
+                "A room operation is still finishing. Quit was cancelled so it can complete safely."
+            )
+            return false
+        }
+
+        startCandidateNotesPersistenceIfNeeded()
+        await waitForLocalPersistence()
+
+        guard pendingCandidateNotes == nil,
+              candidateNotesPersistenceTask == nil,
+              pendingBoardWriteCount == 0 else {
+            candidateNotesSavePresentation = .error(
+                "The latest local changes are still saving. Quit was cancelled so you can retry."
+            )
+            return false
+        }
+        guard let coordinator else { return snapshot == nil }
+        guard coordinator.snapshot.board.draft == boardEditor.document else {
+            boardErrorMessage = "The latest Board edit is not durable yet. Quit was cancelled so you can retry."
+            return false
+        }
+        guard coordinator.snapshot.candidateNotes.body == candidateNotesDraft else {
+            candidateNotesSavePresentation = .error(
+                "The latest Notes text is not durable yet. Quit was cancelled so you can retry."
+            )
+            return false
+        }
+        return true
     }
 
     func saveBoardRevision() async {
-        guard !isBoardSaving,
+        guard !hasPendingLocalPersistence,
               canSaveBoardRevision,
               let coordinator else { return }
         beginBoardWork()
@@ -536,7 +678,8 @@ final class SystemDesignRoomModel: ObservableObject {
     }
 
     func inspectBoardRevision(_ revisionID: BoardRevisionID) async {
-        guard let coordinator,
+        guard !hasPendingLocalPersistence,
+              let coordinator,
               snapshot?.board.revisions.contains(where: { $0.id == revisionID }) == true else {
             boardErrorMessage = "That saved board revision is unavailable."
             return
@@ -556,6 +699,7 @@ final class SystemDesignRoomModel: ObservableObject {
     }
 
     func returnToBoardDraft() async {
+        guard !hasPendingLocalPersistence else { return }
         guard let coordinator else {
             inspectedBoardRevisionID = nil
             return
@@ -575,7 +719,8 @@ final class SystemDesignRoomModel: ObservableObject {
     }
 
     func attachSelectedBoardRevision() async {
-        guard let coordinator,
+        guard !hasPendingLocalPersistence,
+              let coordinator,
               let revision = selectedBoardRevision,
               let turn = snapshot?.turns.reversed().compactMap({ turn -> CandidateTurn? in
                   guard case .candidate(let candidate) = turn,
@@ -603,6 +748,7 @@ final class SystemDesignRoomModel: ObservableObject {
 
     func exportSelectedBoardRevision() async {
         guard !isBoardExporting,
+              !hasPendingLocalPersistence,
               let coordinator,
               canExportBoardRevision,
               let revision = selectedBoardRevision else {
@@ -697,9 +843,9 @@ final class SystemDesignRoomModel: ObservableObject {
             boardErrorMessage = "The room is still restoring. This board change is not durable yet."
             return
         }
-        let previous = boardPersistenceTail
+        let previous = localPersistenceTail
         beginBoardWork()
-        boardPersistenceTail = Task { @MainActor [weak self, weak coordinator] in
+        let operation = Task { @MainActor [weak self, weak coordinator] in
             await previous?.value
             guard let self, let coordinator else { return }
             defer {
@@ -716,6 +862,8 @@ final class SystemDesignRoomModel: ObservableObject {
                 boardErrorMessage = "The latest board change is visible but not saved. Try the action again."
             }
         }
+        localPersistenceGeneration += 1
+        localPersistenceTail = operation
     }
 
     private func beginBoardWork() {
@@ -768,6 +916,7 @@ final class SystemDesignRoomModel: ObservableObject {
 
     var canRecordSegment: Bool {
         guard !isWorking,
+              !hasPendingLocalPersistence,
               hasUsableGroqCredential,
               snapshot?.phase == .candidateFloor else {
             return false
@@ -785,7 +934,9 @@ final class SystemDesignRoomModel: ObservableObject {
     }
 
     var canAct: Bool {
-        guard !isWorking, !isBoardSaving, let snapshot else { return false }
+        guard !isWorking,
+              !hasPendingLocalPersistence,
+              let snapshot else { return false }
         switch snapshot.phase {
         case .candidateFloor:
             guard boardAttachmentForHandOff != nil else { return false }
@@ -995,7 +1146,8 @@ final class SystemDesignRoomModel: ObservableObject {
     func stopRecording() async {
         guard let coordinator,
               let activeSegment = activeCaptureSegment,
-              !isWorking else {
+              !isWorking,
+              !hasPendingLocalPersistence else {
             return
         }
 
@@ -1032,7 +1184,9 @@ final class SystemDesignRoomModel: ObservableObject {
     }
 
     func transcribeSegment(id: String) async {
-        guard let coordinator, !isWorking else { return }
+        guard let coordinator,
+              !isWorking,
+              !hasPendingLocalPersistence else { return }
         guard hasUsableGroqCredential else {
             credentialErrorMessage = "Add a Groq API key before retrying this transcript."
             presentCredentialSetup()
@@ -1067,7 +1221,9 @@ final class SystemDesignRoomModel: ObservableObject {
     }
 
     func excludeSegment(id: String) async {
-        guard let coordinator, !isWorking else { return }
+        guard let coordinator,
+              !isWorking,
+              !hasPendingLocalPersistence else { return }
         guard let segment = draftSegments.first(where: { $0.id.rawValue == id }),
               segment.canExcludeFromAnswer else {
             return
@@ -1179,17 +1335,19 @@ final class SystemDesignRoomModel: ObservableObject {
     /// keeps sole ownership of the model's visible and durable state.
     @discardableResult
     func finishInterview() async -> Bool {
-        guard !isWorking else { return false }
+        guard !isWorking, !hasPendingLocalPersistence else { return false }
         guard let coordinator, let snapshot else { return false }
         if snapshot.phase == .completed {
             return true
         }
 
+        isFinishingInterview = true
         isWorking = true
         errorMessage = nil
         statusMessage = "Ending interview…"
         defer {
             isWorking = false
+            isFinishingInterview = false
             statusMessage = status(for: self.snapshot)
         }
 
@@ -1606,11 +1764,79 @@ final class SystemDesignRoomModel: ObservableObject {
         }
     }
 
+    private func startCandidateNotesPersistenceIfNeeded() {
+        guard !isWorking,
+              pendingCandidateNotes != nil,
+              candidateNotesPersistenceTask == nil else { return }
+        let previous = localPersistenceTail
+        let operation = Task { @MainActor [weak self] in
+            await previous?.value
+            await self?.drainCandidateNotesPersistence()
+        }
+        candidateNotesPersistenceTask = operation
+        localPersistenceGeneration += 1
+        localPersistenceTail = operation
+    }
+
+    private func waitForLocalPersistence() async {
+        while true {
+            startCandidateNotesPersistenceIfNeeded()
+            let observedGeneration = localPersistenceGeneration
+            let observed = localPersistenceTail
+            await observed?.value
+            if pendingCandidateNotes == nil,
+               candidateNotesPersistenceTask == nil,
+               localPersistenceGeneration == observedGeneration {
+                return
+            }
+            if isWorking {
+                return
+            }
+        }
+    }
+
+    private func drainCandidateNotesPersistence() async {
+        while let notes = pendingCandidateNotes {
+            pendingCandidateNotes = nil
+            guard let coordinator else {
+                candidateNotesSavePresentation = .error(
+                    "Wait for the local room to finish restoring, then retry."
+                )
+                break
+            }
+            do {
+                let updated = try await coordinator.updateCandidateNotes(
+                    notes,
+                    commandID: commandID("update-candidate-notes")
+                )
+                publish(updated)
+                if pendingCandidateNotes == nil,
+                   candidateNotesDraft == notes.body {
+                    candidateNotesSavePresentation = .saved
+                }
+            } catch {
+                publish(coordinator.snapshot)
+                candidateNotesSavePresentation = .error(
+                    "Notes were not saved. Your text remains here; choose Retry."
+                )
+                break
+            }
+        }
+        candidateNotesPersistenceTask = nil
+        if pendingCandidateNotes != nil {
+            startCandidateNotesPersistenceIfNeeded()
+        }
+    }
+
     private func publish(_ snapshot: InterviewRoomSnapshot) {
         if !didLoadInitialBoard {
             boardEditor = BoardEditorState(document: snapshot.board.draft)
             inspectedBoardRevisionID = snapshot.board.selectedRevisionID
             didLoadInitialBoard = true
+        }
+        if !didLoadInitialCandidateNotes {
+            candidateNotesDraft = snapshot.candidateNotes.body
+            didLoadInitialCandidateNotes = true
         }
         if self.snapshot != snapshot {
             self.snapshot = snapshot

--- a/Sources/InterviewArcLiveCore/InterviewRoomSession.swift
+++ b/Sources/InterviewArcLiveCore/InterviewRoomSession.swift
@@ -4,6 +4,7 @@ import Foundation
 public enum InterviewRoomCommand: Codable, Sendable, Equatable {
     case giveCandidateFloor(commandID: CommandID)
     case setTurnMode(commandID: CommandID, mode: TurnMode)
+    case updateCandidateNotes(commandID: CommandID, notes: CandidateNotes)
     case beginSegment(commandID: CommandID)
     case finalizeSegment(commandID: CommandID, segmentID: SegmentID)
     case recordSegmentCaptureOutcome(
@@ -98,6 +99,7 @@ public enum InterviewRoomCommand: Codable, Sendable, Equatable {
         switch self {
         case .giveCandidateFloor(let commandID),
              .setTurnMode(let commandID, _),
+             .updateCandidateNotes(let commandID, _),
              .beginSegment(let commandID),
              .finalizeSegment(let commandID, _),
              .recordSegmentCaptureOutcome(let commandID, _, _),
@@ -418,6 +420,7 @@ public actor InterviewRoomSession {
         var endpointEvaluations = manifest.endpointEvaluations
         var interviewerUtterances = manifest.interviewerUtterances
         var board = manifest.board
+        var candidateNotes = manifest.candidateNotes
 
         switch command {
         case .giveCandidateFloor:
@@ -431,6 +434,12 @@ public actor InterviewRoomSession {
                 throw invalidTransition("setTurnMode")
             }
             mode = selectedMode
+
+        case .updateCandidateNotes(_, let notes):
+            guard phase != .completed else {
+                throw invalidTransition("updateCandidateNotes")
+            }
+            candidateNotes = notes
 
         case .beginSegment(let commandID):
             guard phase == .candidateFloor else {
@@ -941,7 +950,8 @@ public actor InterviewRoomSession {
             segments: segments,
             endpointEvaluations: endpointEvaluations,
             interviewerUtterances: interviewerUtterances,
-            board: board
+            board: board,
+            candidateNotes: candidateNotes
         )
     }
 
@@ -1181,6 +1191,7 @@ public actor InterviewRoomSession {
             endpointEvaluations: manifest.endpointEvaluations,
             interviewerUtterances: manifest.interviewerUtterances,
             board: manifest.board,
+            candidateNotes: manifest.candidateNotes,
             revision: candidateRevision,
             appliedCommands: manifest.appliedCommands + [receipt]
         )
@@ -1213,6 +1224,7 @@ public actor InterviewRoomSession {
             endpointEvaluations: manifest.endpointEvaluations,
             interviewerUtterances: manifest.interviewerUtterances,
             board: manifest.board,
+            candidateNotes: manifest.candidateNotes,
             revision: manifest.revision + 1,
             appliedCommands: manifest.appliedCommands + [receipt]
         )
@@ -1270,6 +1282,7 @@ public actor InterviewRoomSession {
             endpointEvaluations: manifest.endpointEvaluations,
             interviewerUtterances: manifest.interviewerUtterances + [utterance],
             board: manifest.board,
+            candidateNotes: manifest.candidateNotes,
             revision: manifest.revision + 1,
             appliedCommands: manifest.appliedCommands
         )
@@ -1286,7 +1299,8 @@ public actor InterviewRoomSession {
         segments: [CandidateSegment],
         endpointEvaluations: [EndpointEvaluation],
         interviewerUtterances: [InterviewerUtterance]? = nil,
-        board: BoardWorkspace? = nil
+        board: BoardWorkspace? = nil,
+        candidateNotes: CandidateNotes? = nil
     ) -> SessionManifest {
         let nextRevision = manifest.revision + 1
         let applied = AppliedCommandRecord(
@@ -1305,6 +1319,7 @@ public actor InterviewRoomSession {
             endpointEvaluations: endpointEvaluations,
             interviewerUtterances: interviewerUtterances ?? manifest.interviewerUtterances,
             board: board ?? manifest.board,
+            candidateNotes: candidateNotes ?? manifest.candidateNotes,
             revision: nextRevision,
             appliedCommands: manifest.appliedCommands + [applied]
         )

--- a/Sources/InterviewArcLiveCore/SegmentSpeechCoordinator.swift
+++ b/Sources/InterviewArcLiveCore/SegmentSpeechCoordinator.swift
@@ -146,6 +146,16 @@ public final class SegmentSpeechCoordinator {
     }
 
     @discardableResult
+    public func updateCandidateNotes(
+        _ notes: CandidateNotes,
+        commandID: CommandID
+    ) async throws -> InterviewRoomSnapshot {
+        try await applyAndPublish(
+            .updateCandidateNotes(commandID: commandID, notes: notes)
+        ).snapshot
+    }
+
+    @discardableResult
     public func retryInterviewerResponse(
         commandID: CommandID
     ) async throws -> InterviewRoomSnapshot {

--- a/Sources/InterviewArcLiveCore/SessionManifest.swift
+++ b/Sources/InterviewArcLiveCore/SessionManifest.swift
@@ -155,6 +155,45 @@ public struct ActivityPrompt: Codable, Sendable, Equatable {
     }
 }
 
+public enum CandidateNotesValidationError: Error, Sendable, Equatable {
+    case bodyTooLong(maximumUTF8Bytes: Int)
+}
+
+/// Private candidate scratch text. It is durable room state, not transcript,
+/// prompt, spoken output, Board evidence, or hosted mutation data.
+public struct CandidateNotes: Codable, Sendable, Equatable {
+    public static let maximumBodyUTF8Bytes = 16 * 1_024
+
+    public let body: String
+
+    public init(body: String) throws {
+        guard body.utf8.count <= Self.maximumBodyUTF8Bytes else {
+            throw CandidateNotesValidationError.bodyTooLong(
+                maximumUTF8Bytes: Self.maximumBodyUTF8Bytes
+            )
+        }
+        self.body = body
+    }
+
+    public static var empty: CandidateNotes {
+        CandidateNotes(validatedBody: "")
+    }
+
+    private init(validatedBody: String) {
+        body = validatedBody
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        try self.init(body: container.decode(String.self))
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(body)
+    }
+}
+
 public enum InterviewRoomPhase: String, Codable, Sendable, Equatable {
     case ready
     case candidateFloor
@@ -308,6 +347,7 @@ public struct SessionManifest: Codable, Sendable, Equatable {
     public let endpointEvaluations: [EndpointEvaluation]
     public let interviewerUtterances: [InterviewerUtterance]
     public let board: BoardWorkspace
+    public let candidateNotes: CandidateNotes
     public let revision: Int
 
     let appliedCommands: [AppliedCommandRecord]
@@ -323,6 +363,7 @@ public struct SessionManifest: Codable, Sendable, Equatable {
         endpointEvaluations: [EndpointEvaluation] = [],
         interviewerUtterances: [InterviewerUtterance] = [],
         board: BoardWorkspace = .empty,
+        candidateNotes: CandidateNotes = .empty,
         revision: Int,
         appliedCommands: [AppliedCommandRecord]
     ) {
@@ -336,6 +377,7 @@ public struct SessionManifest: Codable, Sendable, Equatable {
         self.endpointEvaluations = endpointEvaluations
         self.interviewerUtterances = interviewerUtterances
         self.board = board
+        self.candidateNotes = candidateNotes
         self.revision = revision
         self.appliedCommands = appliedCommands
     }
@@ -351,6 +393,7 @@ public struct SessionManifest: Codable, Sendable, Equatable {
         case endpointEvaluations
         case interviewerUtterances
         case board
+        case candidateNotes
         case revision
         case appliedCommands
     }
@@ -373,6 +416,10 @@ public struct SessionManifest: Codable, Sendable, Equatable {
             forKey: .interviewerUtterances
         ) ?? []
         board = try container.decodeIfPresent(BoardWorkspace.self, forKey: .board) ?? .empty
+        candidateNotes = try container.decodeIfPresent(
+            CandidateNotes.self,
+            forKey: .candidateNotes
+        ) ?? .empty
         revision = try container.decode(Int.self, forKey: .revision)
         appliedCommands = try container.decode(
             [AppliedCommandRecord].self,
@@ -392,6 +439,7 @@ public struct SessionManifest: Codable, Sendable, Equatable {
         try container.encode(endpointEvaluations, forKey: .endpointEvaluations)
         try container.encode(interviewerUtterances, forKey: .interviewerUtterances)
         try container.encode(board, forKey: .board)
+        try container.encode(candidateNotes, forKey: .candidateNotes)
         try container.encode(revision, forKey: .revision)
         try container.encode(appliedCommands, forKey: .appliedCommands)
     }
@@ -409,6 +457,7 @@ public struct InterviewRoomSnapshot: Sendable, Equatable {
     public let endpointEvaluations: [EndpointEvaluation]
     public let interviewerUtterances: [InterviewerUtterance]
     public let board: BoardWorkspace
+    public let candidateNotes: CandidateNotes
     public let revision: Int
 
     init(manifest: SessionManifest) {
@@ -422,6 +471,7 @@ public struct InterviewRoomSnapshot: Sendable, Equatable {
         endpointEvaluations = manifest.endpointEvaluations
         interviewerUtterances = manifest.interviewerUtterances
         board = manifest.board
+        candidateNotes = manifest.candidateNotes
         revision = manifest.revision
     }
 }

--- a/Tests/InterviewArcLiveCoreTests/CandidateNotesTests.swift
+++ b/Tests/InterviewArcLiveCoreTests/CandidateNotesTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import XCTest
+@testable import InterviewArcLiveCore
+
+final class CandidateNotesTests: XCTestCase {
+    func testNotesAreBoundedByUTF8Bytes() throws {
+        let exact = String(repeating: "é", count: CandidateNotes.maximumBodyUTF8Bytes / 2)
+        XCTAssertEqual(try CandidateNotes(body: exact).body, exact)
+
+        XCTAssertThrowsError(try CandidateNotes(body: exact + "é")) { error in
+            XCTAssertEqual(
+                error as? CandidateNotesValidationError,
+                .bodyTooLong(maximumUTF8Bytes: CandidateNotes.maximumBodyUTF8Bytes)
+            )
+        }
+    }
+
+    func testNotesUpdateIsIdempotentAndSurvivesInterviewerTransitions() async throws {
+        let store = InMemorySessionManifestStore()
+        let runtime = NotesRuntime()
+        let session = try await InterviewRoomSession.start(
+            sessionID: SessionID("notes-session"),
+            activityID: "notes-activity",
+            activityPrompt: try prompt(),
+            manifestStore: store,
+            interviewerRuntime: runtime
+        )
+        let notes = try CandidateNotes(body: "Verify regional failover.")
+        let command = InterviewRoomCommand.updateCandidateNotes(
+            commandID: CommandID("notes-update-1"),
+            notes: notes
+        )
+
+        let first = try await session.apply(command)
+        let replay = try await session.apply(command)
+        XCTAssertEqual(first.disposition, .accepted)
+        XCTAssertEqual(replay.disposition, .alreadyApplied)
+        XCTAssertEqual(replay.snapshot.revision, first.snapshot.revision)
+        XCTAssertEqual(replay.snapshot.candidateNotes, notes)
+
+        _ = try await session.execute(
+            .giveCandidateFloor(commandID: CommandID("notes-floor"))
+        )
+        let completed = try await session.execute(
+            .handOff(
+                commandID: CommandID("notes-hand-off"),
+                transcript: CandidateTranscript(
+                    body: "The queue absorbs the burst.",
+                    quality: .verified
+                )
+            )
+        )
+
+        XCTAssertEqual(completed.phase, .interviewerTurn)
+        XCTAssertEqual(completed.candidateNotes, notes)
+        let requests = await runtime.requests()
+        let request = try XCTUnwrap(requests.first)
+        XCTAssertNotEqual(request.candidateTurn.transcript.body, notes.body)
+        XCTAssertFalse(request.activityPrompt.question.contains(notes.body))
+        XCTAssertTrue(request.priorVisibleTurns.isEmpty)
+    }
+
+    func testLegacyManifestWithoutNotesDecodesEmpty() throws {
+        let manifest = SessionManifest(
+            sessionID: SessionID("legacy-notes"),
+            activityID: "legacy-notes-activity",
+            activityPrompt: try prompt(),
+            phase: .ready,
+            turnMode: .manual,
+            turns: [],
+            revision: 0,
+            appliedCommands: []
+        )
+        let encoded = try JSONEncoder().encode(manifest)
+        var object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        )
+        object.removeValue(forKey: "candidateNotes")
+        let legacy = try JSONSerialization.data(withJSONObject: object)
+
+        XCTAssertEqual(
+            try JSONDecoder().decode(SessionManifest.self, from: legacy).candidateNotes,
+            .empty
+        )
+    }
+
+    private func prompt() throws -> ActivityPrompt {
+        try ActivityPrompt(
+            specialty: .systemDesign,
+            stage: "Architecture",
+            question: "Design a public notification service.",
+            requestedParts: ["Explain delivery reliability."]
+        )
+    }
+}
+
+private actor NotesRuntime: InterviewerRuntime {
+    private var recordedRequests: [InterviewerRequest] = []
+
+    func respond(to request: InterviewerRequest) -> CanonicalInterviewerResponse {
+        recordedRequests.append(request)
+        return CanonicalInterviewerResponse(
+            displayMarkdown: "What trade-off comes next?",
+            spokenText: "What trade-off comes next?"
+        )
+    }
+
+    func requests() -> [InterviewerRequest] { recordedRequests }
+}

--- a/Tests/InterviewArcLiveTests/InterviewFinishTestFixtures.swift
+++ b/Tests/InterviewArcLiveTests/InterviewFinishTestFixtures.swift
@@ -6,7 +6,8 @@ import InterviewArcLiveCore
 
 @MainActor
 func makeCompletionBlockingRoomModel(
-    boardArtifactStore: PrivateBoardArtifactStore? = nil
+    boardArtifactStore: PrivateBoardArtifactStore? = nil,
+    preferences: UserDefaults = .standard
 ) async throws -> (
     model: SystemDesignRoomModel,
     store: CompletionBlockingManifestStore
@@ -33,6 +34,7 @@ func makeCompletionBlockingRoomModel(
         SystemDesignRoomModel(
             codexRuntime: runtime,
             activityPrompt: prompt,
+            preferences: preferences,
             initialCoordinator: coordinator,
             boardArtifactStore: boardArtifactStore
         ),

--- a/Tests/InterviewArcLiveTests/InterviewRoomPresentationCoordinatorTests.swift
+++ b/Tests/InterviewArcLiveTests/InterviewRoomPresentationCoordinatorTests.swift
@@ -6,6 +6,32 @@ import XCTest
 
 @MainActor
 final class InterviewRoomPresentationCoordinatorTests: XCTestCase {
+    func testApplicationTerminationReplyWaitsForLocalDurability() async {
+        let preparation = TerminationPreparationFixture()
+        let gate = InterviewArcLiveTerminationGate {
+            await preparation.run()
+        }
+        var firstReply: Bool?
+        var secondReply: Bool?
+
+        XCTAssertEqual(
+            gate.requestTermination { firstReply = $0 },
+            .terminateLater
+        )
+        XCTAssertEqual(
+            gate.requestTermination { secondReply = $0 },
+            .terminateLater
+        )
+        await preparation.waitUntilStarted()
+        XCTAssertNil(firstReply)
+        XCTAssertNil(secondReply)
+
+        await preparation.release(result: true)
+        while firstReply == nil || secondReply == nil { await Task.yield() }
+        XCTAssertEqual(firstReply, true)
+        XCTAssertEqual(secondReply, true)
+    }
+
     func testCompactPanelUsesToolPaletteScale() {
         XCTAssertEqual(CompactPanelLayout.contentWidth, 580)
         XCTAssertEqual(CompactPanelLayout.minimumContentHeight, 82)
@@ -370,5 +396,32 @@ final class InterviewRoomPresentationCoordinatorTests: XCTestCase {
             frameAutosaveName: "InterviewArcLiveTests.TransientFrame",
             compactDynamicTypeSizeOverride: compactDynamicTypeSizeOverride
         )
+    }
+}
+
+private actor TerminationPreparationFixture {
+    private var started = false
+    private var startContinuation: CheckedContinuation<Void, Never>?
+    private var resultContinuation: CheckedContinuation<Bool, Never>?
+
+    func run() async -> Bool {
+        started = true
+        startContinuation?.resume()
+        startContinuation = nil
+        return await withCheckedContinuation { continuation in
+            resultContinuation = continuation
+        }
+    }
+
+    func waitUntilStarted() async {
+        if started { return }
+        await withCheckedContinuation { continuation in
+            startContinuation = continuation
+        }
+    }
+
+    func release(result: Bool) {
+        resultContinuation?.resume(returning: result)
+        resultContinuation = nil
     }
 }

--- a/Tests/InterviewArcLiveTests/SystemDesignWorkSurfaceTests.swift
+++ b/Tests/InterviewArcLiveTests/SystemDesignWorkSurfaceTests.swift
@@ -1,0 +1,159 @@
+import Foundation
+import XCTest
+
+import InterviewArcLiveCodexAdapter
+import InterviewArcLiveCore
+@testable import InterviewArcLive
+
+@MainActor
+final class SystemDesignWorkSurfaceTests: XCTestCase {
+    func testPaneSelectionPersistsAndBriefUsesExactPrompt() async throws {
+        let suiteName = "InterviewArcLiveTests.work-surface.\(UUID().uuidString)"
+        let preferences = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { preferences.removePersistentDomain(forName: suiteName) }
+        let (model, _) = try await makeCompletionBlockingRoomModel(
+            preferences: preferences
+        )
+
+        model.selectWorkSurface(.notes)
+
+        XCTAssertEqual(model.selectedWorkSurface, .notes)
+        XCTAssertEqual(model.activityPromptForPresentation.specialty, .systemDesign)
+        XCTAssertEqual(
+            model.activityPromptForPresentation.stage,
+            "High-level design"
+        )
+        XCTAssertEqual(
+            model.activityPromptForPresentation.question,
+            "Design a public-safe notification service."
+        )
+        XCTAssertEqual(
+            model.activityPromptForPresentation.requestedParts,
+            ["Clarify requirements."]
+        )
+        let restoredPreference = SystemDesignRoomModel(
+            codexRuntime: WorkSurfaceCodexRuntime(),
+            preferences: preferences,
+            boardArtifactStore: nil
+        )
+        XCTAssertEqual(restoredPreference.selectedWorkSurface, .notes)
+        XCTAssertFalse(restoredPreference.canEditCandidateNotes)
+        restoredPreference.updateCandidateNotesDraft("Must not edit while restoring")
+        XCTAssertTrue(restoredPreference.candidateNotesDraft.isEmpty)
+    }
+
+    func testLatestNotesAreDurableBeforeSavedStatus() async throws {
+        let (model, store) = try await makeCompletionBlockingRoomModel()
+
+        model.updateCandidateNotesDraft("First assumption")
+        model.updateCandidateNotesDraft("Latest assumption · multi-region")
+        await model.waitForCandidateNotesPersistence()
+
+        XCTAssertEqual(
+            model.snapshot?.candidateNotes.body,
+            "Latest assumption · multi-region"
+        )
+        XCTAssertEqual(model.candidateNotesSavePresentation, .saved)
+        let sessionID = try XCTUnwrap(model.snapshot?.sessionID)
+        let durable = try await store.load(sessionID: sessionID)
+        XCTAssertEqual(
+            durable?.candidateNotes.body,
+            "Latest assumption · multi-region"
+        )
+    }
+
+    func testBoardAndNotesWritesSerializeAndTerminationWaitsForBoth() async throws {
+        let (model, store) = try await makeCompletionBlockingRoomModel()
+        await store.holdNextBoardRevisionSave()
+
+        XCTAssertTrue(
+            model.applyBoardAction(
+                .createLabel(
+                    origin: BoardPoint(x: 80, y: 80),
+                    text: "Durable boundary"
+                )
+            )
+        )
+        await store.waitUntilBoardRevisionSaveStarts()
+        model.updateCandidateNotesDraft("Keep the queue idempotent.")
+
+        let termination = Task { @MainActor in
+            await model.prepareLocalPersistenceForTermination()
+        }
+        await Task.yield()
+        XCTAssertTrue(model.isBoardSaving)
+        XCTAssertEqual(model.candidateNotesSavePresentation, .saving)
+
+        await store.releaseBoardRevisionSave()
+        let shouldTerminate = await termination.value
+        XCTAssertTrue(shouldTerminate)
+        XCTAssertEqual(model.snapshot?.board.draft, model.boardEditor.document)
+        XCTAssertEqual(
+            model.snapshot?.candidateNotes.body,
+            "Keep the queue idempotent."
+        )
+        XCTAssertEqual(model.candidateNotesSavePresentation, .saved)
+
+        let sessionID = try XCTUnwrap(model.snapshot?.sessionID)
+        let durable = try await store.load(sessionID: sessionID)
+        XCTAssertEqual(durable?.board.draft, model.boardEditor.document)
+        XCTAssertEqual(
+            durable?.candidateNotes.body,
+            "Keep the queue idempotent."
+        )
+    }
+
+    func testNotesCannotAcceptUnretryableTextDuringCompletion() async throws {
+        let (model, store) = try await makeCompletionBlockingRoomModel()
+        model.updateCandidateNotesDraft("Persist before completion")
+        await model.waitForCandidateNotesPersistence()
+
+        let finishing = Task { @MainActor in
+            await model.finishInterview()
+        }
+        await store.waitUntilCompletionSaveStarts()
+
+        XCTAssertTrue(model.isFinishingInterview)
+        XCTAssertFalse(model.canEditCandidateNotes)
+        model.updateCandidateNotesDraft("Must not be accepted")
+        XCTAssertEqual(model.candidateNotesDraft, "Persist before completion")
+
+        await store.releaseCompletionSave()
+        let didFinish = await finishing.value
+        XCTAssertTrue(didFinish)
+        XCTAssertEqual(model.snapshot?.phase, .completed)
+        XCTAssertEqual(
+            model.snapshot?.candidateNotes.body,
+            "Persist before completion"
+        )
+    }
+
+    func testOversizedNotesPreserveTheLastAcceptedDraft() async throws {
+        let (model, _) = try await makeCompletionBlockingRoomModel()
+        model.updateCandidateNotesDraft("Keep this")
+        await model.waitForCandidateNotesPersistence()
+
+        model.updateCandidateNotesDraft(
+            String(repeating: "a", count: CandidateNotes.maximumBodyUTF8Bytes + 1)
+        )
+
+        XCTAssertEqual(model.candidateNotesDraft, "Keep this")
+        guard case .error(let message) = model.candidateNotesSavePresentation else {
+            return XCTFail("Expected a bounded Notes error")
+        }
+        XCTAssertTrue(message.contains("16 KB"))
+    }
+}
+
+private struct WorkSurfaceCodexRuntime: LiveCodexInterviewerRuntime {
+    func preflight() async -> CodexAppServerReadiness { .ready }
+
+    func respond(
+        to request: InterviewerRequest
+    ) -> CanonicalInterviewerResponse {
+        CanonicalInterviewerResponse(
+            displayMarkdown: "What trade-off comes next?",
+            spokenText: "What trade-off comes next?"
+        )
+    }
+}


### PR DESCRIPTION
## **User description**
Closes #34

## Summary
- turn Board, Brief, and Notes into one real accessible work-surface switcher
- render the exact authoritative Activity Prompt in a read-only Brief
- persist bounded private Candidate Notes through an idempotent Session command with local save/retry truth
- keep Board-only controls out of Brief and Notes and keep Notes out of transcript, provider, speech, export, and hosted contracts

## Verification
- strict Swift 6 Core and full-app emit/link with complete concurrency and warnings as errors
- changed Core/app test targets typecheck
- runtime harness verifies exact Brief, pane restoration, coalesced durable Notes, legacy-safe bounds, and visible oversize failure
- Swift parse, diff check, public-safety scan, and Impeccable detector pass

## Integration note
PR #30 independently changes the Board implementation. This PR intentionally starts from current main per fastlane; any authorized merge/rebase must preserve both its Excalidraw bridge and this pane/persistence contract.


___

## **CodeAnt-AI Description**
Add persistent Brief and private Notes work surfaces

### What Changed
- Switch between Board, Brief, and Notes, with the selected surface restored when the room reopens
- Show the exact activity question and requested parts in a selectable, read-only Brief
- Add private local Notes with automatic saving, retry feedback, and a visible 16 KB limit
- Keep Notes out of interviewer requests, transcripts, spoken responses, exports, and shared activity data
- Wait for Board and Notes changes to finish saving before quitting; cancel quitting when local changes are not durable
- Preserve Notes across interviewer transitions and open older sessions with an empty Notes surface

### Impact
`✅ Persistent work-surface selection`
`✅ Private notes stay out of interviewer responses`
`✅ Clearer local save and size-limit feedback`
`✅ Fewer lost changes when quitting`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
