### PR TITLE
Document the Continuous Conversation default

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -35,9 +35,9 @@ may finalize an audio Segment but never ends the Candidate Floor by itself.
 The default Turn Mode for new Sessions. While the Candidate Floor is open,
 Live locally detects speech, creates durable Segments, transcribes finalized
 audio, evaluates the accumulated answer, and may complete the canonical Hand
-off after Endpoint Grace. Interviewer speech remains half-duplex in the first
-shipment: candidate capture arms only after playback ends or is explicitly
-stopped.
+off after Endpoint Grace. During interviewer playback, local echo cancellation
+and speech-start detection remain armed only to recognize candidate barge-in;
+confirmed candidate speech stops playback and durably opens Candidate Floor.
 
 ### Floor Hold
 
@@ -45,7 +45,8 @@ A durable candidate intent that suppresses automatic Hand off while a longer
 answer is in progress. Activating **Hold floor** keeps silence and semantic
 endpoint proposals from yielding the floor; **Send answer** ends the hold and
 uses the same canonical Hand off transition after active Segment evidence is
-durable.
+durable. It is a temporary state inside Continuous Conversation, not another
+persisted Turn Mode.
 
 ### Hand off
 
@@ -215,9 +216,10 @@ separate recording, model, transcript, or persistence state.
 - One current `likely_end` Endpoint Evaluation owns at most one Endpoint Grace,
   and automatic completion uses the same at-most-once Hand off transition as
   the explicit action.
-- Continuous Conversation may arm capture only during Candidate Floor. It does
-  not listen through Interviewer TTS or infer a Candidate Turn from speech over
-  playback in the first shipment.
+- Continuous Conversation records candidate evidence only during Candidate
+  Floor. During interviewer TTS it may process echo-cancelled microphone frames
+  locally for barge-in; confirmed candidate speech must stop playback before
+  it opens and records the new Candidate Floor.
 - Floor Hold cancels or suppresses Endpoint Grace and automatic Hand off until
   **Send answer** explicitly releases it.
 - Acoustic silence may finalize one Segment but never commits a Candidate Turn

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -30,6 +30,23 @@ thread is a replaceable runtime binding, not the Session identity.
 The interval in which the candidate may speak, think, code, or draw. Silence
 may finalize an audio Segment but never ends the Candidate Floor by itself.
 
+### Continuous Conversation
+
+The default Turn Mode for new Sessions. While the Candidate Floor is open,
+Live locally detects speech, creates durable Segments, transcribes finalized
+audio, evaluates the accumulated answer, and may complete the canonical Hand
+off after Endpoint Grace. Interviewer speech remains half-duplex in the first
+shipment: candidate capture arms only after playback ends or is explicitly
+stopped.
+
+### Floor Hold
+
+A durable candidate intent that suppresses automatic Hand off while a longer
+answer is in progress. Activating **Hold floor** keeps silence and semantic
+endpoint proposals from yielding the floor; **Send answer** ends the hold and
+uses the same canonical Hand off transition after active Segment evidence is
+durable.
+
 ### Hand off
 
 The durable transition that commits one Candidate Turn and permits an
@@ -89,8 +106,10 @@ controls its evidence status, never whether the text remains visible.
 
 ### Turn Mode
 
-The policy controlling Hand off: `Cue Only`, functional `Patient Auto`, or
-`Manual`.
+The policy controlling capture and Hand off. New Sessions default to
+`Continuous Conversation`; restored Sessions preserve their recorded mode.
+`Cue Only`, `Patient Auto`, and `Manual` remain explicit compatibility and
+recovery modes.
 
 ### Endpoint Proposal
 
@@ -196,6 +215,13 @@ separate recording, model, transcript, or persistence state.
 - One current `likely_end` Endpoint Evaluation owns at most one Endpoint Grace,
   and automatic completion uses the same at-most-once Hand off transition as
   the explicit action.
+- Continuous Conversation may arm capture only during Candidate Floor. It does
+  not listen through Interviewer TTS or infer a Candidate Turn from speech over
+  playback in the first shipment.
+- Floor Hold cancels or suppresses Endpoint Grace and automatic Hand off until
+  **Send answer** explicitly releases it.
+- Acoustic silence may finalize one Segment but never commits a Candidate Turn
+  without current durable semantic and grace policy.
 - Accepted transitions advance the Session Manifest revision monotonically.
 - Every nonempty audio-derived transcript candidate remains visible with an
   explicit quality state.

