### PR TITLE
Validate bounded historical Engineering batches

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  issues: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event.action == 'edited' && 'metadata' || 'source' }}
@@ -33,6 +34,8 @@ jobs:
           git fetch --no-tags --depth=1 "$HEAD_REPO_URL" "$HEAD_SHA"
       - name: Validate Engineering impact classification
         if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: python3 scripts/validate-engineering-impact.py "$GITHUB_EVENT_PATH"
 
   test:

--- a/Tests/ScriptTests/engineering-impact-policy-tests.py
+++ b/Tests/ScriptTests/engineering-impact-policy-tests.py
@@ -12,6 +12,8 @@ WORKFLOW = Path(__file__).parents[2] / ".github" / "workflows" / "swift.yml"
 PACKAGE_SCRIPT = Path(__file__).parents[2] / "scripts" / "package-app.sh"
 BUILD_RECEIPT_SCRIPT = Path(__file__).parents[2] / "scripts" / "build-product-receipt.sh"
 SCHEMA = Path(__file__).parents[2] / "docs" / "contracts" / "engineering-pull-request-receipt.schema.json"
+HISTORICAL_SCHEMA = Path(__file__).parents[2] / "docs" / "contracts" / "engineering-historical-backfill-batch.schema.json"
+PROTOCOL = Path(__file__).parents[2] / "docs" / "engineering" / "pull-request-history.md"
 CURRENT_RECEIPT = Path(__file__).parents[2] / "docs" / "engineering" / "changes" / "pr-42.md"
 SPEC = importlib.util.spec_from_file_location("engineering_impact", SCRIPT)
 MODULE = importlib.util.module_from_spec(SPEC)
@@ -527,6 +529,80 @@ Adopted complete pull-request receipts and a curated Engineering record for the 
             with self.assertRaisesRegex(ValueError, "invalid or oversized"):
                 list(MODULE.iter_frontmatters_at("head", [path]))
         process.stdout.read.assert_not_called()
+
+    def test_historical_batch_contract_and_owner_authorization(self):
+        schema = json.loads(HISTORICAL_SCHEMA.read_text(encoding="utf-8"))
+        self.assertEqual(
+            schema["$id"],
+            "urn:interview-arc:contracts:engineering-historical-backfill-batch:1",
+        )
+        self.assertEqual(schema["properties"]["receiptPaths"]["maxItems"], 20)
+        protocol = PROTOCOL.read_text(encoding="utf-8")
+        self.assertIn("engineering-historical-backfill-batch.schema.json", protocol)
+        self.assertIn(MODULE.HISTORICAL_AUTHORIZATION, protocol)
+        authorization_url = (
+            "https://github.com/Vinosaamaa/interview-arc-live/issues/52#issuecomment-5310182290"
+        )
+        manifest = {
+            "schemaVersion": 1,
+            "repository": "interview-arc-live",
+            "pullRequest": 57,
+            "privacyAuthorizationUrl": authorization_url,
+            "receiptPaths": ["docs/engineering/changes/pr-7.md"],
+            "recordRefs": [],
+            "addedRecordRefs": [],
+        }
+        historical_receipts = [{
+            "path": "docs/engineering/changes/pr-7.md",
+            "pr": 7,
+            "repository": "interview-arc-live",
+            "classification": "none",
+            "richRecordRefs": [],
+            "reconstructed": True,
+        }]
+        changed_files = [
+            "docs/engineering/changes/pr-57.md",
+            "docs/engineering/backfill/pr-57.json",
+            "docs/engineering/changes/pr-7.md",
+        ]
+        self.assertEqual(
+            MODULE.validate_historical_batch(
+                manifest=manifest,
+                manifest_path="docs/engineering/backfill/pr-57.json",
+                pull_request_number=57,
+                repository="interview-arc-live",
+                repository_full_name="Vinosaamaa/interview-arc-live",
+                changed_files=changed_files,
+                historical_receipts=historical_receipts,
+                added_record_refs=[],
+                added_reconstructed=[],
+                base_existing_paths=[],
+            ),
+            {"historicalReceiptCount": 1, "historicalRecordCount": 0},
+        )
+        with self.assertRaisesRegex(ValueError, "add-only"):
+            MODULE.validate_historical_batch(
+                manifest=manifest,
+                manifest_path="docs/engineering/backfill/pr-57.json",
+                pull_request_number=57,
+                repository="interview-arc-live",
+                repository_full_name="Vinosaamaa/interview-arc-live",
+                changed_files=changed_files,
+                historical_receipts=historical_receipts,
+                added_record_refs=[],
+                added_reconstructed=[],
+                base_existing_paths=["docs/engineering/changes/pr-7.md"],
+            )
+        with self.assertRaisesRegex(ValueError, "owner privacy authorization"):
+            MODULE.verify_historical_authorization(
+                manifest,
+                "Vinosaamaa/interview-arc-live",
+                load_comment=lambda *_: {
+                    "html_url": authorization_url,
+                    "author_association": "CONTRIBUTOR",
+                    "body": MODULE.HISTORICAL_AUTHORIZATION,
+                },
+            )
 
 
 if __name__ == "__main__":

