### PR TITLE
Document the shared Live SwiftPM cache

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,15 @@ as ADRs instead of duplicating narrative across guides.
   available. A CLT-only Fastlane may use focused build/typecheck, JS/runtime,
   and headed-app proof instead; do not install full Xcode solely for local
   XCTest. Hosted XCTest must pass before merge.
+- All Live worktrees share the existing workspace cache at
+  `.cache/interview-arc-live-swift`. Derive it from the workspace root, source
+  its `env.sh` when present, and pass
+  `--cache-path "$INTERVIEW_ARC_LIVE_SWIFTPM_CACHE"` to `swift build`,
+  `swift test`, and other SwiftPM `swift` subcommands. The environment also
+  owns the Clang and Swift module caches. Never create
+  per-worktree, per-agent, per-issue, or timestamped clones; move or recreate
+  the cache; or commit cache contents, environment internals, or machine-
+  specific absolute paths.
 - Recording, transcription, persistence, privacy, synchronization, signing,
   and recovery changes use the Reliability lane.
 - Do not merge, install, or release without explicit user authorization.

--- a/docs/engineering/changes/pr-88.md
+++ b/docs/engineering/changes/pr-88.md
@@ -1,0 +1,23 @@
+---
+schemaVersion: 1
+repository: interview-arc-live
+pr: 88
+title: "Document the shared Live SwiftPM cache"
+classification: none
+richRecordRefs: []
+reconstructed: false
+confidence: verified
+unknowns: []
+headCommit: null
+mergeCommit: null
+mergedAt: null
+sources: [{"label":"Pull request #88","url":"https://github.com/Vinosaamaa/interview-arc-live/pull/88","kind":"pull-request"},{"label":"Issue #87","url":"https://github.com/Vinosaamaa/interview-arc-live/issues/87","kind":"issue"}]
+verification: {"state":"verified","evidenceRefs":["pull-request:88","issue:87"]}
+visibility: public-safe
+publicationEligibility: eligible
+---
+
+# Document the shared Live SwiftPM cache
+
+Documents the existing workspace-level SwiftPM and module cache so Live
+worktrees reuse downloads without committing or cloning machine-local state.


### PR DESCRIPTION
## **User description**
Refs #87

## Summary
- document the existing workspace-level Live SwiftPM cache in the Live `AGENTS.md` only
- require every Live worktree to reuse the same SwiftPM, Clang, and Swift module caches
- prohibit per-worktree cache clones, committed cache state, and machine-specific paths

## Engineering impact
- [x] None — reason: This documentation-only rule records existing machine-local cache usage without changing product behavior.

## Verification
- Engineering impact policy tests: 32 passed
- `git diff --check`
- public-safety scan
- outer Interview Prep `AGENTS.md` unchanged


___

## **CodeAnt-AI Description**
Document the shared Live SwiftPM cache for consistent worktree builds

### What Changed
- Documents that all Live worktrees reuse the workspace-level SwiftPM, Clang, and Swift module caches
- Specifies how Swift commands locate the shared cache and prohibits per-worktree copies, cache changes, and committed machine-specific state

### Impact
`✅ Consistent dependency reuse across Live worktrees`
`✅ Fewer repeated Swift package downloads`
`✅ No committed machine-specific cache data`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
