### PR TITLE
Adopt the external Interview Prep support root

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,20 @@ state and APIs; `interview-arc-voice` owns the system-wide dictation client.
 
 Do not create or change a thread Goal unless the user explicitly asks.
 
+## Issue worktrees
+
+Create Live worktrees only under
+`$HOME/Projects/interview-prep-support/worktrees` and name them
+`live-<issue>-<slug>`. Before creating or resuming work, inspect
+`git worktree list --porcelain`, reuse the registered issue worktree, and honor
+any Git lock reason. Never implement in the primary/shared checkout or create a
+duplicate worktree.
+
+The owner removes a worktree only after verifying the exact tested PR head,
+merge, released `main`, cleanliness, and absence of unpublished work. Use
+`git worktree remove <exact-path>` without `--force`; never recursively delete
+a registered worktree.
+
 ## Product invariants
 
 - One `InterviewRoomSession` is bound to one Interview Arc activity.
@@ -61,9 +75,11 @@ as ADRs instead of duplicating narrative across guides.
   available. A CLT-only Fastlane may use focused build/typecheck, JS/runtime,
   and headed-app proof instead; do not install full Xcode solely for local
   XCTest. Hosted XCTest must pass before merge.
-- All Live worktrees share the existing workspace cache at
-  `.cache/interview-arc-live-swift`. Derive it from the workspace root, source
-  its `env.sh` when present, and pass
+- All Live worktrees share the existing support cache at
+  `$HOME/Projects/interview-prep-support/cache/interview-arc-live-swift`.
+  Resolve the support root from `$INTERVIEW_PREP_SUPPORT_ROOT` when set or
+  `$HOME/Projects/interview-prep-support` otherwise, source the cache's
+  `env.sh`, and pass
   `--cache-path "$INTERVIEW_ARC_LIVE_SWIFTPM_CACHE"` to `swift build`,
   `swift test`, and other SwiftPM `swift` subcommands. The environment also
   owns the Clang and Swift module caches. Never create

--- a/docs/engineering/changes/pr-96.md
+++ b/docs/engineering/changes/pr-96.md
@@ -1,0 +1,21 @@
+---
+schemaVersion: 1
+repository: interview-arc-live
+pr: 96
+title: "Adopt the external Interview Prep support root"
+classification: none
+richRecordRefs: []
+reconstructed: false
+confidence: verified
+unknowns: []
+headCommit: null
+mergeCommit: null
+mergedAt: null
+sources: [{"label":"Pull request #96","url":"https://github.com/Vinosaamaa/interview-arc-live/pull/96","kind":"pull-request"},{"label":"Issue #95","url":"https://github.com/Vinosaamaa/interview-arc-live/issues/95","kind":"issue"}]
+verification: {"state":"verified","evidenceRefs":["pull-request:96","issue:95"]}
+visibility: public-safe
+publicationEligibility: eligible
+---
+# Adopt the external Interview Prep support root
+
+Documented the external Live issue-worktree root and relocated shared build-cache contract without changing the application runtime or package graph.

--- a/docs/engineering/changes/pr-96.md
+++ b/docs/engineering/changes/pr-96.md
@@ -11,8 +11,8 @@ unknowns: []
 headCommit: null
 mergeCommit: null
 mergedAt: null
-sources: [{"label":"Pull request #96","url":"https://github.com/Vinosaamaa/interview-arc-live/pull/96","kind":"pull-request"},{"label":"Issue #95","url":"https://github.com/Vinosaamaa/interview-arc-live/issues/95","kind":"issue"}]
-verification: {"state":"verified","evidenceRefs":["pull-request:96","issue:95"]}
+sources: [{"label":"Pull request #96","url":"https://github.com/Vinosaamaa/interview-arc-live/pull/96","kind":"pull-request"},{"label":"Issue #95","url":"https://github.com/Vinosaamaa/interview-arc-live/issues/95","kind":"issue"},{"label":"Paired Arc issue #425","url":"https://github.com/Vinosaamaa/interview-arc/issues/425","kind":"issue"}]
+verification: {"state":"verified","evidenceRefs":["pull-request:96","issue:95","issue:425"]}
 visibility: public-safe
 publicationEligibility: eligible
 ---


### PR DESCRIPTION
## **User description**
## **User description**
Refs #95

Paired with Vinosaamaa/interview-arc#425. Related shared-cache contract: #87.

## Summary

- use `$HOME/Projects/interview-prep-support/worktrees/live-<issue>-<slug>` for future Live issue worktrees
- preserve ownership, Git-lock, release-verification, and no-force cleanup requirements
- point every Live worktree at the relocated shared SwiftPM/module cache under the support root

## Engineering impact

- [x] None — reason: Operational guidance and a local cache path only; no application runtime or package graph changed.
- [ ] Change Note
- [ ] ADR
- [ ] Architecture Review
- [ ] Feature Retrospective
- [ ] Postmortem
- [ ] Capability Dossier

## Verification

- `git diff --cached --check`
- relocated cache `env.sh` passes `sh -n`
- SwiftPM, Clang module, and Swift module cache directories all resolve after sourcing the helper

## Risk and rollback

Documentation/local cache location only; no Swift source, package graph, recording, credential, signing, or installation behavior changes. Revert the commit and move the cache back to roll back.

## Execution ledger

- request_submitted_at: unavailable
- tool_execution_started_at: unavailable; first exact checkpoint was `2026-08-24 03:09:51 PDT (-0700)` after initial instruction reads
- client_measured_duration: unavailable
- active engineering total: unknown because exact work-block instrumentation began late

At `2026-08-24 03:34:48 PDT (-0700)`, the guidance change, cache relocation, focused checks, commit, and branch push were complete. Hosted CI had not yet run.


___

## **CodeAnt-AI Description**
Standardize Live worktrees and shared build-cache location

### What Changed
- Live issue worktrees now use the external Interview Prep support directory with required naming, reuse, ownership, and cleanup rules
- Live worktrees now share SwiftPM, Clang, and Swift module caches from the support root, with an environment override for custom installations
- Added a verified engineering record documenting the change and its related issues

### Impact
`✅ Consistent Live worktree locations`
`✅ Shared build caches across worktrees`
`✅ Safer worktree cleanup`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