--- a/docs/contracts/engineering-historical-backfill-batch.schema.json
+++ b/docs/contracts/engineering-historical-backfill-batch.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:interview-arc:contracts:engineering-historical-backfill-batch:1",
+  "title": "Engineering historical backfill batch manifest",
+  "description": "The exact add-only reconstructed receipts and rich records reviewed in one bounded historical publication pull request.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion", "repository", "pullRequest", "privacyAuthorizationUrl",
+    "receiptPaths", "recordRefs", "addedRecordRefs"
+  ],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "repository": { "type": "string", "pattern": "^[A-Za-z0-9_.-]+$" },
+    "pullRequest": { "type": "integer", "minimum": 1 },
+    "privacyAuthorizationUrl": {
+      "type": "string",
+      "pattern": "^https://github\\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/(issues|pull)/[1-9]\\d*#issuecomment-[1-9]\\d*$",
+      "maxLength": 2048
+    },
+    "receiptPaths": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 20,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^docs/engineering/changes/pr-[1-9]\\d*\\.md$",
+        "maxLength": 180
+      }
+    },
+    "recordRefs": {
+      "type": "array",
+      "maxItems": 32,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*@[1-9]\\d*$",
+        "maxLength": 180
+      }
+    },
+    "addedRecordRefs": {
+      "type": "array",
+      "maxItems": 8,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*@[1-9]\\d*$",
+        "maxLength": 180
+      }
+    }
+  }
+}

--- a/docs/engineering/changes/pr-57.md
+++ b/docs/engineering/changes/pr-57.md
@@ -1,0 +1,21 @@
+---
+schemaVersion: 1
+repository: interview-arc-live
+pr: 57
+title: Validate bounded historical Engineering batches
+classification: change-note
+richRecordRefs: ["change-note-live-historical-backfill-gate@1"]
+reconstructed: false
+confidence: verified
+unknowns: []
+headCommit: null
+mergeCommit: null
+mergedAt: null
+sources: [{"label":"Pull request #57","url":"https://github.com/Vinosaamaa/interview-arc-live/pull/57","kind":"pull-request"}]
+verification: {"state":"verified","evidenceRefs":["pull-request:57"]}
+visibility: public-safe
+publicationEligibility: eligible
+---
+# Validate bounded historical Engineering batches
+
+Added a bounded, add-only historical publication contract that preserves the current Live receipt, verifies privacy authorization, and requires exact reconstructed receipt and rich-record parity.

--- a/docs/engineering/pull-request-history.md
+++ b/docs/engineering/pull-request-history.md
@@ -88,6 +88,18 @@ An accepted rich-record file and exact revision are immutable in place and are n
 
 Each rich-record Markdown file is limited to 65,536 UTF-8 bytes so pull-request policy validation remains bounded.
 