--- a/docs/adr/0010-default-continuous-conversation.md
+++ b/docs/adr/0010-default-continuous-conversation.md
@@ -50,10 +50,18 @@ Continuous Conversation adds one durable two-state candidate control:
   selected evidence are durable, it invokes the same canonical Hand off used
   by automatic and manual completion.
 
-The first shipment remains half-duplex. Capture is not armed while interviewer
-TTS is playing. Candidate speech over playback is not silently promoted into a
-turn; the candidate must stop playback or wait for it to finish. Autonomous
-barge-in, echo cancellation, and full-duplex audio require a separate decision.
+These are the only two user-facing conversation states in the first shipment:
+Automatic and Hold floor. Floor Hold is a temporary durable state inside
+Continuous Conversation, not another Turn Mode. Legacy Turn Modes remain
+decodable and available only as recovery or advanced behavior.
+
+The first shipment supports candidate barge-in without adopting simultaneous
+two-speaker dialogue. While interviewer TTS plays, its exact output frames are
+the far-end reference for local echo cancellation. Local speech-start
+detection receives only the cleaned near-end signal. Confirmed candidate speech
+stops playback and stale generation, preserves a bounded pre-roll, durably
+opens Candidate Floor, and then records normal Segment evidence. Unconfirmed
+noise or residual playback cannot create a Candidate Turn or leave the device.
 
 Every capture, boundary, transcription, endpoint, hold, grace, and Hand off
 transition remains manifest-owned and recoverable. Module boundaries emit
@@ -73,4 +81,5 @@ they never log audio, transcripts, credentials, private IDs, or paths.
   visible manual controls; they never fabricate a transcript or Hand off.
 - Local VAD, re-arming, termination recovery, and Hold-floor reconciliation add
   lifecycle complexity and require headed audio tests plus relaunch coverage.
-- Automatic barge-in and full-duplex speech are intentionally deferred.
+- Simultaneous overlapping candidate/interviewer dialogue remains deferred;
+  interruption itself is part of the first shipment.

--- a/docs/adr/0010-default-continuous-conversation.md
+++ b/docs/adr/0010-default-continuous-conversation.md
@@ -1,0 +1,76 @@
+# ADR 0010: Default to durable Continuous Conversation
+
+- Status: Accepted
+- Date: 2026-08-17
+- Issue: #90
+
+## Context
+
+Live currently exposes the persistence boundaries of segmented speech as
+primary conversation controls: Record segment, Stop segment, and Hand off.
+Those controls are valuable recovery seams, but requiring them for every turn
+makes a practice interview feel like operating a recorder rather than speaking
+with an interviewer.
+
+Issue #48 made Patient Auto complete the canonical Hand off at an explicit
+finalized-Segment boundary. It deliberately left acoustic speech-boundary
+detection to a following slice. The first natural-conversation shipment must
+add that boundary without weakening the durable Segment, transcription,
+endpoint, grace, and at-most-once Hand off contracts.
+
+Long system-design and behavioral answers also need a deliberate way to keep
+the floor. Ordinary pauses cannot be treated as that intent: silence is
+ambiguous, and a model prediction must not overrule an explicit candidate
+choice.
+
+## Decision
+
+New Interview Room Sessions default to `Continuous Conversation`. Existing
+Session Manifests preserve their recorded Turn Mode.
+
+During Candidate Floor, Live locally detects speech and creates a durable
+Segment before capture. Local acoustic VAD may finalize that Segment after
+silence. Live then follows the existing pipeline: retain the Source Recording,
+authorize Groq transcription durably, select transcript evidence, run semantic
+endpoint evaluation, and, for a current `likely_end`, complete Endpoint Grace
+and the canonical at-most-once Hand off. After the Interviewer Turn and local
+speech playback complete, Live re-arms Candidate Floor automatically.
+
+The normal Continuous Conversation presentation does not require Record,
+Stop, or Hand off. Those actions remain available as explicit recovery and
+compatibility controls when automatic capture is unavailable or a retained
+Session uses another mode.
+
+Continuous Conversation adds one durable two-state candidate control:
+
+- **Hold floor** records a Floor Hold and cancels or suppresses Endpoint Grace
+  and automatic Hand off. Local VAD may continue finalizing multiple Segments,
+  but none may yield the Candidate Floor.
+- **Send answer** releases the Floor Hold. After any active Segment and its
+  selected evidence are durable, it invokes the same canonical Hand off used
+  by automatic and manual completion.
+
+The first shipment remains half-duplex. Capture is not armed while interviewer
+TTS is playing. Candidate speech over playback is not silently promoted into a
+turn; the candidate must stop playback or wait for it to finish. Autonomous
+barge-in, echo cancellation, and full-duplex audio require a separate decision.
+
+Every capture, boundary, transcription, endpoint, hold, grace, and Hand off
+transition remains manifest-owned and recoverable. Module boundaries emit
+public-safe traces containing command, phase, result code, and counts only;
+they never log audio, transcripts, credentials, private IDs, or paths.
+
+## Consequences
+
+- The default interaction feels like a conversation while retaining the same
+  durable evidence and at-most-once transitions as the explicit workflow.
+- Silence can end an audio Segment but cannot independently commit a Candidate
+  Turn. Semantic endpoint policy, Endpoint Grace, and Floor Hold remain
+  authoritative.
+- Long answers gain explicit non-interruption intent without requiring the
+  candidate to manage each recording interval.
+- Microphone permission, credential, provider, or recovery failures degrade to
+  visible manual controls; they never fabricate a transcript or Hand off.
+- Local VAD, re-arming, termination recovery, and Hold-floor reconciliation add
+  lifecycle complexity and require headed audio tests plus relaunch coverage.
+- Automatic barge-in and full-duplex speech are intentionally deferred.

