### PR TITLE
Make Engineering receipt authoring self-teaching

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@
 
 Select exactly one classification. If `None` is selected, replace the placeholder with a concrete reason.
 
-Add the compact receipt for this pull request at `docs/engineering/changes/pr-<number>.md`. Material changes also add or amend a rich record and link its exact `id@revision` from the receipt.
+Classify materiality during issue work. For material work, author or select the exact rich record before review. After this draft PR has a number, run `python3 scripts/new-engineering-receipt.py --help`, create its numbered receipt, and commit it before requesting review.
 
 - [ ] None — reason: REPLACE WITH A CONCRETE REASON
 - [ ] Change Note

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -22,6 +22,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Test Engineering impact policy
         run: python3 Tests/ScriptTests/engineering-impact-policy-tests.py
+      - name: Test Engineering receipt scaffold
+        run: python3 Tests/ScriptTests/engineering-receipt-scaffold-tests.py
       - name: Fetch exact Engineering impact comparison revisions
         if: github.event_name == 'pull_request'
         env:

--- a/Tests/ScriptTests/engineering-impact-policy-tests.py
+++ b/Tests/ScriptTests/engineering-impact-policy-tests.py
@@ -129,7 +129,16 @@ Adopted complete pull-request receipts and a curated Engineering record for the 
         self.assertIn("'source'", concurrency_group)
         self.assertEqual(self.workflow_scalar(concurrency, "cancel-in-progress", 2), "true")
         self.assertIn("Test Engineering impact policy", policy_job)
+        self.assertIn("Test Engineering receipt scaffold", policy_job)
         self.assertIn("Validate Engineering impact classification", policy_job)
+
+    def test_protocol_teaches_the_draft_pr_authorship_boundary(self):
+        protocol = (Path(__file__).parents[2] / "docs/engineering/pull-request-history.md").read_text(encoding="utf-8")
+        lifecycle = (Path(__file__).parents[2] / "docs/agents/issue-lifecycle.md").read_text(encoding="utf-8")
+        self.assertIn("use a draft pull request to obtain the Live repository number", protocol)
+        self.assertIn("new-engineering-receipt.py --help", protocol)
+        self.assertIn("portable static HTML export", lifecycle)
+        self.assertIn("CI never invents them", lifecycle)
 
     def test_packaging_uses_a_clean_exact_tree_after_mutating_tests(self):
         workflow = WORKFLOW.read_text(encoding="utf-8")