+## Historical backfill protocol
+
+A backfill coordinator uses the same contracts. Each publication pull request keeps its own forward-authored `reconstructed: false` receipt and selects `None` with a concrete reason because the batch publishes historical evidence without asserting a new current architecture change. It also adds exactly one `docs/engineering/backfill/pr-<current-pr-number>.json` manifest conforming to `docs/contracts/engineering-historical-backfill-batch.schema.json`.
+
+The required validation gate rejects unmanifested files, modifications or deletions of accepted history, repository/path/PR mismatches, forward receipts masquerading as reconstructed history, dangling rich records, and material receipts whose exact `id@revision` targets are missing or have the wrong type. Rich owners land before, or in the same bounded batch as, the receipts that depend on them.
+
+`recordRefs` enumerates the exact union of rich revisions used by every receipt in the batch, including already-accepted owners. `addedRecordRefs` is its schema-bounded subset added by this pull request.
+
+The authorization URL is not merely format-checked. Hosted validation reads the owning-repository comment, requires repository-owner authorship, and requires the exact sentence `I authorize publication of this bounded historical Engineering backfill batch under the residual-link policy.` This authorization approves the identified bounded batch; it does not authorize history rewrites, evidence deletion, visibility changes, or later batches.
+
+The batch manifest is review metadata, not narrative content. Canonical historical receipts and rich Markdown remain the only content sources.
+
 ## Diagrams
 
 Receipts do not require diagrams. A rich record may include a repository-native, public-safe diagram when verified structure, data flow, control flow, ownership, or before/after architecture is materially clearer visually. The coordinator authors that diagram from evidence and links it from the rich record; CI never invents a diagram from a diff.

--- a/docs/engineering/records/change-note-live-historical-backfill-gate.md
+++ b/docs/engineering/records/change-note-live-historical-backfill-gate.md
@@ -23,12 +23,12 @@ capabilities: ["bounded-historical-publication","residual-link-authorization"]
 amends: []
 supersedes: []
 learningRefs: []
-sources: [{"label":"Live historical backfill issue #52","url":"https://github.com/Vinosaamaa/interview-arc-live/issues/52","kind":"issue"}]
-verification: {"state":"verified","evidenceRefs":["issue:52","parser:passed"]}
+sources: [{"label":"Live historical backfill issue #52","url":"https://github.com/Vinosaamaa/interview-arc-live/issues/52","kind":"issue"},{"label":"Live pull request #57","url":"https://github.com/Vinosaamaa/interview-arc-live/pull/57","kind":"pull-request"}]
+verification: {"state":"verified","evidenceRefs":["issue:52","pull-request:57","parser:passed"]}
 visibility: public-safe
 publicationEligibility: eligible
 issue: 52
-pr: null
+pr: 57
 release: null
 run: null
 ---

