### PR TITLE
Abandon stale foreign-session outbox rows and emit public-safe traces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,10 @@ Do not create or change a thread Goal unless the user explicitly asks.
   a Live-specific Application Support root. Never commit credentials, audio,
   transcripts, model caches, private IDs, personal paths, or personal contact
   information.
+- Emit public-safe `LiveDebugTrace` events at hosted/session/handoff
+  boundaries (command, phase, result code, counts). Never log secrets,
+  transcripts, audio, private IDs, or paths. Traces must not change control
+  flow.
 
 ## Architecture
 

--- a/Sources/InterviewArcLive/HostedPracticeController.swift
+++ b/Sources/InterviewArcLive/HostedPracticeController.swift
@@ -1,4 +1,5 @@
 import Foundation
+import InterviewArcLiveCore
 import InterviewArcLiveHostedClient
 
 @MainActor
@@ -239,6 +240,10 @@ final class HostedPracticeController: ObservableObject {
             errorMessage = "Interview Arc is offline. Local recovery data is retained."
         case .recoveryRequired(let code):
             errorMessage = "Hosted recovery is required before recording (\(code))."
+            LiveDebugTrace.event(
+                "hosted.connection",
+                ["connection": snapshot.connection.debugCode]
+            )
         case .noOpenSystemDesignActivity:
             errorMessage = "Add a System Design activity to Today in Interview Arc."
         case .loading, .readOnly, .writable:

--- a/Sources/InterviewArcLive/SystemDesignRoomModel.swift
+++ b/Sources/InterviewArcLive/SystemDesignRoomModel.swift
@@ -1086,7 +1086,13 @@ final class SystemDesignRoomModel: ObservableObject {
         isCheckingCodex = true
         errorMessage = nil
         errorWasCodexFailure = false
-        defer { isWorking = false }
+        defer {
+            isWorking = false
+            LiveDebugTrace.event(
+                "room.open.end",
+                ["ok": coordinator == nil ? "false" : "true"]
+            )
+        }
 
         async let codexCheck = codexRuntime.preflight()
 
@@ -1095,6 +1101,10 @@ final class SystemDesignRoomModel: ObservableObject {
         var launchActivityID = "local-system-design-tracer"
         if let hostedController {
             hostedSnapshot = await hostedController.open()
+            LiveDebugTrace.event(
+                "room.open.hosted",
+                ["connection": hostedSnapshot.connection.debugCode]
+            )
             switch hostedSnapshot.connection {
             case .signedOut:
                 isLiveIntegrationSetupPresented = true
@@ -1112,9 +1122,11 @@ final class SystemDesignRoomModel: ObservableObject {
                 statusMessage = hostedController.errorMessage
                     ?? "Hosted recovery needs attention"
                 errorMessage = hostedController.errorMessage
-                isCheckingCodex = false
-                _ = await codexCheck
-                return
+                if hostedSnapshot.activity == nil {
+                    isCheckingCodex = false
+                    _ = await codexCheck
+                    return
+                }
             case .loading:
                 statusMessage = "Reading Interview Arc Today…"
             case .readOnly, .writable:
@@ -1259,6 +1271,10 @@ final class SystemDesignRoomModel: ObservableObject {
         defer { isCheckingCodex = false }
 
         applyCodexReadiness(await codexRuntime.preflight())
+        LiveDebugTrace.event(
+            "codex.preflight",
+            ["ok": isCodexReady ? "true" : "false"]
+        )
     }
 
     func saveLiveIntegrationToken(_ value: String, untilQuit: Bool) async {
@@ -1358,6 +1374,10 @@ final class SystemDesignRoomModel: ObservableObject {
     }
 
     func recordSegment() async {
+        LiveDebugTrace.event(
+            "room.record",
+            ["ok": canRecordSegment ? "true" : "false"]
+        )
         guard let coordinator else { return }
         guard hasUsableGroqCredential else {
             presentCredentialSetup()
@@ -1553,6 +1573,13 @@ final class SystemDesignRoomModel: ObservableObject {
     }
 
     func performPrimaryAction() async {
+        LiveDebugTrace.event(
+            "room.handoff",
+            [
+                "phase": snapshot?.phase.rawValue ?? "none",
+                "ok": canAct ? "true" : "false",
+            ]
+        )
         guard let coordinator, let snapshot else { return }
         if snapshot.phase == .candidateFloor,
            boardAttachmentForHandOff == nil {
@@ -1926,16 +1953,19 @@ final class SystemDesignRoomModel: ObservableObject {
 
         do {
             try await credentialStore.saveAndVerify(value)
+            LiveDebugTrace.event("groq.save", ["ok": "true"])
             credentialState = .readyFromKeychain
             statusMessage = segments.contains(where: { $0.transcriptionAction != nil })
                 ? "Groq key saved to Keychain · transcribe the affected segment"
                 : status(for: snapshot)
             return true
         } catch let error as LiveGroqCredentialStoreError {
+            LiveDebugTrace.event("groq.save", ["ok": "false"])
             credentialState = .unusable
             credentialErrorMessage = error.localizedDescription
             return false
         } catch {
+            LiveDebugTrace.event("groq.save", ["ok": "false"])
             credentialState = .unusable
             credentialErrorMessage = "macOS Keychain could not save the Groq API key."
             return false

--- a/Sources/InterviewArcLiveCore/LiveDebugTrace.swift
+++ b/Sources/InterviewArcLiveCore/LiveDebugTrace.swift
@@ -1,0 +1,43 @@
+import Foundation
+import os
+
+/// Public-safe runtime traces for Live. Values are allow-listed and sanitized
+/// so unified logs never carry secrets, transcripts, audio, private IDs, or
+/// paths. Emitting a trace must not change control flow.
+public enum LiveDebugTrace: Sendable {
+    public static let subsystem = "app.interviewarc.live"
+
+    private static let logger = Logger(subsystem: subsystem, category: "trace")
+
+    private static let allowedKeys: Set<String> = [
+        "code",
+        "connection",
+        "count",
+        "ok",
+        "operation",
+        "phase",
+        "reason",
+    ]
+
+    public static func event(_ name: String, _ fields: [String: String] = [:]) {
+        var parts = ["event=\(token(name))"]
+        for key in fields.keys.sorted() where allowedKeys.contains(key) {
+            parts.append("\(key)=\(token(fields[key] ?? ""))")
+        }
+        let line = parts.joined(separator: " ")
+        logger.debug("\(line, privacy: .public)")
+    }
+
+    public static func token(_ value: String) -> String {
+        if value.isEmpty { return "empty" }
+        if value.count > 64 { return "redacted" }
+        if value.contains("/") || value.contains("\\") { return "redacted" }
+        if value.hasPrefix("sk-") || value.hasPrefix("gsk_") { return "redacted" }
+        if value.contains("@") { return "redacted" }
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "._-"))
+        guard value.unicodeScalars.allSatisfy({ allowed.contains($0) }) else {
+            return "redacted"
+        }
+        return value
+    }
+}

--- a/Sources/InterviewArcLiveHostedClient/HostedPracticeSession.swift
+++ b/Sources/InterviewArcLiveHostedClient/HostedPracticeSession.swift
@@ -1,4 +1,5 @@
 import Foundation
+import InterviewArcLiveCore
 
 public protocol LiveClock: Sendable {
     func epochMilliseconds() -> LiveEpochMilliseconds
@@ -20,6 +21,19 @@ public enum HostedPracticeConnection: Equatable, Sendable {
     case writable
     case offline
     case recoveryRequired(code: String)
+
+    public var debugCode: String {
+        switch self {
+        case .signedOut: "signedOut"
+        case .loading: "loading"
+        case .noOpenSystemDesignActivity: "noOpenSystemDesignActivity"
+        case .readOnly: "readOnly"
+        case .writable: "writable"
+        case .offline: "offline"
+        case .recoveryRequired(let code):
+            "recoveryRequired.\(LiveDebugTrace.token(code))"
+        }
+    }
 }
 
 public struct HostedPracticeSnapshot: Equatable, Sendable {
@@ -133,6 +147,7 @@ public actor HostedPracticeSession {
 
     @discardableResult
     public func open(acquireWriterLease: Bool = true) async -> HostedPracticeSnapshot {
+        LiveDebugTrace.event("hosted.open.start")
         state = copy(connection: .loading)
         do {
             let fingerprint = try await tokenReader.credentialFingerprint()
@@ -206,6 +221,13 @@ public actor HostedPracticeSession {
         } catch {
             state = copy(connection: .offline)
         }
+        LiveDebugTrace.event(
+            "hosted.open.end",
+            [
+                "connection": state.connection.debugCode,
+                "count": "\(state.pendingOperationCount)",
+            ]
+        )
         return state
     }
 
@@ -578,9 +600,21 @@ public actor HostedPracticeSession {
                 credentialFingerprint: credentialFingerprint
             )
             applyRecoveredReceipt(record)
+            LiveDebugTrace.event(
+                "hosted.recover.receipt",
+                ["operation": record.operation, "ok": "true"]
+            )
             return true
         } catch let error as LiveV1ClientError {
             guard error.code == "receipt_not_found" else {
+                LiveDebugTrace.event(
+                    "hosted.recover.receipt",
+                    [
+                        "operation": record.operation,
+                        "ok": "false",
+                        "code": error.code ?? "hosted_response",
+                    ]
+                )
                 if error.code == "unauthorized" {
                     state = copy(connection: .signedOut)
                 } else {
@@ -591,17 +625,28 @@ public actor HostedPracticeSession {
         }
 
         guard record.holderSessionId == holderSessionID else {
-            try await markRecovery(
-                record,
-                error: LiveV1ClientError.server(
-                    statusCode: 404,
-                    code: "receipt_not_found",
-                    retryable: false
-                )
+            // A previous room prepared this mutation. Replaying it would
+            // rewrite that session's fence. The server has no receipt, so
+            // abandon the row and let this launch acquire a fresh lease.
+            LiveDebugTrace.event(
+                "hosted.recover.abandon",
+                [
+                    "operation": record.operation,
+                    "code": "receipt_not_found",
+                    "reason": "foreign_holder_session",
+                ]
             )
-            return false
+            try await outbox.remove(
+                operationID: record.operationId,
+                credentialFingerprint: credentialFingerprint
+            )
+            return true
         }
         do {
+            LiveDebugTrace.event(
+                "hosted.recover.replay",
+                ["operation": record.operation]
+            )
             if record.method == .put {
                 try await replayClipUpload(record)
             } else {

--- a/Tests/InterviewArcLiveCoreTests/LiveDebugTraceTests.swift
+++ b/Tests/InterviewArcLiveCoreTests/LiveDebugTraceTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+
+import InterviewArcLiveCore
+
+final class LiveDebugTraceTests: XCTestCase {
+    func testTokenKeepsShortPublicCodes() {
+        XCTAssertEqual(LiveDebugTrace.token("receipt_not_found"), "receipt_not_found")
+        XCTAssertEqual(LiveDebugTrace.token("lease.renew"), "lease.renew")
+        XCTAssertEqual(LiveDebugTrace.token("foreign_holder_session"), "foreign_holder_session")
+    }
+
+    func testTokenRedactsSecretsPathsAndLongValues() {
+        XCTAssertEqual(LiveDebugTrace.token("sk-example"), "redacted")
+        XCTAssertEqual(LiveDebugTrace.token("gsk_example"), "redacted")
+        XCTAssertEqual(LiveDebugTrace.token("/Users/example/Library"), "redacted")
+        XCTAssertEqual(LiveDebugTrace.token("owner@example.com"), "redacted")
+        XCTAssertEqual(LiveDebugTrace.token(String(repeating: "a", count: 65)), "redacted")
+        XCTAssertEqual(LiveDebugTrace.token("hello world"), "redacted")
+    }
+}

--- a/Tests/InterviewArcLiveHostedClientTests/HostedPracticeSessionTests.swift
+++ b/Tests/InterviewArcLiveHostedClientTests/HostedPracticeSessionTests.swift
@@ -166,11 +166,8 @@ final class HostedPracticeSessionTests: XCTestCase {
 
         let snapshot = await fixture.session.open()
 
-        XCTAssertEqual(
-            snapshot.connection,
-            .recoveryRequired(code: "receipt_not_found")
-        )
-        XCTAssertEqual(snapshot.pendingOperationCount, 1)
+        XCTAssertEqual(snapshot.connection, .writable)
+        XCTAssertEqual(snapshot.pendingOperationCount, 0)
         let paths = await fixture.transport.paths()
         XCTAssertEqual(
             paths,
@@ -178,8 +175,10 @@ final class HostedPracticeSessionTests: XCTestCase {
                 "/live/v1/today",
                 "/live/v1/activities/activity-1",
                 "/live/v1/activities/activity-1/receipts/old-op",
+                "/live/v1/activities/activity-1/lease/acquire",
             ]
         )
+        XCTAssertEqual(await fixture.transport.commandBodies(), [])
     }
 
     func testCredentialChangeQuarantineNeverAcquiresWritableLease() async throws {

--- a/Tests/InterviewArcLiveHostedClientTests/HostedPracticeSessionTests.swift
+++ b/Tests/InterviewArcLiveHostedClientTests/HostedPracticeSessionTests.swift
@@ -178,7 +178,8 @@ final class HostedPracticeSessionTests: XCTestCase {
                 "/live/v1/activities/activity-1/lease/acquire",
             ]
         )
-        XCTAssertEqual(await fixture.transport.commandBodies(), [])
+        let commandBodies = await fixture.transport.commandBodies()
+        XCTAssertEqual(commandBodies, [])
     }
 
     func testCredentialChangeQuarantineNeverAcquiresWritableLease() async throws {

--- a/docs/engineering/changes/pr-74.md
+++ b/docs/engineering/changes/pr-74.md
@@ -1,0 +1,21 @@
+---
+schemaVersion: 1
+repository: interview-arc-live
+pr: 74
+title: Abandon stale foreign-session outbox rows and emit public-safe traces
+classification: change-note
+richRecordRefs: ["change-note-abandon-foreign-outbox-debug-trace@1"]
+reconstructed: false
+confidence: verified
+unknowns: []
+headCommit: null
+mergeCommit: null
+mergedAt: null
+sources: [{"label":"Pull request #74","url":"https://github.com/Vinosaamaa/interview-arc-live/pull/74","kind":"pull-request"},{"label":"Issue #72","url":"https://github.com/Vinosaamaa/interview-arc-live/issues/72","kind":"issue"},{"label":"Issue #19","url":"https://github.com/Vinosaamaa/interview-arc-live/issues/19","kind":"issue"}]
+verification: {"state":"verified","evidenceRefs":["pull-request:74","issue:72","issue:19"]}
+visibility: public-safe
+publicationEligibility: eligible
+---
+# Abandon stale foreign-session outbox rows and emit public-safe traces
+
+Foreign-session outbox rows with receipt_not_found are abandoned instead of bricking launch. LiveDebugTrace emits public-safe hosted and room events.

--- a/docs/engineering/records/change-note-abandon-foreign-outbox-debug-trace.md
+++ b/docs/engineering/records/change-note-abandon-foreign-outbox-debug-trace.md
@@ -1,0 +1,43 @@
+---
+schemaVersion: 1
+id: change-note-abandon-foreign-outbox-debug-trace
+revision: 1
+type: change-note
+status: accepted
+title: Abandon Foreign-Session Outbox 404s And Emit Public-Safe Traces
+repository: interview-arc-live
+capabilityIds: ["hosted-practice-authority","system-design-room"]
+createdAt: 2026-08-17
+reconstructed: false
+confidence: verified
+unknowns: []
+modules: ["hosted-practice-session","system-design-room-model"]
+interfaces: ["hosted-practice-session","live-debug-trace"]
+seams: ["outbox-to-receipt-recovery","hosted-today-to-local-coordinator"]
+adapters: []
+relatedRecords: ["architecture-review-hosted-practice-authority@1"]
+decisions: ["0009-authoritative-hosted-practice-session"]
+incidents: []
+features: []
+capabilities: ["abandon-foreign-outbox","public-safe-debug-trace"]
+amends: []
+supersedes: []
+learningRefs: []
+sources: [{"label":"Issue #72","url":"https://github.com/Vinosaamaa/interview-arc-live/issues/72","kind":"issue"},{"label":"Issue #19","url":"https://github.com/Vinosaamaa/interview-arc-live/issues/19","kind":"issue"},{"label":"Pull request #74","url":"https://github.com/Vinosaamaa/interview-arc-live/pull/74","kind":"pull-request"}]
+verification: {"state":"verified","evidenceRefs":["issue:72","issue:19","pull-request:74"]}
+visibility: public-safe
+publicationEligibility: eligible
+issue: 72
+pr: 74
+release: null
+run: null
+---
+# Abandon Foreign-Session Outbox 404s And Emit Public-Safe Traces
+
+A previous room can leave a prepared mutation in the private outbox. After relaunch the holder session is new, so receipt lookup 404s. ADR 0009 forbids replaying that body because it would rewrite the old fence. The previous client marked `recoveryRequired(receipt_not_found)` and returned before creating the local coordinator, so Board claimed the room was still restoring and Record stayed disabled.
+
+## Change
+
+`HostedPracticeSession.recover` now removes a foreign-session row when the receipt is `receipt_not_found`, continues the drain, and lets `open()` acquire a fresh lease. Same-session 404s still receipt-then-replay. If hosted connection is recovery-required or offline but Today already has an activity, `SystemDesignRoomModel.open` still binds the local coordinator. Record remains gated on a writable lease.
+
+`LiveDebugTrace` writes allow-listed command, phase, result-code, and count fields to the `app.interviewarc.live` unified log. Tokens, transcripts, audio, private IDs, and paths are rejected.


### PR DESCRIPTION
## **User description**
## Summary
- Foreign-session outbox rows whose receipt 404s are abandoned instead of bricking every later launch with `receipt_not_found`.
- The old canonical body is never replayed (ADR 0009: do not rewrite a previous holder-session fence).
- If hosted recovery is still visible but Today already has a System Design activity, the local coordinator still opens so Board is not blocked on a false “restoring” state.
- `LiveDebugTrace` emits public-safe command/phase/result-code events on the `app.interviewarc.live` subsystem.

## Engineering impact

Select exactly one classification. If `None` is selected, replace the placeholder with the exact reason.

- [ ] None — reason: REPLACE_WITH_REASON
- [x] Change Note
- [ ] ADR
- [ ] Architecture Review
- [ ] Feature Retrospective
- [ ] Postmortem
- [ ] Capability Dossier

## Test plan
- [ ] Hosted client test: foreign-session `receipt_not_found` does not POST the old body and continues to lease acquire
- [ ] Existing same-session receipt-then-replay tests still pass
- [ ] `LiveDebugTrace` token tests redact secrets/paths
- [ ] Installed smoke: after a stuck `lease.renew`, relaunch is writable; Board editable; Record gated on writable lease
- [ ] `log show --predicate 'subsystem == "app.interviewarc.live"'` shows open/recover/abandon events with no tokens or transcripts

Refs #72
Refs #19

Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
Recover from stale hosted sessions without blocking room access

### What Changed
- Stale outbox entries from a previous room are discarded when their receipt is missing, allowing the next launch to acquire a fresh writable lease without replaying the old command.
- The System Design room can open when hosted recovery is offline or required if Today already contains the activity; recording remains unavailable until the current lease is writable.
- Hosted sessions, room actions, handoffs, and credential checks now produce searchable diagnostics that expose only safe event codes, phases, results, and counts.
- Added coverage for stale-session recovery and redaction of secrets, paths, contact details, and long values.

### Impact
`✅ Fewer launches blocked by stale session recovery`
`✅ No replay of commands from previous room sessions`
`✅ Safer diagnostics without exposing credentials or private data`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