--- a/docs/design/specialty-rooms.md
+++ b/docs/design/specialty-rooms.md
@@ -9,10 +9,10 @@ All specialties are projections of one active `InterviewRoomSession`. Changing t
 - The Live mark is two asymmetric open arcs with one moving handoff point. A microphone icon is reserved for literal permission, mute, or input-device controls; it is not the Live product mark.
 - The transcript uses role-tagged typographic blocks on one continuous Turnline, not chat bubbles.
 - The current question is the visual anchor. Prior turns recede without disappearing.
-- New Sessions default to half-duplex **Continuous Conversation**: Live locally arms capture during Candidate Floor and uses durable segmentation, semantic endpointing, grace, and the canonical Hand off without requiring Record / Stop / Hand off on the normal path.
+- New Sessions default to **Continuous Conversation**: Live locally detects candidate speech, supports barge-in during interviewer playback, and uses durable segmentation, semantic endpointing, grace, and the canonical Hand off without requiring Record / Stop / Hand off on the normal path.
 - **Hold floor** is the candidate's deliberate long-answer control. While held, Live cannot automatically Hand off; **Send answer** releases the hold and completes the same canonical transition after active evidence is durable.
 - `Record segment`, `Stop segment`, and explicit `Hand off` remain recovery and compatibility controls, not the default conversation chrome.
-- The first shipment does not perform autonomous barge-in. Candidate capture is off while interviewer TTS is playing and arms after playback ends or is explicitly stopped.
+- During interviewer TTS, local echo cancellation and speech-start detection may listen only for candidate barge-in. Confirmed speech stops Mara, invalidates stale output, and opens Candidate Floor before candidate evidence is recorded; simultaneous overlapping dialogue remains out of scope.
 - The compact capsule is another presentation of the same session and phase. It never creates another recorder or conversation.
 - Interviewer turns keep one canonical pair: rich `displayMarkdown` for the room and concise `spokenText` for TTS.
 - The work surface changes by specialty while the transcript, persona, timer, privacy state, and floor rail remain consistent.

--- a/docs/design/specialty-rooms.md
+++ b/docs/design/specialty-rooms.md
@@ -1,6 +1,6 @@
 # Specialty Room Concepts
 