--- a/docs/engineering/records/change-note-live-historical-backfill-gate.md
+++ b/docs/engineering/records/change-note-live-historical-backfill-gate.md
@@ -1,0 +1,43 @@
+---
+schemaVersion: 1
+id: change-note-live-historical-backfill-gate
+revision: 1
+type: change-note
+status: accepted
+title: Live Validates Bounded Historical Engineering Batches
+repository: interview-arc-live
+capabilityIds: ["engineering-evidence"]
+createdAt: 2026-08-16
+reconstructed: false
+confidence: verified
+unknowns: []
+modules: ["engineering-policy"]
+interfaces: ["engineering-historical-backfill-batch"]
+seams: ["pull-request-receipt-to-historical-manifest"]
+adapters: ["github-issue-comment-authorization"]
+relatedRecords: ["capability-dossier-deep-interview-room-session@1"]
+decisions: []
+incidents: []
+features: []
+capabilities: ["bounded-historical-publication","residual-link-authorization"]
+amends: []
+supersedes: []
+learningRefs: []
+sources: [{"label":"Live historical backfill issue #52","url":"https://github.com/Vinosaamaa/interview-arc-live/issues/52","kind":"issue"}]
+verification: {"state":"verified","evidenceRefs":["issue:52","parser:passed"]}
+visibility: public-safe
+publicationEligibility: eligible
+issue: 52
+pr: null
+release: null
+run: null
+---
+# Live Validates Bounded Historical Engineering Batches
+
+Live already required one numbered forward receipt. Historical publication still needed a bounded, add-only gate so reconstructed receipts could land without rewriting accepted history or inferring missing evidence.
+
+## Change
+
+The Live pull-request workflow now vendors the shared historical-batch contract and validates a publication pull request against it. A historical PR keeps one forward `reconstructed: false` receipt classified `None`, adds at most twenty reconstructed receipts, and may add at most eight reconstructed rich records. The numbered manifest must enumerate those documents exactly, stay add-only against the pull-request base, and cite an owning-repository comment whose entire body is the residual-link authorization sentence.
+
+Hosted validation reads that comment through GitHub and requires repository-owner authorship. The gate does not authorize history rewrites, evidence deletion, visibility changes, or later batches. Product runtime behavior is unchanged.