--- a/Tests/ScriptTests/engineering-receipt-scaffold-tests.py
+++ b/Tests/ScriptTests/engineering-receipt-scaffold-tests.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts/new-engineering-receipt.py"
+
+
+def fixture(root: Path):
+    (root / "docs/contracts").mkdir(parents=True)
+    (root / "docs/engineering/changes").mkdir(parents=True)
+    (root / "AGENTS.md").write_text("# Fixture\n", encoding="utf-8")
+    (root / "docs/contracts/engineering-pull-request-receipt.schema.json").write_text("{}\n", encoding="utf-8")
+
+
+def scaffold(root: Path, *arguments: str):
+    return subprocess.run(["python3", str(SCRIPT), *arguments], cwd=root, text=True, capture_output=True, check=False)
+
+
+class EngineeringReceiptScaffoldTests(unittest.TestCase):
+    def test_help_teaches_draft_pr_and_authorship_boundary(self):
+        result = subprocess.run(["python3", str(SCRIPT), "--help"], text=True, capture_output=True, check=False)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Decide the Engineering impact before opening", result.stdout)
+        self.assertIn("Open a draft pull request", result.stdout)
+        self.assertIn("exact revision already available", result.stdout)
+        self.assertIn("concrete reason of at least 12 characters", result.stdout)
+        self.assertIn("does not author prose or diagrams", result.stdout)
+
+    def test_non_material_receipt_is_canonical_and_never_overwritten(self):
+        with tempfile.TemporaryDirectory(prefix="live-receipt-") as directory:
+            root = Path(directory)
+            fixture(root)
+            arguments = (
+                "--pr", "45", "--title", "Make Engineering receipt authoring self-teaching",
+                "--summary", "Added a local scaffold and durable coordinator guidance without changing Live runtime behavior.",
+                "--classification", "none",
+            )
+            result = scaffold(root, *arguments)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            target = root / "docs/engineering/changes/pr-45.md"
+            markdown = target.read_text(encoding="utf-8")
+            self.assertIn("repository: interview-arc-live", markdown)
+            self.assertIn("pr: 45", markdown)
+            self.assertIn("reconstructed: false", markdown)
+            self.assertIn("https://github.com/Vinosaamaa/interview-arc-live/pull/45", markdown)
+            repeated = scaffold(root, *arguments)
+            self.assertEqual(repeated.returncode, 1)
+            self.assertIn("Refusing to overwrite", repeated.stderr)
+            self.assertEqual(target.read_text(encoding="utf-8"), markdown)
+
+    def test_material_refs_are_required_valid_unique_and_sorted(self):
+        with tempfile.TemporaryDirectory(prefix="live-receipt-") as directory:
+            root = Path(directory)
+            fixture(root)
+            result = scaffold(
+                root,
+                "--pr", "46", "--title", "Document one reviewed boundary",
+                "--summary", "Linked the exact reviewed records that own this material architecture change.",
+                "--classification", "architecture-review",
+                "--rich-record-ref", "second-record@2",
+                "--rich-record-ref", "first-record@1",
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            markdown = (root / "docs/engineering/changes/pr-46.md").read_text(encoding="utf-8")
+            self.assertIn('richRecordRefs: ["first-record@1","second-record@2"]', markdown)
+            invalid_cases = (
+                (),
+                ("--rich-record-ref", "Bad@0"),
+                ("--rich-record-ref", "same@1", "--rich-record-ref", "same@1"),
+            )
+            for index, suffix in enumerate(invalid_cases, start=50):
+                result = scaffold(
+                    root,
+                    "--pr", str(index), "--title", "Document one reviewed boundary",
+                    "--summary", "Linked the exact reviewed record that owns this material architecture change.",
+                    "--classification", "architecture-review", *suffix,
+                )
+                self.assertEqual(result.returncode, 1)
+
+    def test_public_unsafe_values_fail_without_echo_or_file(self):
+        unsafe = str(Path("/", "Users", "person", "Projects", "private", "notes.txt"))
+        with tempfile.TemporaryDirectory(prefix="live-receipt-") as directory:
+            root = Path(directory)
+            fixture(root)
+            result = scaffold(
+                root,
+                "--pr", "60", "--title", "Document one safe change",
+                "--summary", unsafe, "--classification", "none",
+            )
+            self.assertEqual(result.returncode, 1)
+            self.assertNotIn(unsafe, result.stderr)
+            self.assertFalse((root / "docs/engineering/changes/pr-60.md").exists())
+
+    def test_title_json_quoting_matches_the_shared_scalar_grammar(self):
+        with tempfile.TemporaryDirectory(prefix="live-receipt-") as directory:
+            root = Path(directory)
+            fixture(root)
+            title = 'Don\'t regress: preserve "receipt" titles'
+            result = scaffold(
+                root,
+                "--pr", "61", "--title", title,
+                "--summary", "Preserved public punctuation in the exact pull-request title.",
+                "--classification", "none",
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            markdown = (root / "docs/engineering/changes/pr-61.md").read_text(encoding="utf-8")
+            title_line = next(line for line in markdown.splitlines() if line.startswith("title: "))
+            self.assertEqual(json.loads(title_line.removeprefix("title: ")), title)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/agents/issue-lifecycle.md
+++ b/docs/agents/issue-lifecycle.md
@@ -33,6 +33,34 @@ or any behavior that could silently lose or corrupt interview work.
 - Test through Module Interfaces. Use deterministic, public-safe fixtures.
 - Record changed behavior, verification, risks, rollback, and known limits.
 
+### Engineering record authorship
+
+Every pull request owns one compact Engineering receipt. This is implementation
+work, not a separate operation that the user must remember to request.
+
+1. During issue intake, classify the planned change as `none` or one material
+   Engineering record type from
+   [`docs/engineering/pull-request-history.md`](../engineering/pull-request-history.md).
+2. For material work, author its canonical public-safe rich Markdown record on
+   the implementation branch before its receipt refers to it, or select an
+   existing exact `id@revision` at the pull-request head whose reviewed cluster
+   genuinely covers the change. Author evidence-backed diagrams only when they
+   clarify verified structure or flow; CI never invents them.
+3. Push the first coherent public-safe commit and open a **draft pull request**
+   when its Live repository number is not yet known.
+4. Run `python3 scripts/new-engineering-receipt.py --pr <number> ...`, commit
+   exactly one `docs/engineering/changes/pr-<number>.md`, and select the matching
+   Engineering-impact checkbox. `None` requires a concrete reason of at least
+   12 characters.
+5. Request review only after the receipt, every required rich record/reference,
+   and the PR classification agree. CI validates canonical authorship. Arc's
+   build derives JSON, search, backlinks, Statistics, immutable links to
+   authored diagram assets, a portable static HTML export, and the website
+   projection; it does not create their narrative or diagram content.
+
+Run `python3 scripts/new-engineering-receipt.py --help` for exact examples.
+Automatic projection never means automatic narrative.
+
 ## Verification and release
 
 - Run focused tests locally and require clean hosted CI.

--- a/docs/engineering/changes/pr-46.md
+++ b/docs/engineering/changes/pr-46.md
@@ -1,0 +1,21 @@
+---
+schemaVersion: 1
+repository: interview-arc-live
+pr: 46
+title: "Make Engineering receipt authoring self-teaching"
+classification: none
+richRecordRefs: []
+reconstructed: false
+confidence: verified
+unknowns: []
+headCommit: null
+mergeCommit: null
+mergedAt: null
+sources: [{"label":"Pull request #46","url":"https://github.com/Vinosaamaa/interview-arc-live/pull/46","kind":"pull-request"}]
+verification: {"state":"verified","evidenceRefs":["pull-request:46"]}
+visibility: public-safe
+publicationEligibility: eligible
+---
+# Make Engineering receipt authoring self-teaching
+
+Added repository-local guidance and a public-safe receipt scaffold so Live coordinators author canonical Engineering evidence before review without changing native runtime behavior.

--- a/docs/engineering/pull-request-history.md
+++ b/docs/engineering/pull-request-history.md
@@ -22,17 +22,35 @@ This representation keeps the Python policy gate and Arc's deterministic JavaScr
 
 ## Forward authoring protocol
 
-The implementation coordinator owns the receipt as part of the pull request. The user does not need to request a separate Journal operation.
+The implementation coordinator owns the receipt as part of the pull request.
+The user does not need to request a separate Journal operation. Follow
+[`Engineering record authorship`](../agents/issue-lifecycle.md#engineering-record-authorship):
+classify the change during issue work, author or select any exact rich record
+before review, use a draft pull request to obtain the Live repository number,
+then scaffold and commit its numbered receipt. Material work may add a record or
+reuse an exact existing rich record whose reviewed cluster genuinely covers the
+change.
 
-1. Open or identify the pull request so its Live repository number is known.
-2. Add exactly one compact receipt at `docs/engineering/changes/pr-<number>.md`.
-3. Record a public-safe title and one factual summary paragraph of at most 280 characters.
-4. Classify a small or non-material pull request as `none` and leave `richRecordRefs` empty.
-5. For a material pull request, link the exact `id@revision` of a suitable existing rich record or add the appropriate rich record. Reusing a reviewed record lets one dossier or retrospective cover an explicit multi-PR cluster without duplicating prose.
-6. Let CI validate the classification, receipt, and rich-record linkage. Arc deterministically projects reviewed Live receipts from an exact trusted commit pin.
-7. Merge and release through Live's normal verification workflow.
+After the pull request number is known, run:
 
-CI does not invent motivation, architecture, root cause, impact, prose, or diagrams from a diff. The coordinator authors the factual receipt and any required rich record while it has the implementation context. Canonical state is Markdown in Git; generated JSON and HTML are disposable Arc projections, not a database or second source of narrative truth.
+```sh
+python3 scripts/new-engineering-receipt.py \
+  --pr <number> \
+  --title "<exact pull-request title>" \
+  --summary "<one public-safe factual paragraph>" \
+  --classification none
+```
+
+Run `python3 scripts/new-engineering-receipt.py --help` for complete
+non-material and material examples. The helper is non-interactive, makes no
+GitHub, network, Xcode, installation, or runtime call, and refuses unsafe values
+or an existing target.
+
+CI does not invent motivation, architecture, root cause, impact, prose, or
+diagrams from a diff. The coordinator authors the factual receipt and any
+required rich record while it has the implementation context. Canonical state
+is Markdown in Git; generated JSON and the portable static HTML export are
+disposable Arc projections, not a database or second source of narrative truth.
 
 ## Compact receipt example
 

--- a/scripts/new-engineering-receipt.py
+++ b/scripts/new-engineering-receipt.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Create one canonical forward Engineering pull-request receipt."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+OWNER = "Vinosaamaa"
+REPOSITORY = "interview-arc-live"
+CLASSIFICATIONS = {
+    "none", "change-note", "adr", "architecture-review",
+    "feature-retrospective", "postmortem", "capability-dossier",
+}
+RECORD_REF = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*@[1-9]\d*$")
+CONTROL_CHARACTER = re.compile(r"[\x00-\x1f\x7f-\x9f\u2028\u2029]")
+PUBLIC_UNSAFE_PATTERNS = (
+    re.compile(r"(?:^|[\s(\"'`])/(?:Users|home|root)/[^\s)\"'`]+"),
+    re.compile(r"(?:^|[\s(\"'`])/(?:private/tmp|tmp|var|opt|srv|workspace|mnt|Volumes)/[^\s)\"'`]+"),
+    re.compile(r"(?:^|[\s(\"'`])~/[^\s)\"'`]+"),
+    re.compile(r"\b[A-Za-z]:\\[^\s\"'`]+"),
+    re.compile(r"\\\\[^\s\\]+\\[^\s\"'`]+"),
+    re.compile(r"\bgh[pousr]_[A-Za-z0-9]{20,}\b"),
+    re.compile(r"\bsk-[A-Za-z0-9_-]{20,}\b"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+    re.compile(r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----"),
+    re.compile(r"\b(?:password|access[_-]?token|api[_-]?key|client[_-]?secret)\s*[:=]\s*[^\s]{8,}", re.I),
+    re.compile(r"\b(?:thread|task)_[A-Za-z0-9_-]{8,}\b"),
+    re.compile(r"\bgit@[A-Za-z0-9.-]+:[^\s]+"),
+    re.compile(r"https?://[^\s/@:]+:[^\s/@]+@[^\s/]+"),
+    re.compile(r"\b[A-Z0-9._%+-]+@(?!example\.com\b)[A-Z0-9.-]+\.[A-Z]{2,}\b", re.I),
+)
+
+HELP_EPILOG = """Authoring order:
+  1. Decide the Engineering impact before opening the pull request.
+  2. For material work, commit a new rich record first, or select an existing
+     exact revision already available at the pull-request head.
+  3. Open a draft pull request to obtain its Live repository number.
+  4. Run this command and commit the generated pr-<number>.md file.
+  5. Select the matching Engineering-impact checkbox. For None, replace its
+     placeholder with a concrete reason of at least 12 characters.
+
+Non-material example:
+  python3 scripts/new-engineering-receipt.py \\
+    --pr <number> \\
+    --title "Correct Engineering workflow labels" \\
+    --summary "Renamed one local label without changing a Module or Interface." \\
+    --classification none
+
+Material example:
+  python3 scripts/new-engineering-receipt.py \\
+    --pr <number> \\
+    --title "Document the Live session boundary" \\
+    --summary "Documented the reviewed Live session boundary and its durable invariants." \\
+    --classification capability-dossier \\
+    --rich-record-ref <id>@<revision>
+
+This scaffold creates canonical Markdown only. CI validates it, and Arc's build
+derives JSON, search, backlinks, Statistics, portable static HTML, and the website
+projection. It does not author prose or diagrams.
+"""
+
+
+class ScaffoldError(ValueError):
+    pass
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(
+        description="Create the canonical compact Engineering receipt for a Live pull request.",
+        epilog=HELP_EPILOG,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    result.add_argument("--pr", type=int, required=True)
+    result.add_argument("--title", required=True)
+    result.add_argument("--summary", required=True)
+    result.add_argument("--classification", required=True, choices=sorted(CLASSIFICATIONS))
+    result.add_argument("--rich-record-ref", action="append", default=[])
+    return result
+
+
+def one_line(value: str, label: str, maximum: int) -> str:
+    if not value or value != value.strip() or CONTROL_CHARACTER.search(value):
+        raise ScaffoldError(f"{label} must be one non-empty line without surrounding whitespace.")
+    if len(value) > maximum:
+        raise ScaffoldError(f"{label} exceeds {maximum} characters.")
+    return value
+
+
+def require_public_safe(*values: str) -> None:
+    if any(pattern.search(value) for value in values for pattern in PUBLIC_UNSAFE_PATTERNS):
+        raise ScaffoldError("Receipt text is not public-safe.")
+
+
+def receipt_directory(root: Path) -> Path:
+    root = root.resolve()
+    if not (root / "AGENTS.md").is_file() or not (root / "docs/contracts/engineering-pull-request-receipt.schema.json").is_file():
+        raise ScaffoldError("Run this command from the Interview Arc Live repository root.")
+    current = root
+    for segment in ("docs", "engineering", "changes"):
+        current = current / segment
+        current.mkdir(mode=0o755, exist_ok=True)
+        if current.is_symlink() or not current.is_dir():
+            raise ScaffoldError("The canonical Engineering receipt directory is unsafe.")
+    if current.resolve() != root / "docs/engineering/changes":
+        raise ScaffoldError("The canonical Engineering receipt directory is unsafe.")
+    return current
+
+
+def render(pr: int, title: str, summary: str, classification: str, refs: list[str]) -> str:
+    url = f"https://github.com/{OWNER}/{REPOSITORY}/pull/{pr}"
+    compact = lambda value: json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+    return f"""---
+schemaVersion: 1
+repository: {REPOSITORY}
+pr: {pr}
+title: {compact(title)}
+classification: {classification}
+richRecordRefs: {compact(refs)}
+reconstructed: false
+confidence: verified
+unknowns: []
+headCommit: null
+mergeCommit: null
+mergedAt: null
+sources: {compact([{"label": f"Pull request #{pr}", "url": url, "kind": "pull-request"}])}
+verification: {compact({"state": "verified", "evidenceRefs": [f"pull-request:{pr}"]})}
+visibility: public-safe
+publicationEligibility: eligible
+---
+# {title}
+
+{summary}
+"""
+
+
+def run(arguments: argparse.Namespace, root: Path) -> Path:
+    if arguments.pr < 1:
+        raise ScaffoldError("PR number must be a positive integer.")
+    title = one_line(arguments.title, "Title", 160)
+    summary = one_line(arguments.summary, "Summary", 280)
+    if re.match(r"^#{1,6}\s", summary):
+        raise ScaffoldError("Summary must be a factual paragraph, not a Markdown heading.")
+    require_public_safe(title, summary)
+    refs = sorted(arguments.rich_record_ref)
+    if len(refs) > 16:
+        raise ScaffoldError("A receipt cannot link more than 16 rich Engineering records.")
+    if len(refs) != len(set(refs)):
+        raise ScaffoldError("Rich-record references must be unique.")
+    if any(len(reference) > 180 or not RECORD_REF.fullmatch(reference) for reference in refs):
+        raise ScaffoldError("Every rich-record reference must use the exact id@revision format.")
+    if arguments.classification == "none" and refs:
+        raise ScaffoldError("Classification none cannot link a rich Engineering record.")
+    if arguments.classification != "none" and not refs:
+        raise ScaffoldError("A material classification requires at least one exact rich-record reference.")
+
+    directory = receipt_directory(root)
+    target = directory / f"pr-{arguments.pr}.md"
+    try:
+        descriptor = os.open(target, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
+    except FileExistsError as error:
+        raise ScaffoldError(f"Refusing to overwrite docs/engineering/changes/pr-{arguments.pr}.md.") from error
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as stream:
+            stream.write(render(arguments.pr, title, summary, arguments.classification, refs))
+    except Exception:
+        target.unlink(missing_ok=True)
+        raise
+    return target
+
+
+def main() -> int:
+    try:
+        target = run(parser().parse_args(), Path.cwd())
+    except ScaffoldError as error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 1
+    print(f"Created {target.relative_to(Path.cwd().resolve()).as_posix()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## **User description**
Refs #45

## Summary

- teach Live coordinators to classify Engineering impact during issue work and use a draft PR only to obtain its repository number
- add a public-safe, non-interactive Live receipt scaffold with exact v1 output and no-overwrite behavior
- run scaffold compatibility tests inside the existing Engineering policy gate

## Engineering impact

- [x] None — reason: Documentation and a local authoring helper only; Live runtime and architecture are unchanged.
- [ ] Change Note
- [ ] ADR
- [ ] Architecture Review
- [ ] Feature Retrospective
- [ ] Postmortem
- [ ] Capability Dossier

## Verification

- `python3 Tests/ScriptTests/engineering-receipt-scaffold-tests.py`
- `python3 Tests/ScriptTests/engineering-impact-policy-tests.py`
- `git diff --check`


___

## **CodeAnt-AI Description**
Make Engineering receipt creation guided, safe, and repeatable

### What Changed
- Adds a command that creates the numbered Engineering receipt with the required public metadata and pull-request link.
- Guides coordinators through classifying work, using a draft pull request to obtain its number, and linking exact records for material changes.
- Rejects unsafe or invalid content, enforces classification and record-link rules, and refuses to overwrite an existing receipt.
- Updates repository guidance and pull-request instructions to use the scaffold, with automated checks running in the Engineering policy gate.

### Impact
`✅ Consistent Engineering receipts`
`✅ Fewer unsafe or invalid public records`
`✅ Protected existing receipt files`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
