### PR TITLE
Tick the hosted floor timer and live recording waveform

### DIFF
--- a/Sources/InterviewArcLive/SystemDesignRoomModel.swift
+++ b/Sources/InterviewArcLive/SystemDesignRoomModel.swift
@@ -144,6 +144,8 @@ final class SystemDesignRoomModel: ObservableObject {
     @Published private(set) var candidateNotesDraft = ""
     @Published private(set) var candidateNotesSavePresentation: CandidateNotesSavePresentation = .saved
     @Published private(set) var isFinishingInterview = false
+    @Published private(set) var recordingPowerHistory: [Float] = []
+    @Published private(set) var recordingElapsedSeconds: TimeInterval = 0
 
     @Published var isCredentialSetupPresented = false
     @Published private(set) var isSavingCredential = false
@@ -189,6 +191,7 @@ final class SystemDesignRoomModel: ObservableObject {
     private var credentialState: CredentialState = .checking
     private var errorWasCodexFailure = false
     private var coordinator: SegmentSpeechCoordinator?
+    private var segmentRecorder: VoiceCoreSegmentRecorder?
     private var interviewerSpeechCoordinator: InterviewerSpeechCoordinator?
     private var speechPreparationTask: Task<Void, Never>?
     private var audioPlayer: AVAudioPlayer?
@@ -273,13 +276,16 @@ final class SystemDesignRoomModel: ObservableObject {
     }
 
     var hostedElapsedText: String? {
+        hostedElapsedText(at: Date())
+    }
+
+    func hostedElapsedText(at date: Date) -> String? {
         guard let seconds = hostedSnapshot.elapsedSeconds(
             localNow: LiveEpochMilliseconds(
-                (Date().timeIntervalSince1970 * 1_000).rounded()
+                (date.timeIntervalSince1970 * 1_000).rounded()
             )
         ) else { return nil }
-        let total = max(0, Int(seconds.rounded(.down)))
-        return String(format: "%02d:%02d", total / 60, total % 60)
+        return FullRoomHostedTimerLayout.elapsedText(seconds: seconds)
     }
 
     var hostedResult: LiveResult? {
@@ -1158,7 +1164,7 @@ final class SystemDesignRoomModel: ObservableObject {
                 activityPrompt: launchPrompt,
                 turnMode: .manual,
                 interviewerRuntime: codexRuntime,
-                recording: VoiceCoreSegmentRecorder(),
+                recording: makeBoundSegmentRecorder(),
                 transcriber: VoiceCoreSegmentTranscriber(),
                 credentialReader: credentialStore,
                 semanticEndpointClassifier: GroqEndpointClassifier(
@@ -1688,6 +1694,10 @@ final class SystemDesignRoomModel: ObservableObject {
         speechPreparationTask = nil
         interviewerSpeechCoordinator = nil
         coordinator = nil
+        segmentRecorder?.onMetering = nil
+        segmentRecorder = nil
+        recordingPowerHistory = []
+        recordingElapsedSeconds = 0
         snapshot = nil
         segments = []
         localPersistenceTail = nil
@@ -2022,6 +2032,16 @@ final class SystemDesignRoomModel: ObservableObject {
             ),
             audioStore: audioStore
         )
+    }
+
+    private func makeBoundSegmentRecorder() -> VoiceCoreSegmentRecorder {
+        let recorder = VoiceCoreSegmentRecorder()
+        segmentRecorder = recorder
+        recorder.onMetering = { [weak self] sample in
+            self?.recordingPowerHistory = sample.powerHistory
+            self?.recordingElapsedSeconds = sample.elapsedSeconds
+        }
+        return recorder
     }
 
     private static func makeDefaultCodexRuntime(

--- a/Sources/InterviewArcLive/SystemDesignRoomView.swift
+++ b/Sources/InterviewArcLive/SystemDesignRoomView.swift
@@ -951,7 +951,11 @@ struct SystemDesignRoomView: View {
             .accessibilityLabel(floorState.full.label)
             .accessibilityValue(floorState.full.detail)
 
-            LiveWaveform(isActive: model.canStopRecording)
+            LiveWaveform(
+                isActive: model.canStopRecording,
+                powerHistory: model.recordingPowerHistory,
+                elapsedSeconds: model.recordingElapsedSeconds
+            )
                 .frame(
                     minWidth: compact
                         ? FullRoomLayout.floorCompactWaveformWidth
@@ -964,16 +968,21 @@ struct SystemDesignRoomView: View {
                 Button {
                     Task { await model.toggleHostedTimer() }
                 } label: {
-                    floorActionLabel(
-                        model.hostedElapsedText
-                            ?? (model.hostedTimerIsRunning ? "Pause" : "Start"),
-                        systemImage: model.hostedTimerIsRunning
-                            ? "pause.circle.fill"
-                            : "play.circle.fill",
-                        compact: compact,
-                        wideMinimumWidth: 76
-                    )
-                    .monospacedDigit()
+                    TimelineView(.periodic(from: .now, by: 1)) { context in
+                        floorActionLabel(
+                            model.hostedElapsedText(at: context.date)
+                                ?? (model.hostedTimerIsRunning ? "Pause" : "Start"),
+                            systemImage: model.hostedTimerIsRunning
+                                ? "pause.circle.fill"
+                                : "play.circle.fill",
+                            compact: compact,
+                            wideMinimumWidth: 76
+                        )
+                        .monospacedDigit()
+                        .accessibilityValue(
+                            model.hostedElapsedText(at: context.date) ?? ""
+                        )
+                    }
                 }
                 .buttonStyle(.bordered)
                 .disabled(!model.isHostedWritable)
@@ -1734,12 +1743,9 @@ enum LivePalette {
 
 private struct LiveWaveform: View {
     let isActive: Bool
-
-    private let levels: [Double] = [
-        0.18, 0.42, 0.24, 0.66, 0.31, 0.52, 0.2, 0.76, 0.38, 0.24,
-        0.58, 0.33, 0.7, 0.28, 0.45, 0.2, 0.62, 0.35, 0.22, 0.48,
-        0.3, 0.68, 0.26, 0.5, 0.21, 0.4, 0.18, 0.34, 0.2, 0.28,
-    ]
+    let powerHistory: [Float]
+    let elapsedSeconds: TimeInterval
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         Canvas { context, size in
@@ -1753,15 +1759,21 @@ private struct LiveWaveform: View {
                 lineWidth: 1
             )
 
+            let levels = FullRoomWaveformLayout.displayedLevels(
+                powerHistory: powerHistory
+            )
             let barPositions = FullRoomWaveformLayout.barXPositions(
                 width: size.width,
                 levelCount: levels.count
             )
-            for (level, x) in zip(levels, barPositions) {
+            for (index, (level, x)) in zip(levels, barPositions).enumerated() {
                 let height = FullRoomWaveformLayout.barHeight(
-                    level: level,
+                    decibel: level,
                     canvasHeight: size.height,
-                    isActive: isActive
+                    isActive: isActive,
+                    elapsedSeconds: elapsedSeconds,
+                    index: index,
+                    reduceMotion: reduceMotion
                 )
                 guard height > 0 else { continue }
                 var bar = Path()
@@ -1774,7 +1786,17 @@ private struct LiveWaveform: View {
                 )
             }
         }
-        .accessibilityHidden(true)
+        .accessibilityHidden(!isActive)
+        .accessibilityLabel("Live microphone level")
+        .animation(.linear(duration: 0.09), value: powerHistory)
+        .animation(.linear(duration: 0.09), value: elapsedSeconds)
+    }
+}
+
+enum FullRoomHostedTimerLayout {
+    static func elapsedText(seconds: Double) -> String {
+        let total = max(0, Int(seconds.rounded(.down)))
+        return String(format: "%02d:%02d", total / 60, total % 60)
     }
 }
 
@@ -1782,6 +1804,22 @@ enum FullRoomWaveformLayout {
     static let traceCoverageFraction: CGFloat = 0.58
     static let horizontalInset: CGFloat = 10
     static let activeHeightFraction: CGFloat = 0.88
+    static let sampleCount = 30
+    static let pulseAmplitude = 0.18
+
+    static func displayedLevels(powerHistory: [Float]) -> [Float] {
+        Array(
+            (
+                Array(repeating: Float(-60), count: sampleCount)
+                    + powerHistory
+            )
+            .suffix(sampleCount)
+        )
+    }
+
+    static func normalizedLevel(_ decibel: Float) -> Double {
+        Double(max(0.08, min(1, (decibel + 55) / 45)))
+    }
 
     static func barHeight(
         level: Double,
@@ -1790,6 +1828,30 @@ enum FullRoomWaveformLayout {
     ) -> CGFloat {
         guard isActive else { return 0 }
         return max(3, CGFloat(level) * canvasHeight * activeHeightFraction)
+    }
+
+    static func barHeight(
+        decibel: Float,
+        canvasHeight: CGFloat,
+        isActive: Bool,
+        elapsedSeconds: TimeInterval,
+        index: Int,
+        reduceMotion: Bool
+    ) -> CGFloat {
+        guard isActive else { return 0 }
+        let normalized = normalizedLevel(decibel)
+        let pulse: Double
+        if reduceMotion {
+            pulse = 1
+        } else {
+            pulse = 0.82
+                + pulseAmplitude
+                * sin(elapsedSeconds * 11 + Double(index) * 0.72)
+        }
+        return max(
+            3,
+            canvasHeight * activeHeightFraction * CGFloat(normalized * pulse)
+        )
     }
 
     static func barXPositions(

--- a/Sources/InterviewArcLiveVoiceAdapter/VoiceCoreRecordingDriver.swift
+++ b/Sources/InterviewArcLiveVoiceAdapter/VoiceCoreRecordingDriver.swift
@@ -78,6 +78,7 @@ final class AnswerRecorderDriver: VoiceCoreRecordingDriving {
     }
 
     private func beginMetering() {
+        meteringCancellable?.cancel()
         meteringCancellable = Publishers.CombineLatest(
             recorder.$powerHistory,
             recorder.$elapsedSeconds

--- a/Sources/InterviewArcLiveVoiceAdapter/VoiceCoreRecordingDriver.swift
+++ b/Sources/InterviewArcLiveVoiceAdapter/VoiceCoreRecordingDriver.swift
@@ -1,9 +1,26 @@
+import Combine
 import Foundation
 import InterviewArcVoiceCore
+
+public struct VoiceCoreRecordingMetering: Equatable, Sendable {
+    public var powerHistory: [Float]
+    public var elapsedSeconds: TimeInterval
+
+    public static let idle = VoiceCoreRecordingMetering(
+        powerHistory: [],
+        elapsedSeconds: 0
+    )
+
+    public init(powerHistory: [Float], elapsedSeconds: TimeInterval) {
+        self.powerHistory = powerHistory
+        self.elapsedSeconds = elapsedSeconds
+    }
+}
 
 @MainActor
 protocol VoiceCoreRecordingDriving: AnyObject {
     var onUnexpectedTermination: (@MainActor () -> Void)? { get set }
+    var onMetering: (@MainActor (VoiceCoreRecordingMetering) -> Void)? { get set }
 
     func start(
         at destinationURL: URL,
@@ -16,6 +33,7 @@ protocol VoiceCoreRecordingDriving: AnyObject {
 @MainActor
 final class AnswerRecorderDriver: VoiceCoreRecordingDriving {
     private let recorder: AnswerRecorder
+    private var meteringCancellable: AnyCancellable?
 
     convenience init() {
         self.init(recorder: AnswerRecorder())
@@ -23,24 +41,60 @@ final class AnswerRecorderDriver: VoiceCoreRecordingDriving {
 
     init(recorder: AnswerRecorder) {
         self.recorder = recorder
+        recorder.onUnexpectedTermination = { [weak self] in
+            self?.endMetering()
+            self?.unexpectedTerminationClient?()
+        }
     }
 
+    private var unexpectedTerminationClient: (@MainActor () -> Void)?
+
     var onUnexpectedTermination: (@MainActor () -> Void)? {
-        get { recorder.onUnexpectedTermination }
-        set { recorder.onUnexpectedTermination = newValue }
+        get { unexpectedTerminationClient }
+        set { unexpectedTerminationClient = newValue }
     }
+
+    var onMetering: (@MainActor (VoiceCoreRecordingMetering) -> Void)?
 
     func start(
         at destinationURL: URL,
         captureBackendDidStart: @escaping @MainActor () -> Void
     ) async throws {
-        try await recorder.start(
-            at: destinationURL,
-            captureBackendDidStart: captureBackendDidStart
-        )
+        beginMetering()
+        do {
+            try await recorder.start(
+                at: destinationURL,
+                captureBackendDidStart: captureBackendDidStart
+            )
+        } catch {
+            endMetering()
+            throw error
+        }
     }
 
     func stop() throws -> RecordedCapture {
-        try recorder.stop()
+        defer { endMetering() }
+        return try recorder.stop()
+    }
+
+    private func beginMetering() {
+        meteringCancellable = Publishers.CombineLatest(
+            recorder.$powerHistory,
+            recorder.$elapsedSeconds
+        )
+        .sink { [weak self] history, elapsed in
+            self?.onMetering?(
+                VoiceCoreRecordingMetering(
+                    powerHistory: history,
+                    elapsedSeconds: elapsed
+                )
+            )
+        }
+    }
+
+    private func endMetering() {
+        meteringCancellable?.cancel()
+        meteringCancellable = nil
+        onMetering?(.idle)
     }
 }

--- a/Sources/InterviewArcLiveVoiceAdapter/VoiceCoreSegmentRecorder.swift
+++ b/Sources/InterviewArcLiveVoiceAdapter/VoiceCoreSegmentRecorder.swift
@@ -37,6 +37,11 @@ public final class VoiceCoreSegmentRecorder: SegmentRecording {
     private var unexpectedTerminationHandler: (@MainActor @Sendable () -> Void)?
     private var didReportUnexpectedTermination = false
 
+    public var onMetering: (@MainActor (VoiceCoreRecordingMetering) -> Void)? {
+        get { driver.onMetering }
+        set { driver.onMetering = newValue }
+    }
+
     public convenience init() {
         self.init(
             driver: AnswerRecorderDriver(),

--- a/Tests/InterviewArcLiveHostedClientTests/HostedPracticeSessionTests.swift
+++ b/Tests/InterviewArcLiveHostedClientTests/HostedPracticeSessionTests.swift
@@ -420,6 +420,7 @@ final class HostedPracticeSessionTests: XCTestCase {
         let snapshot = await fixture.session.open()
 
         XCTAssertEqual(snapshot.elapsedSeconds(localNow: 1_005_000), 35)
+        XCTAssertEqual(snapshot.elapsedSeconds(localNow: 1_006_000), 36)
         XCTAssertEqual(snapshot.activity?.activity.timer?.accumulatedSeconds, 10)
     }
 

--- a/Tests/InterviewArcLiveTests/SystemDesignRoomLayoutTests.swift
+++ b/Tests/InterviewArcLiveTests/SystemDesignRoomLayoutTests.swift
@@ -476,6 +476,61 @@ final class SystemDesignRoomLayoutTests: XCTestCase {
         )
     }
 
+    func testHostedElapsedTextFormatsWholeSeconds() {
+        XCTAssertEqual(FullRoomHostedTimerLayout.elapsedText(seconds: 0), "00:00")
+        XCTAssertEqual(FullRoomHostedTimerLayout.elapsedText(seconds: 61.9), "01:01")
+        XCTAssertEqual(FullRoomHostedTimerLayout.elapsedText(seconds: -3), "00:00")
+        XCTAssertEqual(FullRoomHostedTimerLayout.elapsedText(seconds: 3599), "59:59")
+        XCTAssertEqual(FullRoomHostedTimerLayout.elapsedText(seconds: 3600), "60:00")
+    }
+
+    func testRecordingWaveformUsesMicrophoneDecibelsAndStaysIdleWhenQuiet() {
+        let levels = FullRoomWaveformLayout.displayedLevels(
+            powerHistory: [-12, -18]
+        )
+        XCTAssertEqual(levels.count, FullRoomWaveformLayout.sampleCount)
+        XCTAssertEqual(levels.suffix(2).map(Float.init), [-12, -18])
+        XCTAssertEqual(levels.first, -60)
+
+        XCTAssertEqual(
+            FullRoomWaveformLayout.barHeight(
+                decibel: -12,
+                canvasHeight: 40,
+                isActive: false,
+                elapsedSeconds: 1.4,
+                index: 3,
+                reduceMotion: false
+            ),
+            0
+        )
+
+        let reduced = FullRoomWaveformLayout.barHeight(
+            decibel: -12,
+            canvasHeight: 40,
+            isActive: true,
+            elapsedSeconds: 0,
+            index: 0,
+            reduceMotion: true
+        )
+        let pulsed = FullRoomWaveformLayout.barHeight(
+            decibel: -12,
+            canvasHeight: 40,
+            isActive: true,
+            elapsedSeconds: 0,
+            index: 0,
+            reduceMotion: false
+        )
+        let expectedReduced = max(
+            3,
+            40
+                * FullRoomWaveformLayout.activeHeightFraction
+                * CGFloat(FullRoomWaveformLayout.normalizedLevel(-12))
+        )
+        XCTAssertEqual(reduced, expectedReduced, accuracy: 0.001)
+        XCTAssertNotEqual(pulsed, reduced, accuracy: 0.001)
+        XCTAssertGreaterThan(pulsed, 3)
+    }
+
     func testFullRoomAccessibilityIdentifiersAreStableAndUnique() {
         XCTAssertEqual(
             Set(FullRoomAccessibility.allIdentifiers).count,

--- a/Tests/InterviewArcLiveVoiceAdapterTests/VoiceCoreSegmentRecorderTests.swift
+++ b/Tests/InterviewArcLiveVoiceAdapterTests/VoiceCoreSegmentRecorderTests.swift
@@ -248,6 +248,7 @@ final class VoiceCoreSegmentRecorderTests: XCTestCase {
 @MainActor
 private final class RecordingDriverSpy: VoiceCoreRecordingDriving {
     var onUnexpectedTermination: (@MainActor () -> Void)?
+    var onMetering: (@MainActor (VoiceCoreRecordingMetering) -> Void)?
     var finalFileName: String
     var finalizedURLOverride: URL?
     var stopFailuresRemaining = 0

--- a/docs/engineering/changes/pr-76.md
+++ b/docs/engineering/changes/pr-76.md
@@ -18,4 +18,4 @@ publicationEligibility: eligible
 ---
 # Tick the hosted floor timer and live recording waveform
 
-Hosted floor MM:SS now ticks every second. Recording waveform bars follow live microphone power history; idle stays a quiet baseline.
+Hosted floor MM:SS now ticks every second. Recording waveform bars follow live microphone power history; idle stays a quiet baseline. Compact does not grow a second timer.

--- a/docs/engineering/changes/pr-76.md
+++ b/docs/engineering/changes/pr-76.md
@@ -1,0 +1,21 @@
+---
+schemaVersion: 1
+repository: interview-arc-live
+pr: 76
+title: Tick the hosted floor timer and live recording waveform
+classification: change-note
+richRecordRefs: ["change-note-live-floor-timer-waveform@1"]
+reconstructed: false
+confidence: verified
+unknowns: []
+headCommit: null
+mergeCommit: null
+mergedAt: null
+sources: [{"label":"Pull request #76","url":"https://github.com/Vinosaamaa/interview-arc-live/pull/76","kind":"pull-request"},{"label":"Issue #75","url":"https://github.com/Vinosaamaa/interview-arc-live/issues/75","kind":"issue"}]
+verification: {"state":"verified","evidenceRefs":["pull-request:76","issue:75"]}
+visibility: public-safe
+publicationEligibility: eligible
+---
+# Tick the hosted floor timer and live recording waveform
+
+Hosted floor MM:SS now ticks every second. Recording waveform bars follow live microphone power history; idle stays a quiet baseline.

--- a/docs/engineering/records/change-note-live-floor-timer-waveform.md
+++ b/docs/engineering/records/change-note-live-floor-timer-waveform.md
@@ -1,0 +1,41 @@
+---
+schemaVersion: 1
+id: change-note-live-floor-timer-waveform
+revision: 1
+type: change-note
+status: accepted
+title: Tick Hosted Floor Timer And Drive Recording Waveform From Microphone Levels
+repository: interview-arc-live
+capabilityIds: ["interview-room-session"]
+createdAt: 2026-08-17
+reconstructed: false
+confidence: verified
+unknowns: []
+modules: ["system-design-room-presentation","voice-core-segment-recorder"]
+interfaces: ["full-room-waveform-layout","full-room-hosted-timer-layout"]
+seams: ["recorder-to-floor-waveform"]
+adapters: ["answer-recorder-driver"]
+relatedRecords: ["change-note-truthful-idle-floor-rail@1","adr-live-0007-retained-full-and-compact-presentations@1"]
+decisions: []
+incidents: []
+features: []
+capabilities: ["truthful-live-floor-metering"]
+amends: []
+supersedes: []
+learningRefs: []
+sources: [{"label":"Issue #75","url":"https://github.com/Vinosaamaa/interview-arc-live/issues/75","kind":"issue"},{"label":"Pull request #76","url":"https://github.com/Vinosaamaa/interview-arc-live/pull/76","kind":"pull-request"}]
+verification: {"state":"verified","evidenceRefs":["issue:75","pull-request:76","test:SystemDesignRoomLayoutTests.testHostedElapsedTextFormatsWholeSeconds","test:SystemDesignRoomLayoutTests.testRecordingWaveformUsesMicrophoneDecibelsAndStaysIdleWhenQuiet"]}
+visibility: public-safe
+publicationEligibility: eligible
+issue: 75
+pr: 76
+release: null
+run: null
+---
+# Tick Hosted Floor Timer And Drive Recording Waveform From Microphone Levels
+
+The hosted floor-rail `MM:SS` was computed from `runningSince` plus `Date()` without a clock, so SwiftUI left the label frozen until another chrome event redrew the rail. `LiveWaveform` drew a hardcoded bar array while recording, so the wave did not follow the microphone.
+
+## Change
+
+The hosted timer label is wrapped in a one-second `TimelineView` and formatted by `FullRoomHostedTimerLayout`. The Voice adapter forwards `AnswerRecorder` power history into the room model. Recording bars use those decibel samples plus the Voice pulse; idle still draws no bars. Reduce Motion drops the pulse only. Compact does not grow a second timer. Hand off enablement is unchanged.


### PR DESCRIPTION
## Summary
- Hosted floor-rail `MM:SS` now ticks every second from `runningSince` via `TimelineView`, so the activity timer no longer freezes until another chrome redraw.
- Recording waveform bars come from live `AnswerRecorder` microphone power history (Voice-style pulse; idle stays a quiet baseline).
- Manual Hand off, Cue Only, Patient Auto, and hosted recovery are unchanged.

Refs #75

## Engineering impact

Select exactly one classification. If `None` is selected, replace the placeholder with a concrete reason.

Add the compact receipt for this pull request at `docs/engineering/changes/pr-<number>.md`. Material changes also add or amend a rich record and link its exact `id@revision` from the receipt.

- [ ] None — reason: REPLACE WITH A CONCRETE REASON
- [x] Change Note
- [ ] ADR
- [ ] Architecture Review
- [ ] Feature Retrospective
- [ ] Postmortem
- [ ] Capability Dossier

## Test plan
- [ ] `FullRoomHostedTimerLayout.elapsedText` formats whole seconds; hosted snapshot elapsed advances when `localNow` advances without a new mutation.
- [ ] `FullRoomWaveformLayout` idle height is 0; active bars use normalized dB; Reduce Motion drops the sine pulse.
- [ ] Existing idle-floor layout test still passes.
- [ ] Hosted CI `test` is green.
- [ ] After authorized install: running hosted timer ticks while idle; recording wave moves with the mic; idle wave stays quiet; Hand off still requires an explicit click.