-Status: design exploration for [issue #1](https://github.com/Vinosaamaa/interview-arc-live/issues/1). These concepts define the intended specialty surfaces; they do not expand the first implementation slice without a separate approval.
+Status: design exploration for [issue #1](https://github.com/Vinosaamaa/interview-arc-live/issues/1), with the shared Continuous Conversation decision approved for [issue #90](https://github.com/Vinosaamaa/interview-arc-live/issues/90). These concepts define the intended specialty surfaces; they do not expand another implementation slice without separate approval.
 
 ## Shared room shell
 
@@ -9,7 +9,10 @@ All specialties are projections of one active `InterviewRoomSession`. Changing t
 - The Live mark is two asymmetric open arcs with one moving handoff point. A microphone icon is reserved for literal permission, mute, or input-device controls; it is not the Live product mark.
 - The transcript uses role-tagged typographic blocks on one continuous Turnline, not chat bubbles.
 - The current question is the visual anchor. Prior turns recede without disappearing.
-- `Hand off` is the single primary action in patient half-duplex mode. It ends the candidate's floor and permits the interviewer to answer.
+- New Sessions default to half-duplex **Continuous Conversation**: Live locally arms capture during Candidate Floor and uses durable segmentation, semantic endpointing, grace, and the canonical Hand off without requiring Record / Stop / Hand off on the normal path.
+- **Hold floor** is the candidate's deliberate long-answer control. While held, Live cannot automatically Hand off; **Send answer** releases the hold and completes the same canonical transition after active evidence is durable.
+- `Record segment`, `Stop segment`, and explicit `Hand off` remain recovery and compatibility controls, not the default conversation chrome.
+- The first shipment does not perform autonomous barge-in. Candidate capture is off while interviewer TTS is playing and arms after playback ends or is explicitly stopped.
 - The compact capsule is another presentation of the same session and phase. It never creates another recorder or conversation.
 - Interviewer turns keep one canonical pair: rich `displayMarkdown` for the room and concise `spokenText` for TTS.
 - The work surface changes by specialty while the transcript, persona, timer, privacy state, and floor rail remain consistent.

--- a/docs/engineering/changes/pr-91.md
+++ b/docs/engineering/changes/pr-91.md
@@ -1,0 +1,24 @@
+---
+schemaVersion: 1
+repository: interview-arc-live
+pr: 91
+title: "Document the Continuous Conversation default"
+classification: adr
+richRecordRefs: ["adr-live-0010-default-continuous-conversation@1"]
+reconstructed: false
+confidence: verified
+unknowns: []
+headCommit: null
+mergeCommit: null
+mergedAt: null
+sources: [{"label":"Pull request #91","url":"https://github.com/Vinosaamaa/interview-arc-live/pull/91","kind":"pull-request"},{"label":"Issue #90","url":"https://github.com/Vinosaamaa/interview-arc-live/issues/90","kind":"issue"}]
+verification: {"state":"verified","evidenceRefs":["pull-request:91","issue:90","git-diff-check"]}
+visibility: public-safe
+publicationEligibility: eligible
+---
+
+# Document the Continuous Conversation default
+
+Records the approved new-session default, durable Hold floor / Send answer
+semantics, and first-shipment half-duplex interruption boundary before runtime
+implementation begins.

--- a/docs/engineering/records/adr-live-0010-default-continuous-conversation.md
+++ b/docs/engineering/records/adr-live-0010-default-continuous-conversation.md
@@ -1,0 +1,50 @@
+---
+schemaVersion: 1
+id: adr-live-0010-default-continuous-conversation
+revision: 1
+type: adr
+status: accepted
+title: Default new Live sessions to durable Continuous Conversation
+repository: interview-arc-live
+capabilityIds: ["continuous-conversation","floor-hold","interview-room-session"]
+createdAt: 2026-08-17
+reconstructed: false
+confidence: high
+unknowns: ["Runtime implementation and installed audio verification remain pending under issue #90."]
+modules: ["interview-room-session","segment-speech-coordinator","endpoint-grace","interviewer-speech-coordinator","room-presentations"]
+interfaces: ["turn-mode","floor-hold","continuous-conversation-state"]
+seams: ["candidate floor ↔ local acoustic segmentation","durable segment evidence ↔ semantic endpoint evaluation","interviewer playback ↔ candidate capture re-arming"]
+adapters: ["local candidate audio adapter","Groq transcription and endpoint adapters","local interviewer speech adapter"]
+relatedRecords: ["adr-live-0004-durable-segmented-speech@1","feature-retrospective-live-issue-11@1"]
+decisions: ["default-continuous-conversation","durable-floor-hold","first-shipment-half-duplex"]
+incidents: []
+features: ["continuous-conversation","floor-hold"]
+capabilities: ["automatic-local-speech-segmentation","semantic-automatic-hand-off","long-answer-floor-hold"]
+amends: []
+supersedes: []
+learningRefs: []
+sources: [{"label":"Issue #90","url":"https://github.com/Vinosaamaa/interview-arc-live/issues/90","kind":"issue"},{"label":"Pull request #91","url":"https://github.com/Vinosaamaa/interview-arc-live/pull/91","kind":"pull-request"},{"label":"ADR 0004","url":"https://github.com/Vinosaamaa/interview-arc-live/blob/main/docs/adr/0004-durable-segmented-speech.md","kind":"documentation"}]
+verification: {"state":"not-recorded","evidenceRefs":[]}
+visibility: public-safe
+publicationEligibility: eligible
+issue: 90
+pr: 91
+release: null
+run: null
+---
+
+# Default new Live sessions to durable Continuous Conversation
+
+New Interview Room Sessions default to a half-duplex Continuous Conversation
+mode. Live automatically arms local capture only during Candidate Floor,
+durably segments and transcribes speech, evaluates the accumulated answer, and
+uses Endpoint Grace plus the canonical at-most-once Hand off. Restored Sessions
+preserve their stored Turn Mode.
+
+A durable Floor Hold suppresses automatic completion across long pauses and
+multiple Segments. Send answer releases that hold only after active Segment
+evidence is durable, then invokes the same canonical Hand off.
+
+The first shipment does not listen through interviewer TTS or infer a
+Candidate Turn from speech over playback. Autonomous barge-in and full-duplex
+audio remain separate decisions.

--- a/docs/engineering/records/adr-live-0010-default-continuous-conversation.md
+++ b/docs/engineering/records/adr-live-0010-default-continuous-conversation.md
@@ -16,7 +16,7 @@ interfaces: ["turn-mode","floor-hold","continuous-conversation-state"]
 seams: ["candidate floor ↔ local acoustic segmentation","durable segment evidence ↔ semantic endpoint evaluation","interviewer playback ↔ candidate capture re-arming"]
 adapters: ["local candidate audio adapter","Groq transcription and endpoint adapters","local interviewer speech adapter"]
 relatedRecords: ["adr-live-0004-durable-segmented-speech@1","feature-retrospective-live-issue-11@1"]
-decisions: ["default-continuous-conversation","durable-floor-hold","first-shipment-half-duplex"]
+decisions: ["default-continuous-conversation","durable-floor-hold","local-candidate-barge-in"]
 incidents: []
 features: ["continuous-conversation","floor-hold"]
 capabilities: ["automatic-local-speech-segmentation","semantic-automatic-hand-off","long-answer-floor-hold"]
@@ -35,16 +35,16 @@ run: null
 
 # Default new Live sessions to durable Continuous Conversation
 
-New Interview Room Sessions default to a half-duplex Continuous Conversation
-mode. Live automatically arms local capture only during Candidate Floor,
-durably segments and transcribes speech, evaluates the accumulated answer, and
-uses Endpoint Grace plus the canonical at-most-once Hand off. Restored Sessions
-preserve their stored Turn Mode.
+New Interview Room Sessions default to Continuous Conversation. Live locally
+detects candidate speech, durably segments and transcribes it, evaluates the
+accumulated answer, and uses Endpoint Grace plus the canonical at-most-once
+Hand off. Restored Sessions preserve their stored Turn Mode.
 
 A durable Floor Hold suppresses automatic completion across long pauses and
 multiple Segments. Send answer releases that hold only after active Segment
 evidence is durable, then invokes the same canonical Hand off.
 
-The first shipment does not listen through interviewer TTS or infer a
-Candidate Turn from speech over playback. Autonomous barge-in and full-duplex
-audio remain separate decisions.
+During interviewer TTS, local echo cancellation and speech-start detection
+remain armed for candidate barge-in. Confirmed speech stops stale playback and
+opens Candidate Floor before evidence capture. Simultaneous overlapping
+dialogue remains a separate decision.


### PR DESCRIPTION
## **User description**
Refs #90

## Summary

- define Continuous Conversation as the default Turn Mode for new sessions
- define durable Hold floor / Send answer semantics and recovery boundaries
- record the first-shipment half-duplex interruption policy in the domain context, specialty-room design, and ADR 0010

## Engineering impact

- [ ] None — reason: not selected
- [ ] Change Note
- [x] ADR
- [ ] Architecture Review
- [ ] Feature Retrospective
- [ ] Postmortem
- [ ] Capability Dossier

## Verification

- `git diff --check`
- focused link and terminology inspection across `CONTEXT.md`, ADR 0010, and `docs/design/specialty-rooms.md`
- added-line public-safety scan

## Known limit

This is the approved design/provenance slice only. Runtime implementation and Reliability verification remain owned by issue #90.


___

## **CodeAnt-AI Description**
Define Continuous Conversation as the default for new interview sessions

### What Changed
- New sessions use Continuous Conversation, automatically detecting candidate speech, segmenting and evaluating answers, and handing off after the existing endpoint and grace rules.
- Candidates can use Hold floor to prevent automatic handoff during long answers, then Send answer to release the hold and complete the handoff.
- Candidate barge-in during interviewer playback stops the stale playback and opens the candidate floor; overlapping two-speaker dialogue remains unsupported.
- Existing sessions retain their saved turn mode, while Record segment, Stop segment, and Hand off remain available as recovery and compatibility controls.
- Documents the approved behavior and its recovery and privacy boundaries; runtime implementation and audio verification remain pending.

### Impact
`✅ Natural conversation for new sessions`
`✅ Fewer manual recording controls during normal turns`
`✅ Uninterrupted long answers with explicit floor control`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