--- a/scripts/validate-engineering-impact.py
+++ b/scripts/validate-engineering-impact.py
@@ -32,6 +32,8 @@ CLASSIFICATION_PATTERN = re.compile(
 RECEIPT_DIRECTORY = "docs/engineering/changes/"
 RECEIPT_SCHEMA_PATH = Path(__file__).parents[1] / "docs" / "contracts" / "engineering-pull-request-receipt.schema.json"
 RECEIPT_SCHEMA = json.loads(RECEIPT_SCHEMA_PATH.read_text(encoding="utf-8"))
+HISTORICAL_SCHEMA_PATH = Path(__file__).parents[1] / "docs" / "contracts" / "engineering-historical-backfill-batch.schema.json"
+HISTORICAL_SCHEMA = json.loads(HISTORICAL_SCHEMA_PATH.read_text(encoding="utf-8"))
 RECEIPT_FIELDS = frozenset(RECEIPT_SCHEMA["required"])
 RECEIPT_PROPERTIES = RECEIPT_SCHEMA["properties"]
 RECEIPT_DEFINITIONS = RECEIPT_SCHEMA["$defs"]
@@ -39,9 +41,17 @@ RECEIPT_CLASSIFICATIONS = frozenset(RECEIPT_PROPERTIES["classification"]["enum"]
 SOURCE_KINDS = {"issue", "pull-request", "commit", "release", "run", "documentation"}
 CONFIDENCE_VALUES = {"verified", "high", "medium", "low", "unknown"}
 RECORD_REF_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*@[1-9]\d*$")
+RECEIPT_PATH_PATTERN = re.compile(r"^docs/engineering/changes/pr-[1-9]\d*\.md$")
 COMMIT_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 MERGED_AT_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
 REPOSITORY_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+$")
+REPOSITORY_FULL_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+HISTORICAL_AUTHORIZATION_URL = re.compile(
+    r"^https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/(issues|pull)/[1-9]\d*#issuecomment-[1-9]\d*$"
+)
+HISTORICAL_AUTHORIZATION = (
+    "I authorize publication of this bounded historical Engineering backfill batch under the residual-link policy."
+)
 MAX_SOURCES = RECEIPT_PROPERTIES["sources"]["maxItems"]
 MAX_SOURCE_LABEL_LENGTH = RECEIPT_PROPERTIES["sources"]["items"]["properties"]["label"]["maxLength"]
 MAX_SOURCE_URL_LENGTH = RECEIPT_PROPERTIES["sources"]["items"]["properties"]["url"]["maxLength"]
@@ -331,6 +341,188 @@ def validate_receipt(
     return receipt
 
 
+def equal_string_sets(left, right):
+    return (
+        isinstance(left, list)
+        and isinstance(right, list)
+        and len(left) == len(set(left))
+        and len(right) == len(set(right))
+        and sorted(left) == sorted(right)
+    )
+
+
+def bounded_record_refs(value, property_schema):
+    return (
+        isinstance(value, list)
+        and len(value) <= property_schema["maxItems"]
+        and len(value) == len(set(value))
+        and all(
+            isinstance(reference, str)
+            and len(reference) <= property_schema["items"]["maxLength"]
+            and RECORD_REF_PATTERN.fullmatch(reference)
+            for reference in value
+        )
+    )
+
+
+def parse_historical_batch_manifest(markdown: str):
+    try:
+        manifest = json.loads(markdown)
+    except json.JSONDecodeError as error:
+        raise ValueError("The historical batch manifest must be valid JSON.") from error
+    properties = HISTORICAL_SCHEMA["properties"]
+    receipt_paths = manifest.get("receiptPaths") if isinstance(manifest, dict) else None
+    if not isinstance(manifest, dict) or set(manifest) != set(HISTORICAL_SCHEMA["required"]):
+        raise ValueError("The historical batch manifest has unsupported or missing fields.")
+    if (
+        manifest.get("schemaVersion") != 1
+        or not isinstance(manifest.get("repository"), str)
+        or not re.fullmatch(properties["repository"]["pattern"], manifest["repository"])
+        or type(manifest.get("pullRequest")) is not int
+        or manifest["pullRequest"] < 1
+        or not isinstance(manifest.get("privacyAuthorizationUrl"), str)
+        or len(manifest["privacyAuthorizationUrl"]) > properties["privacyAuthorizationUrl"]["maxLength"]
+        or not HISTORICAL_AUTHORIZATION_URL.fullmatch(manifest["privacyAuthorizationUrl"])
+        or not isinstance(receipt_paths, list)
+        or not properties["receiptPaths"]["minItems"] <= len(receipt_paths) <= properties["receiptPaths"]["maxItems"]
+        or len(receipt_paths) != len(set(receipt_paths))
+        or any(
+            not isinstance(path, str)
+            or len(path) > properties["receiptPaths"]["items"]["maxLength"]
+            or not RECEIPT_PATH_PATTERN.fullmatch(path)
+            for path in receipt_paths
+        )
+        or not bounded_record_refs(manifest.get("recordRefs"), properties["recordRefs"])
+        or not bounded_record_refs(manifest.get("addedRecordRefs"), properties["addedRecordRefs"])
+    ):
+        raise ValueError("The historical batch manifest has invalid bounded fields.")
+    return manifest
+
+
+def load_authorization_comment(repository_full_name: str, comment_id: str):
+    result = subprocess.run(
+        ["gh", "api", f"repos/{repository_full_name}/issues/comments/{comment_id}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise ValueError("Unable to verify the historical batch privacy authorization comment.")
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise ValueError("The historical batch privacy authorization response is invalid.") from error
+
+
+def verify_historical_authorization(manifest, repository_full_name: str, load_comment=None):
+    loader = load_comment or load_authorization_comment
+    match = re.search(r"#issuecomment-([1-9]\d*)$", manifest["privacyAuthorizationUrl"])
+    if not match:
+        raise ValueError("The historical batch privacy authorization comment URL is invalid.")
+    comment = loader(repository_full_name, match.group(1))
+    if (
+        comment.get("html_url") != manifest["privacyAuthorizationUrl"]
+        or comment.get("author_association") != "OWNER"
+        or (comment.get("body") or "").strip() != HISTORICAL_AUTHORIZATION
+    ):
+        raise ValueError("The historical batch requires an exact repository-owner privacy authorization comment.")
+
+
+def record_path_for_ref(record_ref: str):
+    record_id, _ = record_ref.rsplit("@", 1)
+    return f"docs/engineering/records/{record_id}.md"
+
+
+def parse_reconstructed_receipt(markdown: str, path: str, repository: str, record_index: dict[str, str]):
+    receipt, body = frontmatter_document(markdown, path)
+    missing = sorted(RECEIPT_FIELDS - receipt.keys())
+    extra = sorted(receipt.keys() - RECEIPT_FIELDS)
+    if missing or extra:
+        raise ValueError(f"Receipt v1 fields are invalid: {path}.")
+    if receipt.get("reconstructed") is not True:
+        raise ValueError("Every historical receipt must be reconstructed, repository-owned, and match its numbered path.")
+    if receipt.get("repository") != repository:
+        raise ValueError("Every historical receipt must be reconstructed, repository-owned, and match its numbered path.")
+    match = RECEIPT_PATH_PATTERN.fullmatch(path)
+    if not match or receipt.get("pr") != int(path.rsplit("-", 1)[1].removesuffix(".md")):
+        raise ValueError("Every historical receipt must be reconstructed, repository-owned, and match its numbered path.")
+    classification = receipt.get("classification")
+    if classification not in RECEIPT_CLASSIFICATIONS:
+        raise ValueError(f"Receipt `classification` is invalid: {path}.")
+    validate_receipt_record_refs(receipt, path, classification=classification, record_index=record_index)
+    validate_receipt_sources(
+        receipt,
+        path,
+        repository=repository,
+        pr_number=receipt["pr"],
+        pr_url=f"https://github.com/Vinosaamaa/{repository}/pull/{receipt['pr']}",
+    )
+    validate_receipt_verification(receipt, path)
+    validate_receipt_body(receipt, body, path)
+    return {
+        "path": path,
+        "pr": receipt["pr"],
+        "repository": receipt["repository"],
+        "classification": classification,
+        "richRecordRefs": receipt["richRecordRefs"],
+        "reconstructed": True,
+    }
+
+
+def validate_historical_batch(
+    *,
+    manifest,
+    manifest_path: str,
+    pull_request_number: int,
+    repository: str,
+    repository_full_name: str,
+    changed_files: list[str],
+    historical_receipts: list[dict],
+    added_record_refs: list[str],
+    added_reconstructed: list[bool],
+    base_existing_paths: list[str],
+):
+    expected_manifest_path = f"docs/engineering/backfill/pr-{pull_request_number}.json"
+    if (
+        manifest["repository"] != repository
+        or manifest["pullRequest"] != pull_request_number
+        or manifest_path != expected_manifest_path
+        or not REPOSITORY_FULL_NAME_PATTERN.fullmatch(repository_full_name)
+        or not manifest["privacyAuthorizationUrl"].startswith(f"https://github.com/{repository_full_name}/")
+    ):
+        raise ValueError("A historical batch manifest must match the current repository and pull request.")
+    if f"docs/engineering/changes/pr-{pull_request_number}.md" in manifest["receiptPaths"]:
+        raise ValueError("A historical batch manifest must not claim the current pull request's forward receipt.")
+    if not equal_string_sets(manifest["receiptPaths"], [receipt["path"] for receipt in historical_receipts]):
+        raise ValueError("The historical batch manifest must enumerate its reconstructed receipts exactly.")
+    referenced = sorted({ref for receipt in historical_receipts for ref in receipt["richRecordRefs"]})
+    if not equal_string_sets(manifest["recordRefs"], referenced):
+        raise ValueError("The historical batch manifest must enumerate exactly the rich records referenced by reconstructed receipts.")
+    if not equal_string_sets(manifest["addedRecordRefs"], added_record_refs):
+        raise ValueError("The historical batch manifest must enumerate the changed reconstructed receipts and rich records exactly.")
+    if any(flag is not True for flag in added_reconstructed):
+        raise ValueError("Historical rich records must set reconstructed true.")
+    if any(reference not in referenced for reference in added_record_refs):
+        raise ValueError("Every rich record added by a historical batch must exist at head and be linked by a reconstructed receipt.")
+    for receipt in historical_receipts:
+        if receipt["pr"] == pull_request_number or receipt.get("reconstructed") is not True:
+            raise ValueError("Every historical receipt must be reconstructed, repository-owned, and match its numbered path.")
+    allowed = [
+        f"docs/engineering/changes/pr-{pull_request_number}.md",
+        manifest_path,
+        *manifest["receiptPaths"],
+        *[record_path_for_ref(reference) for reference in manifest["addedRecordRefs"]],
+    ]
+    if not equal_string_sets(allowed, changed_files):
+        raise ValueError("A historical publication pull request may contain only its forward receipt, batch manifest, and declared historical documents.")
+    if base_existing_paths:
+        raise ValueError("Historical batch documents are add-only; accepted receipts and records cannot be modified or deleted.")
+    return {
+        "historicalReceiptCount": len(historical_receipts),
+        "historicalRecordCount": len(added_record_refs),
+    }
+
+
 def git(*args):
     return subprocess.check_output(["git", *args], text=True).strip()
 
@@ -612,23 +804,63 @@ def main():
     pr_number = pull_request.get("number") or event.get("number")
     pr_title = pull_request.get("title")
     repository = event.get("repository", {}).get("name") or pull_request.get("base", {}).get("repo", {}).get("name")
+    repository_full_name = event.get("repository", {}).get("full_name")
     pr_url = pull_request.get("html_url")
     if not base or not head or type(pr_number) is not int or not pr_title or not repository or not pr_url:
         raise ValueError("Pull request base, head, number, title, repository, and URL are required.")
     changed = git("diff", "--name-only", base, head).splitlines()
     record_paths = [path for path in changed if path.startswith("docs/engineering/records/") and path.endswith(".md")]
+    receipt_paths = [path for path in changed if path.startswith("docs/engineering/changes/") and path.endswith(".md")]
+    manifest_paths = [path for path in changed if path.startswith("docs/engineering/backfill/") and path.endswith(".json")]
+    historical_mode = len(receipt_paths) > 1 or len(manifest_paths) > 0
+    expected_manifest_path = f"docs/engineering/backfill/pr-{pr_number}.json"
+    historical_paths = set()
+    historical_receipts = []
+    manifest = None
+    extra_record_refs = []
+    if historical_mode:
+        if not isinstance(repository_full_name, str) or not REPOSITORY_FULL_NAME_PATTERN.fullmatch(repository_full_name) or not repository_full_name.endswith(f"/{repository}"):
+            raise ValueError("A historical publication pull request requires the exact owning repository full name.")
+        if manifest_paths != [expected_manifest_path]:
+            raise ValueError("A historical publication pull request must change its one numbered batch manifest.")
+        manifest_markdown = bounded_git_blob(head, expected_manifest_path)
+        if manifest_markdown is None:
+            raise ValueError("The historical batch manifest must exist at the pull request head.")
+        manifest = parse_historical_batch_manifest(manifest_markdown)
+        verify_historical_authorization(manifest, repository_full_name)
+        historical_markdown = []
+        for path in manifest["receiptPaths"]:
+            markdown = bounded_git_blob(head, path)
+            if markdown is None:
+                raise ValueError("Every declared historical receipt must exist at the pull request head.")
+            historical_markdown.append(markdown)
+            receipt_fields, _ = frontmatter_document(markdown, path)
+            extra_record_refs.extend(receipt_fields.get("richRecordRefs") or [])
+        historical_paths = {expected_manifest_path, *manifest["receiptPaths"], *record_paths}
     validate_record_history(base, record_paths)
-    receipt_path = required_receipt_path(changed, pr_number)
+    forward_changed = [path for path in changed if path not in historical_paths]
+    receipt_path = required_receipt_path(forward_changed, pr_number)
     receipt_markdown = bounded_git_blob(head, receipt_path)
     if receipt_markdown is None:
         raise ValueError(f"Pull-request receipt is missing at the pull-request head: {receipt_path}.")
-    required_record_refs = receipt_record_refs(receipt_markdown, receipt_path)
+    required_record_refs = list(dict.fromkeys([
+        *receipt_record_refs(receipt_markdown, receipt_path),
+        *[reference for reference in extra_record_refs if isinstance(reference, str)],
+    ]))
     record_index, changed_record_types = record_index_and_changed_types_at(
         head,
         record_paths,
         required_record_refs,
     )
-    classification = validate(pull_request.get("body") or "", changed_record_types)
+    if historical_mode:
+        historical_receipts = [
+            parse_reconstructed_receipt(markdown, path, repository, record_index)
+            for path, markdown in zip(manifest["receiptPaths"], historical_markdown)
+        ]
+    classification = validate(
+        pull_request.get("body") or "",
+        [] if historical_mode else changed_record_types,
+    )
     receipt = validate_receipt(
         receipt_markdown,
         receipt_path,
@@ -639,6 +871,34 @@ def main():
         record_index=record_index,
         pr_url=pr_url,
     )
+    if historical_mode:
+        changed_metadata = load_record_metadata(head, record_paths)
+        added_record_refs = []
+        added_reconstructed = []
+        for path, metadata in sorted(changed_metadata.items()):
+            record_id = validated_record_id(metadata, path)
+            added_record_refs.append(f"{record_id}@{metadata['revision']}")
+            added_reconstructed.append(metadata.get("reconstructed") is True)
+        historical_document_paths = [*manifest["receiptPaths"], *record_paths]
+        base_existing_paths = sorted(git_objects_exist(base, historical_document_paths))
+        historical_result = validate_historical_batch(
+            manifest=manifest,
+            manifest_path=expected_manifest_path,
+            pull_request_number=pr_number,
+            repository=repository,
+            repository_full_name=repository_full_name,
+            changed_files=changed,
+            historical_receipts=historical_receipts,
+            added_record_refs=added_record_refs,
+            added_reconstructed=added_reconstructed,
+            base_existing_paths=base_existing_paths,
+        )
+        print(
+            f"Engineering impact: {classification}; historical batch: "
+            f"{historical_result['historicalReceiptCount']} receipt(s), "
+            f"{historical_result['historicalRecordCount']} rich record(s)."
+        )
+        return
     print(
         f"Engineering impact: {classification}; receipt PR #{receipt['pr']}; "
         f"{len(changed)} changed file(s)."


### PR DESCRIPTION
## **User description**
Refs #52

## Summary

- vendor the shared historical-batch contract in Live
- validate add-only reconstructed receipts against exact owner residual-link authorization
- keep product runtime behavior unchanged

## Engineering impact

Select exactly one classification. If `None` is selected, replace the placeholder with a concrete reason.

Add the compact receipt for this pull request at `docs/engineering/changes/pr-<number>.md`. Material changes also add or amend a rich record and link its exact `id@revision` from the receipt.

- [ ] None — reason: REPLACE WITH A CONCRETE REASON
- [x] Change Note
- [ ] ADR
- [ ] Architecture Review
- [ ] Feature Retrospective
- [ ] Postmortem
- [ ] Capability Dossier

## Verification

- [x] `python3 Tests/ScriptTests/engineering-impact-policy-tests.py`

Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
Add a bounded, owner-authorized workflow for publishing historical Engineering records

### What Changed
- Historical backfill pull requests must include one numbered manifest listing every reconstructed receipt and added rich record.
- Validation checks that historical receipts and records are repository-owned, reconstructed, linked exactly, and added without modifying or deleting accepted history.
- Publication is permitted only when the owning repository has an exact owner-authored authorization comment for that specific batch.
- The current pull request keeps its normal forward receipt, while historical receipts remain separate and cannot be mistaken for new runtime changes.
- Added contract and policy tests covering manifest limits, exact file and record matching, add-only behavior, and owner authorization.

### Impact
`✅ Controlled historical record publication`
`✅ Prevented edits to accepted Engineering history`
`✅ Owner-verified privacy authorization`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
