### PR TITLE
Record that floor End already ships

### DIFF
--- a/docs/design/specialty-rooms.md
+++ b/docs/design/specialty-rooms.md
@@ -13,6 +13,28 @@ All specialties are projections of one active `InterviewRoomSession`. Changing t
 - The compact capsule is another presentation of the same session and phase. It never creates another recorder or conversation.
 - Interviewer turns keep one canonical pair: rich `displayMarkdown` for the room and concise `spokenText` for TTS.
 - The work surface changes by specialty while the transcript, persona, timer, privacy state, and floor rail remain consistent.
+- Floor-rail **Start** / **Pause**, **Set result**, **End**, and **Finish & next** already exist in the room. They are hosted Interview Arc timer and finish chrome, not a later design slice. They follow [Existing Pause, End, and result chrome](#existing-pause-end-and-result-chrome).
+
+## Existing Pause, End, and result chrome
+
+The full-room floor already ships these controls. This section records that fact so the concepts are not read as asking for a second End or a new session clock.
+
+| Floor control | Hosted command | Already in the room |
+| --- | --- | --- |
+| Start / Pause (elapsed chip) | `start` / `pause` | Yes — activity stopwatch on Today |
+| Set result | `set_result` / `clear_result` | Yes |
+| End | `finish` | Yes — also the close-sheet **End interview** path |
+| Finish & next | `finish-next` | Yes, when a later System Design activity exists |
+
+Authoritative behavior is Interview Arc [`docs/contracts/live-v1.md`](https://github.com/Vinosaamaa/interview-arc/blob/main/docs/contracts/live-v1.md). Do not add another local timer.
+
+**Pause** stops the bound activity stopwatch and keeps elapsed seconds. It does not require a result, does not lock the timer, and does not Hand off. **Pause recording** is separate and must not pause the hosted stopwatch by itself. Resume is Start.
+
+**End** is hosted `finish` of that activity. The server already requires a writable lease, a started unfinished timer, an **explicit** result flag, at least one satisfied candidate/interviewer pair, and no blocking Voice/clip/conflict guard. If a gate fails, the room stays open. On success the activity timer locks, Today becomes **Ready for journal**, and a parent website session finishes only when no unfinished child remains.
+
+**Set result** is required before End and never finishes the activity by itself.
+
+The six-hour website session countdown is Today’s parent-session timer, not a missing Live control. Live End already finishes that parent when it is the last unfinished child.
 
 ## Coding room
 
@@ -42,7 +64,7 @@ The language selector expresses a provider capability. Java is enabled first. Py
 
 ![System-design room concept](./system-design-room.png)
 
-The Board is an editable architecture workspace. Boxes, connectors, labels, freehand annotations, selection, undo/redo, zoom, and keyboard navigation are product behavior—not a static illustration.
+The Board is an editable architecture workspace. Boxes, connectors, labels, freehand annotations, selection, undo/redo, zoom, and keyboard navigation are product behavior—not a static illustration. The floor **Pause** and **End** in this mockup are the existing hosted activity stopwatch and hosted finish from [Existing Pause, End, and result chrome](#existing-pause-end-and-result-chrome).
 
 ### Board durability
 
@@ -50,7 +72,7 @@ The Board is an editable architecture workspace. Boxes, connectors, labels, free
 - `Attach revision` snapshots the exact board revision addressed by the current interview turn. Retrying that operation must be idempotent.
 - Preserve the editable source as the canonical board. Generate an SVG for the Interview Arc reader and a PNG for portable preview; a flattened image must never replace editable source.
 - Completed reusable system-design artifacts must remain compatible with Interview Arc's versioned `.drawio` source plus exported `.svg` contract. The board implementation must either emit that source directly or provide a deterministic, tested conversion.
-- Export is explicit and reports the exact revision and formats produced. Session finalization verifies the attached revision rather than silently exporting a newer draft.
+- Export is explicit and reports the exact revision and formats produced. Hosted **End** (activity finish) verifies the attached revision rather than silently exporting a newer draft.
 
 The exact system-design preflight is still a design decision. Until approved, Live should preserve the specialist contract: resolve the question and current/provisional Solution Profile privately, avoid revealing the expected architecture before the candidate reasons, and start from a blank or explicitly resumed owner draft.
 
@@ -81,7 +103,7 @@ Owner-attested facts are valid primary evidence when scoped explicitly. Corrobor
 
 The specialty concepts are the target product family, but they should not be built as one large slice.
 
-1. Shared session engine, transcript, patient handoff, recovery, full/compact projection, and provider-neutral agent/TTS boundaries.
+1. Shared session engine, transcript, patient handoff, recovery, full/compact projection, hosted Pause/End/result chrome, and provider-neutral agent/TTS boundaries.
 2. System-design room with an editable, revisioned board and verified export path.
 3. Coding room with the Java-first file and local-harness path; add languages only through explicit capabilities.
 4. Behavioral room after the owner-scoped evidence API from Interview Arc issue #201 is stable.

--- a/docs/engineering/changes/pr-61.md
+++ b/docs/engineering/changes/pr-61.md
@@ -1,0 +1,21 @@
+---
+schemaVersion: 1
+repository: interview-arc-live
+pr: 61
+title: Record that floor End already ships
+classification: none
+richRecordRefs: []
+reconstructed: false
+confidence: verified
+unknowns: []
+headCommit: null
+mergeCommit: null
+mergedAt: null
+sources: [{"label":"Pull request #61","url":"https://github.com/Vinosaamaa/interview-arc-live/pull/61","kind":"pull-request"},{"label":"Issue #1","url":"https://github.com/Vinosaamaa/interview-arc-live/issues/1","kind":"issue"}]
+verification: {"state":"verified","evidenceRefs":["pull-request:61","issue:1"]}
+visibility: public-safe
+publicationEligibility: eligible
+---
+# Record that floor End already ships
+
+Documented that the room already exposes hosted Start/Pause, Set result, End, and Finish & next, so specialty-room concepts do not ask for a second End control.


### PR DESCRIPTION
## Summary
- Record in specialty-room concepts that **Start / Pause**, **Set result**, **End**, and **Finish & next** already ship as hosted `/live/v1` chrome.
- Drop the missing-control framing so later work does not add a second End or a Live parent-session clock.

## Engineering impact

Select exactly one classification. If `None` is selected, replace the placeholder with a concrete reason.

Add the compact receipt for this pull request at `docs/engineering/changes/pr-61.md`. Material changes also add or amend a rich record and link its exact `id@revision` from the receipt.

- [x] None — reason: This change only documents already-shipped floor chrome in specialty-room concepts; runtime, persistence, and architecture are unchanged.
- [ ] Change Note
- [ ] ADR
- [ ] Architecture Review
- [ ] Feature Retrospective
- [ ] Postmortem
- [ ] Capability Dossier

## Verification
- Markdown-only change against current `main`.
- Local `python3 Tests/ScriptTests/engineering-impact-policy-tests.py` passed.
- Hosted Engineering policy plus Swift workflow on this PR.

## Test plan
- [x] Confirm `docs/design/specialty-rooms.md` maps floor End to hosted `finish` and states the control already exists.
- [ ] Confirm hosted CI for Engineering policy and Swift on this PR.

Refs #1