### PR TITLE
Persist Groq Keychain saves and pin Codex CLI 0.148.0-alpha.9

### DIFF
--- a/Sources/InterviewArcLiveCodexAdapter/CodexAppServerInterviewerRuntime.swift
+++ b/Sources/InterviewArcLiveCodexAdapter/CodexAppServerInterviewerRuntime.swift
@@ -26,7 +26,7 @@ public enum CodexAppServerRuntimeError: Error, Sendable, Equatable {
 /// events remain inside this Module; only the canonical response pair crosses
 /// the Interface.
 public actor CodexAppServerInterviewerRuntime: InterviewerRuntime {
-    public static let testedCLIVersion = "codex-cli 0.147.0-alpha.6.5"
+    public static let testedCLIVersion = "codex-cli 0.148.0-alpha.9"
     public static let defaultInterviewerModel = "gpt-5.6-terra"
 
     private static let commandTimeoutNanoseconds: UInt64 = 5_000_000_000

--- a/Sources/InterviewArcLiveVoiceAdapter/LiveGroqCredentialStore.swift
+++ b/Sources/InterviewArcLiveVoiceAdapter/LiveGroqCredentialStore.swift
@@ -1,6 +1,7 @@
 import Foundation
 import InterviewArcLiveCore
 import InterviewArcVoiceCore
+import Security
 
 public enum LiveGroqCredentialReadiness: Equatable, Sendable {
     /// A durable Keychain credential is available.
@@ -37,6 +38,7 @@ public enum LiveGroqCredentialStoreError: Error, Equatable, LocalizedError, Send
 
 public actor LiveGroqCredentialStore: GroqCredentialReading {
     public static let keychainService = "dev.interviewarc.live"
+    public static let keychainAccount = "groq-api-key"
 
     private let backend: LiveGroqCredentialBackend
     private let verificationPolicy = CredentialSaveVerificationPolicy()
@@ -45,12 +47,7 @@ public actor LiveGroqCredentialStore: GroqCredentialReading {
     private var credentialUntilQuit: String?
 
     public init() {
-        let keychain = KeychainStore(service: Self.keychainService)
-        backend = LiveGroqCredentialBackend(
-            read: { try keychain.value(for: .groqAPIKey) },
-            save: { try keychain.set($0, for: .groqAPIKey) },
-            remove: { try keychain.remove(.groqAPIKey) }
-        )
+        backend = Self.securityBackend()
     }
 
     init(backend: LiveGroqCredentialBackend) {
@@ -168,6 +165,69 @@ public actor LiveGroqCredentialStore: GroqCredentialReading {
         } catch {
             throw LiveGroqCredentialStoreError.rollbackFailed
         }
+    }
+
+    private static func securityBackend() -> LiveGroqCredentialBackend {
+        LiveGroqCredentialBackend(
+            read: {
+                var query = baseQuery()
+                query[kSecReturnData as String] = true
+                query[kSecMatchLimit as String] = kSecMatchLimitOne
+                var item: CFTypeRef?
+                let status = SecItemCopyMatching(query as CFDictionary, &item)
+                return try LiveGenericPasswordRead.value(status: status, item: item)
+            },
+            save: { value in
+                let data = Data(value.utf8)
+                let update = [kSecValueData as String: data]
+                let base = baseQuery()
+                let status = SecItemUpdate(
+                    base as CFDictionary,
+                    update as CFDictionary
+                )
+                if status == errSecItemNotFound {
+                    var insert = base
+                    insert[kSecValueData as String] = data
+                    insert[kSecAttrAccessible as String] =
+                        kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+                    guard SecItemAdd(insert as CFDictionary, nil) == errSecSuccess else {
+                        throw LiveGroqCredentialStoreError.keychainUnavailable
+                    }
+                } else if status != errSecSuccess {
+                    throw LiveGroqCredentialStoreError.keychainUnavailable
+                }
+            },
+            remove: {
+                let status = SecItemDelete(baseQuery() as CFDictionary)
+                guard status == errSecSuccess || status == errSecItemNotFound else {
+                    throw LiveGroqCredentialStoreError.keychainUnavailable
+                }
+            }
+        )
+    }
+
+    private nonisolated static func baseQuery() -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: keychainService,
+            kSecAttrAccount as String: keychainAccount,
+        ]
+    }
+}
+
+enum LiveGenericPasswordRead: Sendable {
+    /// Maps a `MatchLimitOne` generic-password read. `errSecItemNotFound` is a
+    /// missing item, not Keychain unavailability. Do not use `MatchLimitAll`.
+    static func value(status: OSStatus, item: CFTypeRef?) throws -> String? {
+        if status == errSecItemNotFound {
+            return nil
+        }
+        guard status == errSecSuccess,
+              let data = item as? Data,
+              let value = String(data: data, encoding: .utf8) else {
+            throw LiveGroqCredentialStoreError.keychainUnavailable
+        }
+        return value
     }
 }
 

--- a/Tests/InterviewArcLiveCodexAdapterTests/CodexAppServerInterviewerRuntimeTests.swift
+++ b/Tests/InterviewArcLiveCodexAdapterTests/CodexAppServerInterviewerRuntimeTests.swift
@@ -13,6 +13,13 @@ final class CodexAppServerInterviewerRuntimeTests: XCTestCase {
         )
     }
 
+    func testCLIProtocolPinMatchesCurrentlyTestedCodex() {
+        XCTAssertEqual(
+            CodexAppServerInterviewerRuntime.testedCLIVersion,
+            "codex-cli 0.148.0-alpha.9"
+        )
+    }
+
     func testPreflightInitializesChecksOnlyAuthPresenceAndReapsBeforeReturning() async throws {
         let connection = ScriptedCodexConnection(lines: Self.authenticationLines())
         let launcher = FixtureCodexLauncher(connection: connection)

--- a/Tests/InterviewArcLiveVoiceAdapterTests/LiveGroqCredentialStoreTests.swift
+++ b/Tests/InterviewArcLiveVoiceAdapterTests/LiveGroqCredentialStoreTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Security
 import XCTest
 
 @testable import InterviewArcLiveVoiceAdapter
@@ -10,10 +11,46 @@ final class LiveGroqCredentialStoreTests: XCTestCase {
             LiveGroqCredentialStore.keychainService,
             "dev.interviewarc.live"
         )
+        XCTAssertEqual(
+            LiveGroqCredentialStore.keychainAccount,
+            "groq-api-key"
+        )
         XCTAssertNotEqual(
             LiveGroqCredentialStore.keychainService,
             "dev.interviewarc.voice"
         )
+    }
+
+    func testMissingGenericPasswordIsNotKeychainUnavailable() throws {
+        XCTAssertNil(
+            try LiveGenericPasswordRead.value(
+                status: errSecItemNotFound,
+                item: nil
+            )
+        )
+    }
+
+    func testParamStatusFromLegacyMatchAllIsKeychainUnavailable() {
+        do {
+            _ = try LiveGenericPasswordRead.value(
+                status: errSecParam,
+                item: nil
+            )
+            XCTFail("Expected errSecParam to be unavailable, not missing")
+        } catch let error as LiveGroqCredentialStoreError {
+            XCTAssertEqual(error, .keychainUnavailable)
+        } catch {
+            XCTFail("Unexpected error \(error)")
+        }
+    }
+
+    func testSuccessfulGenericPasswordReadReturnsUTF8Value() throws {
+        let stored = Data("public-test-key".utf8) as CFTypeRef
+        let value = try LiveGenericPasswordRead.value(
+            status: errSecSuccess,
+            item: stored
+        )
+        XCTAssertEqual(value, "public-test-key")
     }
 
     func testSaveVerifiesReadbackAndReportsReadiness() async throws {

--- a/docs/engineering/changes/pr-59.md
+++ b/docs/engineering/changes/pr-59.md
@@ -1,0 +1,21 @@
+---
+schemaVersion: 1
+repository: interview-arc-live
+pr: 59
+title: Persist Groq Keychain saves and pin Codex CLI 0.148.0-alpha.9
+classification: change-note
+richRecordRefs: ["change-note-groq-keychain-codex-pin@1"]
+reconstructed: false
+confidence: verified
+unknowns: []
+headCommit: null
+mergeCommit: null
+mergedAt: null
+sources: [{"label":"Pull request #59","url":"https://github.com/Vinosaamaa/interview-arc-live/pull/59","kind":"pull-request"},{"label":"Issue #58","url":"https://github.com/Vinosaamaa/interview-arc-live/issues/58","kind":"issue"}]
+verification: {"state":"verified","evidenceRefs":["pull-request:59","issue:58"]}
+visibility: public-safe
+publicationEligibility: eligible
+---
+# Persist Groq Keychain saves and pin Codex CLI 0.148.0-alpha.9
+
+Replaced Voice MatchLimitAll Groq Keychain reads with a Live-owned MatchLimitOne backend so an empty item can persist, and pinned the Codex interviewer Adapter to codex-cli 0.148.0-alpha.9.

--- a/docs/engineering/records/change-note-groq-keychain-codex-pin.md
+++ b/docs/engineering/records/change-note-groq-keychain-codex-pin.md
@@ -1,0 +1,43 @@
+---
+schemaVersion: 1
+id: change-note-groq-keychain-codex-pin
+revision: 1
+type: change-note
+status: accepted
+title: Persist Groq Keychain Saves And Pin Codex CLI
+repository: interview-arc-live
+capabilityIds: ["interview-room-session"]
+createdAt: 2026-08-16
+reconstructed: false
+confidence: verified
+unknowns: []
+modules: ["live-groq-credential-store","codex-app-server-interviewer-runtime"]
+interfaces: ["groq-credential-reading","interviewer-runtime"]
+seams: ["session-to-transcription","session-to-interviewer-runtime"]
+adapters: ["live-generic-password-keychain","codex-app-server"]
+relatedRecords: ["capability-dossier-deep-interview-room-session@1"]
+decisions: ["0005-codex-app-server-private-runtime"]
+incidents: []
+features: []
+capabilities: ["durable-groq-keychain","exact-codex-cli-pin"]
+amends: []
+supersedes: []
+learningRefs: []
+sources: [{"label":"Issue #58","url":"https://github.com/Vinosaamaa/interview-arc-live/issues/58","kind":"issue"},{"label":"Pull request #59","url":"https://github.com/Vinosaamaa/interview-arc-live/pull/59","kind":"pull-request"}]
+verification: {"state":"verified","evidenceRefs":["issue:58","pull-request:59","runtime:errSecParam-match-all"]}
+visibility: public-safe
+publicationEligibility: eligible
+issue: 58
+pr: 59
+release: null
+run: null
+---
+# Persist Groq Keychain Saves And Pin Codex CLI
+
+Live could not persist a Groq key on an empty Keychain item, and Codex preflight rejected the currently authenticated CLI.
+
+## Change
+
+`LiveGroqCredentialStore` no longer reads through Voice `KeychainStore`. Voice's generic-password helper issues a `MatchLimitAll` plus `kSecReturnData` search after a `MatchLimitOne` miss. On current macOS that second query returns `errSecParam`, which Live mapped to `keychainUnavailable`, so the first Save to Keychain never ran. Groq now uses a Live-owned `MatchLimitOne` backend with `errSecItemNotFound` as missing, matching the hosted integration token store, while until-quit stays process-memory only.
+
+The Codex App Server interviewer Adapter still pins one exact tested protocol. The pin is now `codex-cli 0.148.0-alpha.9`. A different version remains fail-closed and does not consume the Candidate Turn.


### PR DESCRIPTION
## Summary
- Groq now uses a Live-owned `MatchLimitOne` Keychain backend, so an empty item is missing instead of `keychainUnavailable` and **Save to Keychain** can persist the first key.
- Codex App Server preflight pins `codex-cli 0.148.0-alpha.9`, the currently tested locally authenticated CLI.
- Until-quit, Voice credential isolation, and exact-version fail-closed behavior are unchanged.

## Engineering impact

Select exactly one classification. If `None` is selected, replace the placeholder with a concrete reason.

Add the compact receipt for this pull request at `docs/engineering/changes/pr-<number>.md`. Material changes also add or amend a rich record and link its exact `id@revision` from the receipt.

- [ ] None — reason: REPLACE WITH A CONCRETE REASON
- [x] Change Note
- [ ] ADR
- [ ] Architecture Review
- [ ] Feature Retrospective
- [ ] Postmortem
- [ ] Capability Dossier

## Test plan
- [ ] `InterviewArcLiveVoiceAdapterTests.LiveGroqCredentialStoreTests` — missing vs `errSecParam` vs save/until-quit/rollback
- [ ] `InterviewArcLiveCodexAdapterTests.CodexAppServerInterviewerRuntimeTests` — pin and incompatible fail-closed
- [ ] Hosted CI `Swift` workflow on this PR
- [ ] After authorized merge/package/install: Save Groq to Keychain, quit, relaunch, Groq is durable; Codex status is ready
- [ ] Do not merge, install, or close `#58` / `#19` without that authorization

Refs #58