### PR TITLE
Keep idle floor quiet and Hand off as sibling chrome

### DIFF
--- a/Sources/InterviewArcLive/SystemDesignRoomView.swift
+++ b/Sources/InterviewArcLive/SystemDesignRoomView.swift
@@ -1048,7 +1048,7 @@ struct SystemDesignRoomView: View {
                     wideMinimumWidth: 132
                 )
             }
-            .buttonStyle(RoomPrimaryActionButtonStyle())
+            .buttonStyle(RoomChromeButtonStyle())
             .disabled(!model.canAct)
             .keyboardShortcut(.return, modifiers: [.command])
             .accessibilityIdentifier(FullRoomAccessibility.primaryAction)
@@ -1314,50 +1314,6 @@ private struct RoomChromeButtonStyle: ButtonStyle {
                 .animation(
                     reduceMotion ? nil : .easeOut(duration: 0.08),
                     value: configuration.isPressed
-                )
-        }
-    }
-}
-
-private struct RoomPrimaryActionButtonStyle: ButtonStyle {
-    func makeBody(configuration: Configuration) -> some View {
-        RoomPrimaryActionButtonBody(configuration: configuration)
-    }
-
-    private struct RoomPrimaryActionButtonBody: View {
-        let configuration: ButtonStyleConfiguration
-        @Environment(\.isEnabled) private var isEnabled
-        @Environment(\.accessibilityReduceMotion) private var reduceMotion
-        @State private var isHovering = false
-
-        var body: some View {
-            configuration.label
-                .frame(height: FullRoomLayout.minimumActionHitTarget)
-                .foregroundStyle(
-                    isEnabled ? Color.white : LivePalette.violet.opacity(0.42)
-                )
-                .background {
-                    Capsule()
-                        .fill(
-                            isEnabled
-                                ? LivePalette.violet.opacity(
-                                    configuration.isPressed
-                                        ? 0.82
-                                        : (isHovering ? 0.92 : 1)
-                                )
-                                : LivePalette.violet.opacity(0.12)
-                        )
-                }
-                .contentShape(Capsule())
-                .scaleEffect(
-                    reduceMotion || !isEnabled
-                        ? 1
-                        : (configuration.isPressed ? 0.98 : 1)
-                )
-                .onHover { isHovering = $0 }
-                .animation(
-                    reduceMotion ? nil : .easeOut(duration: 0.12),
-                    value: isHovering
                 )
         }
     }
@@ -1802,7 +1758,12 @@ private struct LiveWaveform: View {
                 levelCount: levels.count
             )
             for (level, x) in zip(levels, barPositions) {
-                let height = max(3, level * size.height * (isActive ? 0.88 : 0.55))
+                let height = FullRoomWaveformLayout.barHeight(
+                    level: level,
+                    canvasHeight: size.height,
+                    isActive: isActive
+                )
+                guard height > 0 else { continue }
                 var bar = Path()
                 bar.move(to: CGPoint(x: x, y: center - height / 2))
                 bar.addLine(to: CGPoint(x: x, y: center + height / 2))
@@ -1820,6 +1781,16 @@ private struct LiveWaveform: View {
 enum FullRoomWaveformLayout {
     static let traceCoverageFraction: CGFloat = 0.58
     static let horizontalInset: CGFloat = 10
+    static let activeHeightFraction: CGFloat = 0.88
+
+    static func barHeight(
+        level: Double,
+        canvasHeight: CGFloat,
+        isActive: Bool
+    ) -> CGFloat {
+        guard isActive else { return 0 }
+        return max(3, CGFloat(level) * canvasHeight * activeHeightFraction)
+    }
 
     static func barXPositions(
         width: CGFloat,

--- a/Tests/InterviewArcLiveTests/SystemDesignRoomLayoutTests.swift
+++ b/Tests/InterviewArcLiveTests/SystemDesignRoomLayoutTests.swift
@@ -447,6 +447,33 @@ final class SystemDesignRoomLayoutTests: XCTestCase {
             XCTAssertGreaterThanOrEqual(positions.first ?? -1, 0)
             XCTAssertLessThanOrEqual(positions.last ?? .infinity, width)
         }
+
+        XCTAssertEqual(
+            FullRoomWaveformLayout.barHeight(
+                level: 0.66,
+                canvasHeight: 40,
+                isActive: false
+            ),
+            0
+        )
+        XCTAssertEqual(
+            FullRoomWaveformLayout.barHeight(
+                level: 0.5,
+                canvasHeight: 40,
+                isActive: true
+            ),
+            max(3, 0.5 * 40 * FullRoomWaveformLayout.activeHeightFraction),
+            accuracy: 0.001
+        )
+        XCTAssertEqual(
+            FullRoomWaveformLayout.barHeight(
+                level: 0.01,
+                canvasHeight: 40,
+                isActive: true
+            ),
+            3,
+            accuracy: 0.001
+        )
     }
 
     func testFullRoomAccessibilityIdentifiersAreStableAndUnique() {

--- a/docs/engineering/changes/pr-68.md
+++ b/docs/engineering/changes/pr-68.md
@@ -1,0 +1,21 @@
+---
+schemaVersion: 1
+repository: interview-arc-live
+pr: 68
+title: Keep idle floor quiet and Hand off as sibling chrome
+classification: none
+richRecordRefs: []
+reconstructed: false
+confidence: verified
+unknowns: []
+headCommit: null
+mergeCommit: null
+mergedAt: null
+sources: [{"label":"Pull request #68","url":"https://github.com/Vinosaamaa/interview-arc-live/pull/68","kind":"pull-request"},{"label":"Issue #60","url":"https://github.com/Vinosaamaa/interview-arc-live/issues/60","kind":"issue"}]
+verification: {"state":"verified","evidenceRefs":["pull-request:68","issue:60"]}
+visibility: public-safe
+publicationEligibility: eligible
+---
+# Keep idle floor quiet and Hand off as sibling chrome
+
+Idle waveform bars are gone, and Hand off uses the same sibling chrome as Record instead of a filled violet capsule.

--- a/docs/engineering/changes/pr-68.md
+++ b/docs/engineering/changes/pr-68.md
@@ -3,8 +3,8 @@ schemaVersion: 1
 repository: interview-arc-live
 pr: 68
 title: Keep idle floor quiet and Hand off as sibling chrome
-classification: none
-richRecordRefs: []
+classification: change-note
+richRecordRefs: ["change-note-truthful-idle-floor-rail@1"]
 reconstructed: false
 confidence: verified
 unknowns: []
@@ -18,4 +18,4 @@ publicationEligibility: eligible
 ---
 # Keep idle floor quiet and Hand off as sibling chrome
 
-Idle waveform bars are gone, and Hand off uses the same sibling chrome as Record instead of a filled violet capsule.
+Idle LiveWaveform now draws only the quiet baseline; bars appear only while recording. Hand off uses RoomChromeButtonStyle like Record instead of a filled violet capsule. Hosted Start/Pause/Set result/End and Hand off enablement are unchanged.

--- a/docs/engineering/records/change-note-truthful-idle-floor-rail.md
+++ b/docs/engineering/records/change-note-truthful-idle-floor-rail.md
@@ -1,0 +1,43 @@
+---
+schemaVersion: 1
+id: change-note-truthful-idle-floor-rail
+revision: 1
+type: change-note
+status: accepted
+title: Keep Idle Floor Quiet And Hand Off As Sibling Chrome
+repository: interview-arc-live
+capabilityIds: ["interview-room-session"]
+createdAt: 2026-08-17
+reconstructed: false
+confidence: verified
+unknowns: []
+modules: ["system-design-room-presentation"]
+interfaces: ["full-room-waveform-layout"]
+seams: ["session-to-presentations"]
+adapters: ["full-presentation","compact-presentation"]
+relatedRecords: ["capability-dossier-deep-interview-room-session@1","adr-live-0007-retained-full-and-compact-presentations@1"]
+decisions: []
+incidents: []
+features: []
+capabilities: ["truthful-idle-floor-chrome"]
+amends: []
+supersedes: []
+learningRefs: []
+sources: [{"label":"Issue #60","url":"https://github.com/Vinosaamaa/interview-arc-live/issues/60","kind":"issue"},{"label":"Pull request #68","url":"https://github.com/Vinosaamaa/interview-arc-live/pull/68","kind":"pull-request"}]
+verification: {"state":"verified","evidenceRefs":["issue:60","pull-request:68","test:SystemDesignRoomLayoutTests.testWaveformUsesTheRailWithoutPretendingToBeRecordedAudio"]}
+visibility: public-safe
+publicationEligibility: eligible
+issue: 60
+pr: 68
+release: null
+run: null
+---
+# Keep Idle Floor Quiet And Hand Off As Sibling Chrome
+
+Idle floor chrome was drawing a live-looking violet waveform and presenting Hand off as a filled bot CTA even when no segment existed. That is product behavior, not copy: waveform motion must be truthful, and Hand off must remain available without dominating Record or hosted finish chrome.
+
+## Change
+
+`LiveWaveform` still draws the quiet baseline. `FullRoomWaveformLayout.barHeight(level:canvasHeight:isActive:)` returns `0` when `isActive` is false, so idle draws no bars, and returns the existing `max(3, level * height * 0.88)` while recording (`model.canStopRecording`). Compact and full rails share `floorRailContent(compact:)`, so both presentations change together.
+
+Hand off now uses `RoomChromeButtonStyle` like Record and Keep my floor. Enablement, shortcuts, labels, hosted Start/Pause/Set result/End, Cue Only, and Patient Auto are unchanged.


### PR DESCRIPTION
## **User description**
## Summary
- Idle waveform draws the baseline only; bars appear only while recording.
- Hand off uses the same sibling chrome as Record instead of a filled violet CTA.
- Compact and full rails share `floorRailContent(compact:)`, so both presentations change together.
- Hosted Start/Pause/Set result/End and Hand off enablement, shortcuts, and labels are unchanged.

## Engineering impact

Select exactly one classification. If `None` is selected, replace the placeholder with a concrete reason.

Add the compact receipt for this pull request at `docs/engineering/changes/pr-<number>.md`. Material changes also add or amend a rich record and link its exact `id@revision` from the receipt.

- [ ] None — reason: REPLACE WITH A CONCRETE REASON
- [x] Change Note
- [ ] ADR
- [ ] Architecture Review
- [ ] Feature Retrospective
- [ ] Postmortem
- [ ] Capability Dossier

## Verification
- Extended `SystemDesignRoomLayoutTests.testWaveformUsesTheRailWithoutPretendingToBeRecordedAudio`: idle `barHeight` is `0`; active keeps `max(3, level * height * 0.88)`; `barXPositions` unchanged.
- Local `xcodebuild` is unavailable on this machine (Command Line Tools only). Hosted Swift workflow is the package test lane.
- `python3 Tests/ScriptTests/engineering-impact-policy-tests.py` passed, and the PR 68 receipt validates as `change-note`.

## Test plan
- [ ] Idle floor shows YOUR FLOOR / No segment yet without live-looking bars.
- [ ] Recording still shows waveform bars.
- [ ] Hand off remains available and is visually a sibling of Record.
- [ ] Hosted Start/Pause/Set result/End still present with existing semantics.
- [ ] Hosted Swift workflow on this PR.

Refs #60


___

## **CodeAnt-AI Description**
Keep the idle floor truthful and align Hand off with the room controls

### What Changed
- Idle waveform displays only its baseline until recording starts, while active recording retains the existing waveform bars.
- Hand off now uses the same understated control style as Record instead of a filled violet button.
- Added coverage for idle and active waveform rendering, including the minimum active bar height.

### Impact
`✅ No live-looking waveform before recording`
`✅ Clearer visual hierarchy for Hand off and Record`
`✅ Consistent waveform behavior across idle and recording states`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
